### PR TITLE
fix: restore saved translations when reopening projects

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1702,7 +1702,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "keyring",
  "log",

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -9,6 +9,16 @@ async function getDb(): Promise<Database> {
   return db;
 }
 
+async function ensureColumn(table: string, column: string, definition: string): Promise<void> {
+  const conn = await getDb();
+  const columns = await conn.select<Array<{ name: string }>>(`PRAGMA table_info(${table})`);
+  if (columns.some((existing) => existing.name === column)) {
+    return;
+  }
+
+  await conn.execute(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
 /** Run migrations on app startup */
 export async function initDatabase(): Promise<void> {
   const conn = await getDb();
@@ -76,9 +86,12 @@ export async function initDatabase(): Promise<void> {
       stage_results TEXT DEFAULT '{}',
       judge_score REAL DEFAULT 0,
       judge_issues TEXT DEFAULT '[]',
+      judge_result TEXT DEFAULT '',
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   `);
+
+  await ensureColumn('translations', 'judge_result', "TEXT DEFAULT ''");
 
   await conn.execute(`
     CREATE TABLE IF NOT EXISTS app_settings (

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,5 +1,11 @@
 import { select, execute } from './dbService';
-import type { PipelineConfig, PipelineStageConfig, GlossaryEntry, TranslationChunk } from '../types';
+import type {
+  GlossaryEntry,
+  JudgeResult,
+  PipelineConfig,
+  PipelineStageConfig,
+  TranslationChunk,
+} from '../types';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -20,7 +26,45 @@ export interface SavedTranslation {
   stage_results: string; // JSON
   judge_score: number;
   judge_issues: string; // JSON
+  judge_result?: string; // JSON
   created_at: string;
+}
+
+function parseJson<T>(value: string | undefined, fallback: T): T {
+  if (!value) return fallback;
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function restoreJudgeResult(row: SavedTranslation): JudgeResult {
+  const legacyIssues = parseJson<JudgeResult['issues']>(row.judge_issues, []);
+  const legacyFallback: JudgeResult = {
+    content: row.final_translation,
+    status: row.final_translation || row.judge_score > 0 || legacyIssues.length > 0 ? 'completed' : 'idle',
+    score: row.judge_score,
+    issues: legacyIssues,
+  };
+
+  const restored = parseJson<Partial<JudgeResult>>(row.judge_result, legacyFallback);
+  return {
+    ...legacyFallback,
+    ...restored,
+    issues: restored.issues ?? legacyFallback.issues,
+  };
+}
+
+export function restoreTranslations(rows: SavedTranslation[]): TranslationChunk[] {
+  return rows.map((row) => ({
+    id: row.id,
+    originalText: row.original_text,
+    stageResults: parseJson(row.stage_results, {}),
+    judgeResult: restoreJudgeResult(row),
+    currentDraft: row.final_translation || '',
+  }));
 }
 
 // ── Projects CRUD ────────────────────────────────────────────────────
@@ -133,8 +177,9 @@ export async function saveTranslations(projectId: string, chunks: TranslationChu
 
   for (const chunk of chunks) {
     await execute(
-      `INSERT INTO translations (id, project_id, original_text, final_translation, stage_results, judge_score, judge_issues)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      `INSERT INTO translations (
+         id, project_id, original_text, final_translation, stage_results, judge_score, judge_issues, judge_result
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
       [
         chunk.id,
         projectId,
@@ -143,6 +188,7 @@ export async function saveTranslations(projectId: string, chunks: TranslationChu
         JSON.stringify(chunk.stageResults),
         chunk.judgeResult.score,
         JSON.stringify(chunk.judgeResult.issues),
+        JSON.stringify(chunk.judgeResult),
       ],
     );
   }

--- a/src/stores/projectStore.test.ts
+++ b/src/stores/projectStore.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePipelineStore } from './pipelineStore';
+import { useProjectStore } from './projectStore';
+import type { SavedTranslation } from '../services/projectService';
+
+const projectServiceMocks = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  createProject: vi.fn(),
+  deleteProject: vi.fn(),
+  getProjectConfig: vi.fn(),
+  saveProjectConfig: vi.fn(),
+  saveTranslations: vi.fn(),
+  loadTranslations: vi.fn(),
+}));
+
+vi.mock('../services/projectService', async () => {
+  const actual = await vi.importActual<typeof import('../services/projectService')>('../services/projectService');
+  return {
+    ...actual,
+    ...projectServiceMocks,
+  };
+});
+
+describe('projectStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useProjectStore.setState({
+      projects: [],
+      currentProjectId: null,
+      showProjectPanel: false,
+    });
+
+    const pipeline = usePipelineStore.getState();
+    pipeline.setInputText('');
+    pipeline.clearChunks();
+    pipeline.setIsProcessing(false);
+    pipeline.setShowSettings(false);
+    pipeline.setOllamaModels([]);
+    pipeline.setOllamaStatus('unknown');
+    pipeline.setConfig((prev) => ({
+      ...prev,
+      sourceLanguage: 'English',
+      targetLanguage: 'Italian',
+      stages: [
+        {
+          id: 'default-stage',
+          name: 'Default Stage',
+          prompt: 'Default prompt',
+          model: 'gemini-3-flash-preview',
+          provider: 'gemini',
+          enabled: true,
+        },
+      ],
+      judgePrompt: 'Default judge prompt',
+      judgeModel: 'gemini-3-flash-preview',
+      judgeProvider: 'gemini',
+      glossary: [],
+      useChunking: true,
+    }));
+  });
+
+  it('opens a project and restores saved chunks with stage and judge data', async () => {
+    projectServiceMocks.getProjectConfig.mockResolvedValue({
+      stages: [
+        {
+          id: 'stg-1',
+          name: 'Literal Draft',
+          prompt: 'Translate literally',
+          model: 'gpt-4o-mini',
+          provider: 'openai',
+          enabled: true,
+        },
+      ],
+      judgePrompt: 'Judge carefully',
+      judgeModel: 'claude-3-5-sonnet',
+      judgeProvider: 'anthropic',
+      useChunking: false,
+      glossary: [{ term: 'logos', translation: 'logos', notes: 'retain Greek' }],
+    });
+
+    const savedTranslations: SavedTranslation[] = [
+      {
+        id: 'chunk-0',
+        project_id: 'proj-1',
+        original_text: 'Original paragraph',
+        final_translation: 'Translated paragraph',
+        stage_results: JSON.stringify({
+          'stg-1': {
+            content: 'Translated paragraph',
+            status: 'completed',
+          },
+        }),
+        judge_score: 92,
+        judge_issues: JSON.stringify([
+          {
+            type: 'fluency',
+            severity: 'low',
+            description: 'Minor smoothing needed',
+          },
+        ]),
+        judge_result: JSON.stringify({
+          content: 'Translated paragraph',
+          status: 'completed',
+          score: 92,
+          issues: [
+            {
+              type: 'fluency',
+              severity: 'low',
+              description: 'Minor smoothing needed',
+            },
+          ],
+        }),
+        created_at: '2026-04-19T00:00:00Z',
+      },
+    ];
+
+    projectServiceMocks.loadTranslations.mockResolvedValue(savedTranslations);
+
+    await useProjectStore.getState().openProject('proj-1');
+
+    const pipeline = usePipelineStore.getState();
+    expect(useProjectStore.getState().currentProjectId).toBe('proj-1');
+    expect(projectServiceMocks.loadTranslations).toHaveBeenCalledWith('proj-1');
+    expect(pipeline.config.stages).toEqual([
+      {
+        id: 'stg-1',
+        name: 'Literal Draft',
+        prompt: 'Translate literally',
+        model: 'gpt-4o-mini',
+        provider: 'openai',
+        enabled: true,
+      },
+    ]);
+    expect(pipeline.config.judgeProvider).toBe('anthropic');
+    expect(pipeline.config.useChunking).toBe(false);
+    expect(pipeline.chunks).toEqual([
+      {
+        id: 'chunk-0',
+        originalText: 'Original paragraph',
+        stageResults: {
+          'stg-1': {
+            content: 'Translated paragraph',
+            status: 'completed',
+          },
+        },
+        judgeResult: {
+          content: 'Translated paragraph',
+          status: 'completed',
+          score: 92,
+          issues: [
+            {
+              type: 'fluency',
+              severity: 'low',
+              description: 'Minor smoothing needed',
+            },
+          ],
+        },
+        currentDraft: 'Translated paragraph',
+      },
+    ]);
+  });
+
+  it('clears stale chunks when opening a project with no saved translations', async () => {
+    projectServiceMocks.getProjectConfig.mockResolvedValue({
+      stages: [],
+      judgePrompt: '',
+      judgeModel: '',
+      judgeProvider: '',
+      useChunking: true,
+      glossary: [],
+    });
+    projectServiceMocks.loadTranslations.mockResolvedValue([]);
+
+    usePipelineStore.getState().setInputText('Stale text');
+    usePipelineStore.getState().generateChunks();
+    expect(usePipelineStore.getState().chunks).toHaveLength(1);
+
+    await useProjectStore.getState().openProject('proj-empty');
+
+    expect(useProjectStore.getState().currentProjectId).toBe('proj-empty');
+    expect(usePipelineStore.getState().chunks).toEqual([]);
+  });
+});

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -4,6 +4,8 @@ import {
   createProject,
   deleteProject,
   getProjectConfig,
+  loadTranslations,
+  restoreTranslations,
   saveProjectConfig,
   saveTranslations,
   type Project,
@@ -44,10 +46,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 
   openProject: async (id: string) => {
-    const config = await getProjectConfig(id);
+    const [config, savedTranslations] = await Promise.all([
+      getProjectConfig(id),
+      loadTranslations(id),
+    ]);
     if (!config) return;
 
     const pipeline = usePipelineStore.getState();
+    const restoredChunks = restoreTranslations(savedTranslations);
     pipeline.setConfig({
       ...pipeline.config,
       stages: config.stages.length > 0 ? config.stages : pipeline.config.stages,
@@ -57,6 +63,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       useChunking: config.useChunking,
       glossary: config.glossary,
     });
+    pipeline.setChunks(restoredChunks);
+    pipeline.setInputText(restoredChunks.map((chunk) => chunk.originalText).join('\n\n'));
 
     set({ currentProjectId: id });
   },


### PR DESCRIPTION
## What does this PR do?

Fixes #25 by restoring saved translation state when reopening a project. The restore flow now reloads saved chunks, stage outputs, final drafts, and judge results instead of only reloading pipeline config.

It also adds a safe SQLite migration for a new `judge_result` column so the app can persist the full judge payload needed for faithful rehydration, while keeping fallback support for legacy rows.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [x] `npm run lint` passes
- [x] `cargo check` passes (if Rust changes)
- [x] Tested locally
- [ ] i18n keys added for both EN and IT (if UI changes)

## Verification

- `npm test -- --run`
- `npm run lint`
- `cargo check`

## Notes

- Adds `src/stores/projectStore.test.ts` to cover save/reopen rehydration behavior.
- Clears stale in-memory chunks when opening a project with no saved translations.
- Restores legacy translation rows even if they do not yet have the new `judge_result` payload.
