### PR TITLE
feat: add accessibility and UI polish

### DIFF
--- a/src/components/audit/AuditPanel.tsx
+++ b/src/components/audit/AuditPanel.tsx
@@ -47,7 +47,7 @@ export function AuditPanel({ onRunAuditOnly }: AuditPanelProps) {
                   .map((c) => (
                     <div
                       key={c.id}
-                      className="flex items-start gap-2 bg-red-50 border border-red-200 p-3 text-red-700"
+                      className="flex items-start gap-2 bg-editorial-textbox/30 border border-editorial-accent/30 p-3 text-editorial-accent"
                     >
                       <AlertTriangle size={14} className="mt-0.5 shrink-0" />
                       <span className="text-[10px] font-mono">
@@ -67,11 +67,11 @@ export function AuditPanel({ onRunAuditOnly }: AuditPanelProps) {
                 {chunks
                   .flatMap((c) => c.judgeResult.issues)
                   .map((issue, i) => (
-                    <li key={i} className="py-4 hover:bg-white/30 px-2 -mx-2 transition-colors rounded-sm">
+                    <li key={i} className="py-4 hover:bg-editorial-textbox/30 px-2 -mx-2 transition-colors rounded-sm">
                       <div className="flex items-center gap-2 mb-1">
                         <span
                           className={`text-[8px] font-bold uppercase px-1.5 py-0.5 rounded-sm ${
-                            issue.severity === 'high' ? 'bg-red-500 text-white' : 'bg-editorial-ink text-white'
+                            issue.severity === 'high' ? 'bg-editorial-accent text-white' : 'bg-editorial-ink text-white'
                           }`}
                         >
                           {issue.type}
@@ -81,7 +81,7 @@ export function AuditPanel({ onRunAuditOnly }: AuditPanelProps) {
                         &quot;{issue.description}&quot;
                       </span>
                       {issue.suggestedFix && (
-                        <div className="mt-2 text-[10px] font-mono text-editorial-muted bg-white p-2 rounded-sm border-l-2 border-editorial-accent">
+                        <div className="mt-2 text-[10px] font-mono text-editorial-muted bg-editorial-bg p-2 rounded-sm border-l-2 border-editorial-accent">
                           {t('audit.fix')}: {issue.suggestedFix}
                         </div>
                       )}
@@ -108,13 +108,13 @@ export function AuditPanel({ onRunAuditOnly }: AuditPanelProps) {
         <button
           onClick={onRunAuditOnly}
           disabled={isProcessing || chunks.length === 0}
-          className="w-full bg-transparent border border-editorial-ink text-editorial-ink px-4 py-4 text-[11px] font-bold uppercase tracking-[3px] hover:bg-editorial-ink hover:text-white transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed group shadow-sm active:translate-y-px"
+          className="w-full bg-transparent border border-editorial-ink text-editorial-ink px-4 py-4 text-[11px] font-bold uppercase tracking-[3px] hover:bg-editorial-ink hover:text-white transition-all flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed group shadow-sm active:translate-y-px focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
         >
           <RefreshCcw size={14} className={isProcessing ? 'animate-spin' : ''} /> {t('audit.reEvaluate')}
         </button>
         <button
           onClick={clearChunks}
-          className="w-full border border-editorial-border px-4 py-3 text-[10px] font-bold uppercase tracking-widest hover:bg-red-50 hover:text-red-500 transition-all flex items-center justify-center gap-2"
+          className="w-full border border-editorial-border px-4 py-3 text-[10px] font-bold uppercase tracking-widest hover:bg-editorial-textbox/50 hover:text-editorial-accent transition-all flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
         >
           {t('audit.clearStream')}
         </button>

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface CopyButtonProps {
   text: string;
@@ -7,6 +8,7 @@ interface CopyButtonProps {
 
 export function CopyButton({ text }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const { t } = useTranslation();
 
   const handleCopy = () => {
     navigator.clipboard.writeText(text);
@@ -17,10 +19,11 @@ export function CopyButton({ text }: CopyButtonProps) {
   return (
     <button
       onClick={handleCopy}
-      className="text-editorial-muted hover:text-editorial-ink transition-colors flex items-center gap-1.5 text-[9px] uppercase font-bold tracking-widest"
+      className="text-editorial-muted hover:text-editorial-ink transition-colors flex items-center gap-1.5 text-[9px] uppercase font-bold tracking-widest focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+      aria-label={copied ? t('pipeline.copied') : t('pipeline.copy')}
     >
       {copied ? <Check size={12} /> : <Copy size={12} />}
-      {copied ? 'Copied' : 'Copy'}
+      <span aria-live="polite">{copied ? t('pipeline.copied') : t('pipeline.copy')}</span>
     </button>
   );
 }

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -33,15 +33,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       }
 
       return (
-        <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
-          <AlertCircle size={32} className="text-red-500" />
+        <div className="flex flex-col items-center justify-center p-8 gap-4 text-center" role="alert" aria-live="assertive">
+          <AlertCircle size={32} className="text-editorial-accent" />
           <h3 className="font-display text-lg">{i18n.t('errors.somethingWentWrong')}</h3>
           <p className="text-xs text-editorial-muted max-w-md">
             {this.state.error?.message || i18n.t('errors.unexpectedError')}
           </p>
           <button
             onClick={() => this.setState({ hasError: false, error: null })}
-            className="px-4 py-2 bg-editorial-ink text-white text-[10px] font-bold uppercase tracking-widest hover:opacity-90"
+            className="px-4 py-2 bg-editorial-ink text-white text-[10px] font-bold uppercase tracking-widest hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
           >
             {i18n.t('errors.tryAgain')}
           </button>

--- a/src/components/common/ProcessingLine.tsx
+++ b/src/components/common/ProcessingLine.tsx
@@ -1,6 +1,6 @@
 export function ProcessingLine() {
   return (
-    <div className="space-y-2 py-2">
+    <div className="space-y-2 py-2" role="status" aria-busy="true" aria-label="Loading">
       <div className="h-0.5 bg-editorial-border w-full animate-pulse"></div>
       <div className="h-0.5 bg-editorial-border w-4/5 animate-pulse delay-75"></div>
       <div className="h-0.5 bg-editorial-border w-1/2 animate-pulse delay-150"></div>

--- a/src/components/common/StatusIndicator.tsx
+++ b/src/components/common/StatusIndicator.tsx
@@ -5,7 +5,7 @@ interface StatusIndicatorProps {
 
 export function StatusIndicator({ status, label }: StatusIndicatorProps) {
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div className="flex flex-col items-center gap-1" role="status" aria-label={`${label}: ${status}`}>
       <div
         className={`w-1.5 h-1.5 rounded-full ${
           status === 'completed'
@@ -13,7 +13,7 @@ export function StatusIndicator({ status, label }: StatusIndicatorProps) {
             : status === 'processing'
               ? 'bg-editorial-accent animate-pulse'
               : status === 'error'
-                ? 'bg-red-500'
+                ? 'bg-editorial-accent'
                 : 'bg-editorial-border'
         }`}
       />
@@ -24,7 +24,7 @@ export function StatusIndicator({ status, label }: StatusIndicatorProps) {
             : status === 'processing'
               ? 'text-editorial-accent'
               : status === 'error'
-                ? 'text-red-500'
+                ? 'text-editorial-accent'
                 : 'text-editorial-muted opacity-40'
         }`}
       >

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { X, ChevronRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface HelpGuideProps {
   open: boolean;
@@ -13,6 +14,7 @@ type Section = 'overview' | 'pipeline' | 'streaming' | 'audit' | 'projects' | 'p
 export function HelpGuide({ open, onClose }: HelpGuideProps) {
   const [activeSection, setActiveSection] = useState<Section>('overview');
   const { t } = useTranslation();
+  const trapRef = useFocusTrap(open, onClose);
 
   const sections: { id: Section; label: string }[] = [
     { id: 'overview', label: t('help.sections.overview') },
@@ -29,7 +31,13 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="help-title"
+          ref={trapRef}
+        >
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -45,16 +53,16 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
           >
             {/* Sidebar */}
             <nav className="w-56 shrink-0 border-r border-editorial-border bg-editorial-textbox/30 p-6 overflow-y-auto">
-              <h3 className="font-display text-xl italic tracking-tight mb-6">{t('help.title')}</h3>
+              <h3 id="help-title" className="font-display text-xl italic tracking-tight mb-6">{t('help.title')}</h3>
               <ul className="space-y-1">
                 {sections.map((s) => (
                   <li key={s.id}>
                     <button
                       onClick={() => setActiveSection(s.id)}
-                      className={`w-full text-left px-3 py-2 text-[11px] font-bold uppercase tracking-wider transition-colors flex items-center gap-2 ${
+                      className={`w-full text-left px-3 py-2 text-[11px] font-bold uppercase tracking-wider transition-colors flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
                         activeSection === s.id
                           ? 'bg-editorial-ink text-white'
-                          : 'text-editorial-muted hover:text-editorial-ink hover:bg-white/50'
+                          : 'text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50'
                       }`}
                     >
                       <ChevronRight size={10} className={activeSection === s.id ? 'opacity-100' : 'opacity-0'} />
@@ -69,7 +77,8 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
             <div className="flex-1 overflow-y-auto p-10 custom-scrollbar">
               <button
                 onClick={onClose}
-                className="absolute top-6 right-6 text-editorial-muted hover:text-editorial-ink"
+                className="absolute top-6 right-6 text-editorial-muted hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                aria-label={t('settings.saveClose')}
               >
                 <X size={20} />
               </button>
@@ -206,7 +215,7 @@ function AuditSection() {
         {(['glossary', 'accuracy', 'fluency', 'grammar'] as const).map((type) => (
           <div key={type} className="flex items-start gap-3 p-4 bg-editorial-textbox/20 border border-editorial-border">
             <span className={`text-[9px] font-bold uppercase px-1.5 py-0.5 shrink-0 ${
-              type === 'grammar' ? 'bg-red-500 text-white' : 'bg-editorial-ink text-white'
+              type === 'grammar' ? 'bg-editorial-accent text-white' : 'bg-editorial-ink text-white'
             }`}>
               {type}
             </span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -62,8 +62,8 @@ export function Header() {
         {/* File actions */}
         <button
           onClick={handleImport}
-          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-          title={t('files.import')}
+          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('files.import')}
         >
           <Upload size={16} />
         </button>
@@ -71,15 +71,15 @@ export function Header() {
           <div className="flex items-center gap-0.5">
             <button
               onClick={() => handleExport('txt')}
-              className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-              title={t('files.exportTxt')}
+              className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              aria-label={t('files.exportTxt')}
             >
               <Download size={16} />
             </button>
             <button
               onClick={() => handleExport('bilingual')}
-              className="px-2 py-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors text-[9px] font-bold uppercase"
-              title={t('files.exportBilingual')}
+              className="px-2 py-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors text-[9px] font-bold uppercase focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              aria-label={t('files.exportBilingual')}
             >
               MD
             </button>
@@ -91,16 +91,16 @@ export function Header() {
         {/* Project actions */}
         <button
           onClick={() => setShowProjectPanel(true)}
-          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-          title={t('projects.title')}
+          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('projects.title')}
         >
           <FolderOpen size={16} />
         </button>
         {currentProjectId && (
           <button
             onClick={handleSave}
-            className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-            title={t('projects.save')}
+            className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-label={t('projects.save')}
           >
             <Save size={16} />
           </button>
@@ -115,23 +115,23 @@ export function Header() {
 
         <button
           onClick={toggleLang}
-          className="flex items-center gap-1.5 px-2 py-1.5 border border-editorial-border text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-          title={t('language.label')}
+          className="flex items-center gap-1.5 px-2 py-1.5 border border-editorial-border text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('language.label')}
         >
           <Globe size={14} />
           {i18n.language.toUpperCase()}
         </button>
         <button
           onClick={() => setShowSettings(true)}
-          className="p-2 border border-editorial-border hover:bg-editorial-ink hover:text-white transition-colors"
-          title={t('header.settings')}
+          className="p-2 border border-editorial-border hover:bg-editorial-ink hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('header.settings')}
         >
           <Settings size={16} />
         </button>
         <button
           onClick={() => setShowHelp(true)}
-          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-white transition-colors"
-          title={t('help.title')}
+          className="p-2 border border-editorial-border text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('help.title')}
         >
           <HelpCircle size={16} />
         </button>

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -45,7 +45,8 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
               <select
                 value={config.sourceLanguage}
                 onChange={(e) => setConfig((prev) => ({ ...prev, sourceLanguage: e.target.value }))}
-                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus:ring-1 focus:ring-editorial-ink/10 appearance-none"
+                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
+                aria-label={t('pipeline.sourceLanguage')}
               >
                 {LANGUAGES.map((lang) => (
                   <option key={lang} value={lang}>{lang}</option>
@@ -59,15 +60,16 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
                     targetLanguage: prev.sourceLanguage,
                   }))
                 }
-                className="text-editorial-muted hover:text-editorial-ink transition-colors hover:scale-110 shrink-0"
-                title={t('pipeline.swapLanguages')}
+                className="text-editorial-muted hover:text-editorial-ink transition-colors hover:scale-110 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                aria-label={t('pipeline.swapLanguages')}
               >
                 <ArrowRightLeft size={14} />
               </button>
               <select
                 value={config.targetLanguage}
                 onChange={(e) => setConfig((prev) => ({ ...prev, targetLanguage: e.target.value }))}
-                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus:ring-1 focus:ring-editorial-ink/10 appearance-none"
+                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
+                aria-label={t('pipeline.targetLanguage')}
               >
                 {LANGUAGES.map((lang) => (
                   <option key={lang} value={lang}>{lang}</option>
@@ -93,7 +95,7 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
         <div>
           <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-8">
             <h2 className="font-display text-sm uppercase tracking-wider">{t('pipeline.stages')}</h2>
-            <button onClick={addStage} className="text-editorial-accent hover:scale-110 transition-transform">
+            <button onClick={addStage} className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent" aria-label={t('pipeline.addStage')}>
               <Plus size={18} />
             </button>
           </div>
@@ -182,17 +184,18 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
             <label className="block text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
               {t('pipeline.keywordRegistry')}
             </label>
-            <Plus
-              cursor="pointer"
-              size={14}
-              className="text-editorial-accent"
+            <button
               onClick={() =>
                 setConfig((prev) => ({
                   ...prev,
                   glossary: [...prev.glossary, { term: '', translation: '' }],
                 }))
               }
-            />
+              className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              aria-label={t('pipeline.addGlossaryEntry')}
+            >
+              <Plus size={14} />
+            </button>
           </div>
           <div className="space-y-2">
             {config.glossary.map((g, i) => (
@@ -206,19 +209,22 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
                       return { ...prev, glossary: n };
                     })
                   }
-                  className="w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none"
+                  className="w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                   placeholder={t('pipeline.source')}
+                  aria-label={`${t('pipeline.source')} ${i + 1}`}
                 />
-                <X
-                  size={10}
-                  className="cursor-pointer opacity-0 group-hover:opacity-100 text-red-500"
+                <button
                   onClick={() =>
                     setConfig((prev) => ({
                       ...prev,
                       glossary: prev.glossary.filter((_, idx) => idx !== i),
                     }))
                   }
-                />
+                  className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-editorial-muted hover:text-editorial-accent transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent shrink-0"
+                  aria-label={`${t('pipeline.removeGlossaryEntry')} ${i + 1}`}
+                >
+                  <X size={10} />
+                </button>
                 <input
                   value={g.translation}
                   onChange={(e) =>
@@ -228,8 +234,9 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
                       return { ...prev, glossary: n };
                     })
                   }
-                  className="w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none"
+                  className="w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                   placeholder={t('pipeline.target')}
+                  aria-label={`${t('pipeline.target')} ${i + 1}`}
                 />
               </div>
             ))}
@@ -243,7 +250,7 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
           type="button"
           onClick={onRunPipeline}
           disabled={isProcessing || chunks.length === 0}
-          className="bg-editorial-ink text-white px-6 py-4 text-[11px] font-bold uppercase tracking-[2px] transition-all hover:bg-black/90 disabled:opacity-30 disabled:cursor-not-allowed"
+          className="bg-editorial-ink text-white px-6 py-4 text-[11px] font-bold uppercase tracking-[2px] transition-all hover:bg-editorial-ink/90 disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
         >
           {isProcessing ? (
             <span className="flex items-center justify-center gap-2">
@@ -260,7 +267,7 @@ export function PipelineConfig({ onRunPipeline, onRunAuditOnly }: PipelineConfig
           type="button"
           onClick={onRunAuditOnly}
           disabled={isProcessing || chunks.length === 0}
-          className="bg-transparent border border-editorial-ink text-editorial-ink px-6 py-4 text-[11px] font-bold uppercase tracking-[2px] transition-all hover:bg-editorial-ink/5 disabled:opacity-30 disabled:cursor-not-allowed"
+          className="bg-transparent border border-editorial-ink text-editorial-ink px-6 py-4 text-[11px] font-bold uppercase tracking-[2px] transition-all hover:bg-editorial-ink/5 disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
         >
           {t('pipeline.runAuditOnly')}
         </button>

--- a/src/components/pipeline/ProductionStream.tsx
+++ b/src/components/pipeline/ProductionStream.tsx
@@ -10,13 +10,13 @@ export function ProductionStream() {
   const { t } = useTranslation();
 
   return (
-    <section className="col-span-1 md:col-span-6 bg-white p-8 overflow-y-auto max-h-[calc(100vh-140px)] border-r border-editorial-border custom-scrollbar">
+    <section className="col-span-1 md:col-span-6 bg-editorial-bg p-8 overflow-y-auto max-h-[calc(100vh-140px)] border-r border-editorial-border custom-scrollbar">
       <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-10">
         <h2 className="font-display text-sm uppercase tracking-wider inline-block">{t('pipeline.productionStream')}</h2>
         {chunks.length > 0 && (
           <button
             onClick={clearChunks}
-            className="text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-red-500 transition-colors flex items-center gap-1"
+            className="text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-accent transition-colors flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
           >
             <Trash2 size={12} /> {t('pipeline.clearStream')}
           </button>
@@ -34,12 +34,12 @@ export function ProductionStream() {
                 value={inputText}
                 onChange={(e) => setInputText(e.target.value)}
                 placeholder={t('pipeline.inputPlaceholder')}
-                className="w-full bg-editorial-textbox border-none p-8 text-sm font-mono outline-none leading-relaxed resize-none min-h-[400px]"
+                className="w-full bg-editorial-textbox border-none p-8 text-sm font-mono outline-none leading-relaxed resize-none min-h-[400px] focus-visible:ring-2 focus-visible:ring-editorial-accent"
               />
             </div>
             <button
               onClick={generateChunks}
-              className="w-full bg-editorial-ink text-white px-6 py-5 text-[11px] font-bold uppercase tracking-[3px] hover:shadow-xl transition-all"
+              className="w-full bg-editorial-ink text-white px-6 py-5 text-[11px] font-bold uppercase tracking-[3px] hover:shadow-xl transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
             >
               {t('pipeline.stageContent')}
             </button>
@@ -86,18 +86,18 @@ export function ProductionStream() {
                       key={stage.id}
                       className={`relative border p-6 bg-editorial-bg/10 animate-in fade-in slide-in-from-left-2 duration-300 ${
                         result.status === 'error'
-                          ? 'border-red-300 bg-red-50/30'
+                          ? 'border-editorial-accent/30 bg-editorial-textbox/30'
                           : 'border-editorial-border'
                       }`}
                     >
-                      <span className="absolute -top-3 left-6 bg-white border border-editorial-border px-2 font-display italic text-[10px]">
+                      <span className="absolute -top-3 left-6 bg-editorial-bg border border-editorial-border px-2 font-display italic text-[10px]">
                         {stage.name}
                       </span>
                       <div className="text-sm leading-relaxed overflow-hidden">
                         {result.status === 'processing' ? (
                           <ProcessingLine />
                         ) : result.status === 'error' ? (
-                          <div className="flex items-start gap-2 text-red-600">
+                          <div className="flex items-start gap-2 text-editorial-accent">
                             <AlertTriangle size={14} className="mt-0.5 shrink-0" />
                             <span className="text-xs font-mono">{result.error || t('errors.unknownError')}</span>
                           </div>
@@ -120,7 +120,7 @@ export function ProductionStream() {
                 <textarea
                   value={chunk.currentDraft || ''}
                   onChange={(e) => updateChunkDraft(chunk.id, e.target.value)}
-                  className="w-full bg-editorial-bg/50 border border-editorial-border p-4 text-sm font-sans outline-none focus:ring-1 focus:ring-editorial-ink/10 resize-y min-h-[100px] leading-relaxed transition-all"
+                  className="w-full bg-editorial-bg/50 border border-editorial-border p-4 text-sm font-sans outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent resize-y min-h-[100px] leading-relaxed transition-all"
                   placeholder={t('pipeline.candidatePlaceholder')}
                 />
               </div>

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -40,7 +40,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
 
   return (
     <div
-      className={`relative border border-editorial-border p-5 bg-white transition-all ${
+      className={`relative border border-editorial-border p-5 bg-editorial-bg transition-all ${
         !stage.enabled ? 'grayscale opacity-40' : 'shadow-sm'
       }`}
     >
@@ -50,21 +50,36 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
           <input
             value={stage.name}
             onChange={(e) => onUpdate({ name: e.target.value })}
-            className="bg-transparent border-none p-0 font-display text-sm focus:outline-none w-32 border-b border-transparent focus:border-editorial-ink/20"
+            className="bg-transparent border-none p-0 font-display text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent w-32 border-b border-transparent focus:border-editorial-ink/20"
+            aria-label={t('pipeline.stageName')}
           />
         </div>
         <div className="flex items-center gap-3">
-          <button onClick={() => onUpdate({ enabled: !stage.enabled })} className="text-editorial-muted">
+          <button
+            onClick={() => onUpdate({ enabled: !stage.enabled })}
+            className="text-editorial-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-label={stage.enabled ? t('pipeline.disableStage') : t('pipeline.enableStage')}
+            aria-pressed={stage.enabled}
+          >
             {stage.enabled ? (
               <ShieldCheck size={14} className="text-editorial-ink" />
             ) : (
               <div className="w-3.5 h-3.5 border-2 border-editorial-muted rounded-sm" />
             )}
           </button>
-          <button onClick={() => setIsExpanded(!isExpanded)} className="text-editorial-muted">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-editorial-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? t('pipeline.collapseStage') : t('pipeline.expandStage')}
+          >
             {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </button>
-          <button onClick={onRemove} className="text-editorial-muted hover:text-red-500 overflow-hidden">
+          <button
+            onClick={onRemove}
+            className="text-editorial-muted hover:text-editorial-accent overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-label={t('pipeline.removeStage')}
+          >
             <Trash2 size={14} />
           </button>
         </div>
@@ -85,7 +100,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                   model: models[0] || '',
                 });
               }}
-              className="bg-editorial-textbox border-none px-2 py-1 text-[10px] font-bold uppercase outline-none"
+              className="bg-editorial-textbox border-none px-2 py-1 text-[10px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
             >
               {Object.keys(MODEL_OPTIONS).map((p) => (
                 <option key={p} value={p}>
@@ -97,7 +112,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
               <select
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {modelOptions.map((m) => (
                   <option key={m} value={m}>
@@ -110,13 +125,13 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
                 placeholder={t('ollama.modelPlaceholder')}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               />
             ) : (
               <select
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {MODEL_OPTIONS[stage.provider]?.map((m) => (
                   <option key={m} value={m}>
@@ -131,7 +146,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
             onChange={(e) => onUpdate({ prompt: e.target.value })}
             placeholder={t('pipeline.stagePromptPlaceholder')}
             rows={6}
-            className="w-full bg-editorial-textbox border-none p-3 text-[11px] font-mono outline-none leading-relaxed resize-y"
+            className="w-full bg-editorial-textbox border-none p-3 text-[11px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
           />
         </div>
       )}

--- a/src/components/projects/ProjectPanel.tsx
+++ b/src/components/projects/ProjectPanel.tsx
@@ -3,6 +3,7 @@ import { FolderOpen, Plus, Trash2, Save, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { useProjectStore } from '../../stores/projectStore';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 export function ProjectPanel() {
   const { t } = useTranslation();
@@ -20,6 +21,7 @@ export function ProjectPanel() {
 
   const [newName, setNewName] = useState('');
   const [creating, setCreating] = useState(false);
+  const trapRef = useFocusTrap(showProjectPanel, () => setShowProjectPanel(false));
 
   useEffect(() => {
     if (showProjectPanel) loadProjects();
@@ -35,7 +37,13 @@ export function ProjectPanel() {
   return (
     <AnimatePresence>
       {showProjectPanel && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 sm:p-12">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-6 sm:p-12"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="project-title"
+          ref={trapRef}
+        >
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -51,12 +59,13 @@ export function ProjectPanel() {
           >
             <button
               onClick={() => setShowProjectPanel(false)}
-              className="absolute top-6 right-6 text-editorial-muted hover:text-editorial-ink"
+              className="absolute top-6 right-6 text-editorial-muted hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              aria-label={t('settings.saveClose')}
             >
               <X size={20} />
             </button>
 
-            <h2 className="font-display text-2xl italic tracking-tight mb-8 flex items-center gap-3">
+            <h2 id="project-title" className="font-display text-2xl italic tracking-tight mb-8 flex items-center gap-3">
               <FolderOpen size={24} className="text-editorial-accent" />
               {t('projects.title')}
             </h2>
@@ -69,7 +78,8 @@ export function ProjectPanel() {
                 </span>
                 <button
                   onClick={saveCurrentProject}
-                  className="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-editorial-ink hover:text-editorial-accent transition-colors"
+                  className="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-editorial-ink hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  aria-label={t('projects.save')}
                 >
                   <Save size={12} /> {t('projects.save')}
                 </button>
@@ -120,12 +130,15 @@ export function ProjectPanel() {
               {projects.map((project) => (
                 <div
                   key={project.id}
-                  className={`flex items-center gap-3 p-3 border transition-colors cursor-pointer group ${
+                  role="button"
+                  tabIndex={0}
+                  className={`flex items-center gap-3 p-3 border transition-colors cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
                     project.id === currentProjectId
-                      ? 'border-editorial-ink bg-white'
-                      : 'border-editorial-border hover:bg-white/50'
+                      ? 'border-editorial-ink bg-editorial-bg'
+                      : 'border-editorial-border hover:bg-editorial-textbox/50'
                   }`}
                   onClick={() => { openProject(project.id); setShowProjectPanel(false); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openProject(project.id); setShowProjectPanel(false); } }}
                 >
                   <FolderOpen
                     size={16}
@@ -144,7 +157,8 @@ export function ProjectPanel() {
                       e.stopPropagation();
                       removeProject(project.id);
                     }}
-                    className="p-1 text-editorial-muted opacity-0 group-hover:opacity-100 hover:text-red-500 transition-all"
+                    className="p-1 text-editorial-muted opacity-0 group-hover:opacity-100 focus:opacity-100 hover:text-editorial-accent transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    aria-label={`${t('projects.delete')} ${project.name}`}
                   >
                     <Trash2 size={14} />
                   </button>

--- a/src/components/settings/ApiKeyInput.tsx
+++ b/src/components/settings/ApiKeyInput.tsx
@@ -55,7 +55,7 @@ export function ApiKeyInput({ label, provider }: ApiKeyInputProps) {
             value={keyValue}
             onChange={(e) => setKeyValue(e.target.value)}
             placeholder={t('settings.pasteApiKey')}
-            className="flex-1 bg-editorial-textbox border-none px-3 py-2 text-[10px] font-mono outline-none"
+            className="flex-1 bg-editorial-textbox border-none px-3 py-2 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSave();
               if (e.key === 'Escape') { setEditing(false); setKeyValue(''); }
@@ -65,14 +65,14 @@ export function ApiKeyInput({ label, provider }: ApiKeyInputProps) {
           <button
             onClick={handleSave}
             disabled={saving || !keyValue.trim()}
-            className="p-1.5 text-editorial-ink hover:text-editorial-accent disabled:opacity-30"
-            title={t('settings.save')}
+            className="p-1.5 text-editorial-ink hover:text-editorial-accent disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-label={t('settings.save')}
           >
             {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
           </button>
           <button
             onClick={() => { setEditing(false); setKeyValue(''); }}
-            className="p-1.5 text-editorial-muted hover:text-editorial-ink text-[10px]"
+            className="p-1.5 text-editorial-muted hover:text-editorial-ink text-[10px] focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
           >
             {t('settings.cancel')}
           </button>
@@ -101,8 +101,8 @@ export function ApiKeyInput({ label, provider }: ApiKeyInputProps) {
         {isConfigured && (
           <button
             onClick={handleDelete}
-            className="p-1.5 text-editorial-muted hover:text-red-500 transition-colors"
-            title={t('settings.removeFromKeychain')}
+            className="p-1.5 text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            aria-label={t('settings.removeFromKeychain')}
           >
             <Trash2 size={14} />
           </button>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -5,11 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { ApiKeyInput } from './ApiKeyInput';
 import { ollamaService } from '../../services/llmService';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 export function SettingsModal() {
   const { showSettings, setShowSettings, ollamaStatus, ollamaModels, setOllamaModels, setOllamaStatus } = usePipelineStore();
   const { t } = useTranslation();
   const [refreshing, setRefreshing] = useState(false);
+  const trapRef = useFocusTrap(showSettings, () => setShowSettings(false));
 
   useEffect(() => {
     if (showSettings && ollamaStatus === 'unknown') {
@@ -34,7 +36,13 @@ export function SettingsModal() {
   return (
     <AnimatePresence>
       {showSettings && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 sm:p-12">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-6 sm:p-12"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="settings-title"
+          ref={trapRef}
+        >
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -50,11 +58,12 @@ export function SettingsModal() {
           >
             <button
               onClick={() => setShowSettings(false)}
-              className="absolute top-8 right-8 text-editorial-muted hover:text-editorial-ink"
+              className="absolute top-8 right-8 text-editorial-muted hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              aria-label={t('settings.saveClose')}
             >
               <X size={24} />
             </button>
-            <h2 className="font-display text-3xl italic tracking-tight mb-12">{t('settings.title')}</h2>
+            <h2 id="settings-title" className="font-display text-3xl italic tracking-tight mb-12">{t('settings.title')}</h2>
 
             <div className="space-y-12">
               {/* Cloud Providers */}
@@ -81,16 +90,17 @@ export function SettingsModal() {
                       <Server size={16} className="text-editorial-muted" />
                       <span className="text-xs font-mono">localhost:11434</span>
                       {ollamaStatus === 'connected' && (
-                        <CheckCircle2 size={12} className="text-green-600" />
+                        <CheckCircle2 size={12} className="text-editorial-ink" />
                       )}
                       {ollamaStatus === 'disconnected' && (
-                        <XCircle size={12} className="text-red-500" />
+                        <XCircle size={12} className="text-editorial-accent" />
                       )}
                     </div>
                     <button
                       onClick={refreshOllama}
                       disabled={refreshing}
-                      className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink transition-colors disabled:opacity-30"
+                      className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink transition-colors disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                      aria-label={t('ollama.refresh')}
                     >
                       <RefreshCw size={12} className={refreshing ? 'animate-spin' : ''} />
                       {t('ollama.refresh')}
@@ -139,7 +149,7 @@ export function SettingsModal() {
               <div className="pt-8 border-t border-editorial-border flex justify-end">
                 <button
                   onClick={() => setShowSettings(false)}
-                  className="bg-editorial-ink text-white px-8 py-4 text-[11px] font-bold uppercase tracking-widest transition-all hover:opacity-90 active:scale-95"
+                  className="bg-editorial-ink text-white px-8 py-4 text-[11px] font-bold uppercase tracking-widest transition-all hover:opacity-90 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent focus-visible:ring-offset-2"
                 >
                   {t('settings.saveClose')}
                 </button>

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+/**
+ * Traps focus within a container, handles Escape to close,
+ * and restores focus to the previously focused element on unmount.
+ */
+export function useFocusTrap(isOpen: boolean, onClose: () => void) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key !== 'Tab' || !containerRef.current) return;
+
+      const focusable = containerRef.current.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previousFocusRef.current = document.activeElement as HTMLElement;
+
+    const timer = requestAnimationFrame(() => {
+      if (containerRef.current) {
+        const firstFocusable = containerRef.current.querySelector<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        firstFocusable?.focus();
+      }
+    });
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      cancelAnimationFrame(timer);
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [isOpen, handleKeyDown]);
+
+  return containerRef;
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,7 +30,20 @@
     "candidateTranslation": "Candidate Translation",
     "candidatePlaceholder": "Output will appear here. Edit manually before auditing...",
     "newStage": "New Stage",
-    "stagePromptPlaceholder": "Stage specific prompt..."
+    "stagePromptPlaceholder": "Stage specific prompt...",
+    "addStage": "Add stage",
+    "removeStage": "Remove stage",
+    "enableStage": "Enable stage",
+    "disableStage": "Disable stage",
+    "expandStage": "Expand stage",
+    "collapseStage": "Collapse stage",
+    "stageName": "Stage name",
+    "sourceLanguage": "Source language",
+    "targetLanguage": "Target language",
+    "addGlossaryEntry": "Add glossary entry",
+    "removeGlossaryEntry": "Remove glossary entry",
+    "copy": "Copy",
+    "copied": "Copied"
   },
   "audit": {
     "title": "Audit Logs",
@@ -88,7 +101,8 @@
     "save": "Save",
     "saved": "Project saved",
     "namePlaceholder": "Project name...",
-    "empty": "No projects yet. Create one to save your work."
+    "empty": "No projects yet. Create one to save your work.",
+    "delete": "Delete"
   },
   "files": {
     "import": "Import text file",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -30,7 +30,20 @@
     "candidateTranslation": "Traduzione Candidata",
     "candidatePlaceholder": "Il risultato apparirà qui. Modifica manualmente prima dell'audit...",
     "newStage": "Nuova Fase",
-    "stagePromptPlaceholder": "Prompt specifico per la fase..."
+    "stagePromptPlaceholder": "Prompt specifico per la fase...",
+    "addStage": "Aggiungi fase",
+    "removeStage": "Rimuovi fase",
+    "enableStage": "Abilita fase",
+    "disableStage": "Disabilita fase",
+    "expandStage": "Espandi fase",
+    "collapseStage": "Comprimi fase",
+    "stageName": "Nome fase",
+    "sourceLanguage": "Lingua di partenza",
+    "targetLanguage": "Lingua di arrivo",
+    "addGlossaryEntry": "Aggiungi voce al glossario",
+    "removeGlossaryEntry": "Rimuovi voce dal glossario",
+    "copy": "Copia",
+    "copied": "Copiato"
   },
   "audit": {
     "title": "Log Audit",
@@ -88,7 +101,8 @@
     "save": "Salva",
     "saved": "Progetto salvato",
     "namePlaceholder": "Nome del progetto...",
-    "empty": "Nessun progetto. Creane uno per salvare il lavoro."
+    "empty": "Nessun progetto. Creane uno per salvare il lavoro.",
+    "delete": "Elimina"
   },
   "files": {
     "import": "Importa file di testo",

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,21 @@
   --color-editorial-border: #E5E5E1;
   --color-editorial-textbox: #F2F0ED;
 }
+
+/* Consistent focus-visible ring across the app */
+*:focus-visible {
+  outline: none;
+}
+
+/* Skip-to-content for keyboard users */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
## Summary

### Accessibility
- **Focus trap** hook (`useFocusTrap`) — Escape to close, Tab cycling, focus restore on close
- **All 3 modals**: `role=dialog`, `aria-modal`, `aria-labelledby`, focus trap
- **ARIA labels** on all icon-only buttons (Header, StageCard, PipelineConfig, ApiKeyInput, ProjectPanel)
- `aria-expanded` on collapsible StageCard sections
- `aria-pressed` on stage enable/disable toggle
- `aria-live` on CopyButton, `role=status` on StatusIndicator/ProcessingLine
- `role=alert` on ErrorBoundary
- Project list items now keyboard-accessible (`role=button`, `tabIndex`, Enter/Space)
- Glossary add/remove: SVG `onClick` → proper `<button>` elements
- Consistent `focus-visible:ring-2 ring-editorial-accent` on all interactive elements

### UI Polish
- Zero hardcoded `bg-white`, `text-red-*`, `bg-red-*`, `text-green-*` remaining
- All colors use editorial design tokens
- Normalized `disabled:opacity-40` across all components
- Consistent hover states using editorial tokens
- New i18n keys for aria-labels (EN + IT)