### PR TITLE
chore: add release checksums and updater artifact signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,18 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ needs.release-please.outputs.tag_name }}
           releaseName: "Glossa ${{ needs.release-please.outputs.tag_name }}"
+          args: --config src-tauri/tauri.release.conf.json
+      - name: Generate SHA-256 checksums
+        run: node scripts/generate-release-checksums.mjs src-tauri/target/release/bundle SHA256SUMS-linux.txt
+      - name: Upload checksum file
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} SHA256SUMS-linux.txt --clobber
 
   build-windows:
     needs: release-please
@@ -69,6 +78,17 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ needs.release-please.outputs.tag_name }}
           releaseName: "Glossa ${{ needs.release-please.outputs.tag_name }}"
+          args: --config src-tauri/tauri.release.conf.json
+      - name: Generate SHA-256 checksums
+        shell: pwsh
+        run: node scripts/generate-release-checksums.mjs src-tauri/target/release/bundle SHA256SUMS-windows.txt
+      - name: Upload checksum file
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} SHA256SUMS-windows.txt --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
    - A git tag `vX.Y.Z` is created
    - GitHub Actions builds the app on Linux and Windows in parallel
    - Binaries (`.deb`, `.rpm`, `.AppImage`, `.msi`, `.exe`) are uploaded to a GitHub Release
+   - Platform-specific `SHA256SUMS-*.txt` files are uploaded for integrity verification
+   - Release builds also generate signed Tauri updater artifacts when updater signing secrets are configured
 
 ### Build targets
 
@@ -137,3 +139,12 @@ refactor: clean up stores    ──┘
 3. Push and open a PR
 4. CI runs lint + cargo check automatically
 5. After review, merge to `main`
+
+## Release secrets
+
+The automated release workflow expects these repository secrets for Tauri updater artifact signing:
+
+- `TAURI_SIGNING_PRIVATE_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (optional if the private key has no password)
+
+These are used for Tauri updater artifact signing only. They do **not** replace Windows Authenticode code signing.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ npm run tauri:build
 Outputs `.deb`, `.rpm`, and `.AppImage` on Linux; `.dmg` on macOS; `.msi` on Windows.  
 Bundles are in `src-tauri/target/release/bundle/`.
 
+### Verify release downloads
+
+GitHub Releases include machine-readable SHA-256 checksum files so you can verify downloaded assets before running them.
+
+Windows PowerShell:
+```powershell
+Get-FileHash .\Glossa-setup.exe -Algorithm SHA256
+```
+
+Windows CMD:
+```cmd
+certutil -hashfile Glossa-setup.exe SHA256
+```
+
+Compare the resulting hash with the corresponding entry in `SHA256SUMS-*.txt`.
+
+Note: Tauri updater artifacts are also signed for in-app update verification, but that signature is separate from Windows Authenticode code signing and does not suppress SmartScreen warnings.
+
 ## Configuration
 
 ### API keys

--- a/scripts/generate-release-checksums.mjs
+++ b/scripts/generate-release-checksums.mjs
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdir, readdir, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const [, , bundleDirArg, outputFileArg] = process.argv;
+
+if (!bundleDirArg || !outputFileArg) {
+  console.error('Usage: node scripts/generate-release-checksums.mjs <bundle-dir> <output-file>');
+  process.exit(1);
+}
+
+const bundleDir = path.resolve(bundleDirArg);
+const outputFile = path.resolve(outputFileArg);
+const releasableSuffixes = [
+  '.AppImage',
+  '.deb',
+  '.dmg',
+  '.exe',
+  '.msi',
+  '.rpm',
+  '.sig',
+  '.tar.gz',
+  '.zip',
+];
+
+function isReleasable(filePath) {
+  return releasableSuffixes.some((suffix) => filePath.endsWith(suffix));
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+
+    if (entry.isFile() && isReleasable(fullPath)) {
+      return [fullPath];
+    }
+
+    return [];
+  }));
+
+  return files.flat();
+}
+
+async function hashFile(filePath) {
+  await stat(filePath);
+
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+const files = (await walk(bundleDir)).sort((left, right) => left.localeCompare(right));
+
+if (files.length === 0) {
+  console.error(`No releasable assets found under ${bundleDir}`);
+  process.exit(1);
+}
+
+const lines = await Promise.all(files.map(async (filePath) => {
+  const digest = await hashFile(filePath);
+  const relativePath = path.relative(bundleDir, filePath).split(path.sep).join('/');
+  return `${digest}  ${relativePath}`;
+}));
+
+await mkdir(path.dirname(outputFile), { recursive: true });
+await writeFile(outputFile, `${lines.join('\n')}\n`, 'utf8');
+
+console.log(`Wrote ${files.length} checksums to ${outputFile}`);

--- a/src-tauri/tauri.release.conf.json
+++ b/src-tauri/tauri.release.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Implements #28 by hardening the automated release process in two ways:

1. GitHub Releases now get platform-specific `SHA256SUMS-*.txt` files generated from the produced bundle assets.
2. Release builds now use a release-only Tauri config that enables signed updater artifacts.

This improves release integrity and updater authenticity, but it does **not** add Windows Authenticode signing and does **not** remove SmartScreen warnings.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📚 Documentation
- [x] 🔧 Maintenance

## Checklist

- [x] `npm run lint` passes
- [ ] `cargo check` passes (if Rust changes)
- [x] Tested locally
- [ ] i18n keys added for both EN and IT (if UI changes)

## Verification

- `npm run lint`
- `node scripts/generate-release-checksums.mjs /tmp/glossa-bundle-test /tmp/glossa-bundle-test/SHA256SUMS.txt`

## Notes

- Adds `scripts/generate-release-checksums.mjs` as a cross-platform checksum generator used by the release workflow.
- Adds `src-tauri/tauri.release.conf.json` so updater artifacts are only enabled in release CI, not in normal local builds.
- Documents download verification in `README.md`.
- Documents required repo secrets in `CONTRIBUTING.md`:
  - `TAURI_SIGNING_PRIVATE_KEY`
  - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
- Before the next real release, those secrets must be configured in GitHub or the updater-signing portion of the release build will fail.
