### PR TITLE
chore: add open-source project files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: input
+    id: version
+    attributes:
+      label: Glossa version
+      placeholder: e.g. 0.2.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      placeholder: Describe what you expected vs what actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open Glossa
+        2. Go to settings
+        3. ...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error logs (if any)
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,6 +22,7 @@ body:
       options:
         - Linux
         - Windows
+        - macOS
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,6 @@ body:
       options:
         - Linux
         - Windows
-        - macOS
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/nikazzio/glossa/discussions
+    about: Ask questions, share ideas, or show off your translations

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: ✨ Feature Request
+description: Suggest a new feature or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for Glossa? We'd love to hear it!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      placeholder: Describe the use case or pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      placeholder: How should it work? Be as detailed as you like.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Pipeline / Stages
+        - Audit / Judge
+        - LLM Providers
+        - Ollama
+        - Projects / Files
+        - UI / UX
+        - Performance
+        - Other

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What does this PR do?
+
+<!-- Brief description of the change -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] ♻️ Refactor
+- [ ] 📚 Documentation
+- [ ] 🔧 Maintenance
+
+## Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `cargo check` passes (if Rust changes)
+- [ ] Tested locally
+- [ ] i18n keys added for both EN and IT (if UI changes)

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,17 @@ coverage/
 *.log
 .env*
 !.env.example
+
+# Rust / Tauri
+src-tauri/target/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+Thumbs.db
+Desktop.ini

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,9 +30,10 @@ Examples of unacceptable behavior:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainers. All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances.
+reported via [GitHub Security Advisories](https://github.com/nikazzio/glossa/security/advisories/new)
+or by opening a private issue. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate to the
+circumstances.
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-present Niki Corradetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Glossa, please report it responsibly.
+
+**Do NOT open a public issue.**
+
+Instead, email **[nikazzio@users.noreply.github.com]** with:
+
+1. A description of the vulnerability
+2. Steps to reproduce (if applicable)
+3. Affected version(s)
+
+You can expect an initial response within **48 hours**. We will work with you to understand and address the issue before any public disclosure.
+
+## Scope
+
+Glossa is a local desktop application. Security concerns may include:
+
+- **API key handling** — Keys are stored in the OS keychain (macOS Keychain, GNOME Keyring, Windows Credential Manager). If you find a way to extract them, please report it.
+- **LLM data transmission** — All LLM calls go through the Rust backend. If you find unintended data leakage, please report it.
+- **Ollama integration** — Ollama runs locally. If you find a way to exploit the localhost connection, please report it.
+- **Supply chain** — If you notice a compromised or suspicious dependency, please report it.
+
+## Out of Scope
+
+- Vulnerabilities in upstream dependencies that are already publicly known (check their issue trackers first)
+- Issues requiring physical access to the user's machine
+- Social engineering attacks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in Glossa, please report it responsibly
 
 **Do NOT open a public issue.**
 
-Instead, use GitHub Security Advisories to report the issue privately, and include:
+Instead, use [GitHub Security Advisories](https://github.com/nikazzio/glossa/security/advisories/new) to report the issue privately, and include:
 
 1. A description of the vulnerability
 2. Steps to reproduce (if applicable)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in Glossa, please report it responsibly
 
 **Do NOT open a public issue.**
 
-Instead, email **[nikazzio@users.noreply.github.com]** with:
+Instead, use GitHub Security Advisories to report the issue privately, and include:
 
 1. A description of the vulnerability
 2. Steps to reproduce (if applicable)


### PR DESCRIPTION
## Summary

Adds standard open-source project files:

- **LICENSE** — MIT
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **SECURITY.md** — Responsible disclosure policy with scope
- **Issue templates** — Bug report + Feature request (YAML forms with dropdowns)
- **PR template** — Checklist for type, lint, tests, i18n
- **.gitignore** — Extended with Rust/Tauri, IDE, OS patterns

Also updated repo about:
- Description: *Multi-stage AI translation pipeline for scholars...*
- Topics: tauri, translation, ai, llm, rust, react, desktop-app, ollama, nlp, open-source, typescript, scholarly-tools, multi-llm, pipeline