### PR TITLE
S4-T4: importa documenti .docx e .pdf

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1755,8 @@ version = "0.2.2"
 dependencies = [
  "keyring",
  "log",
+ "pdf-extract",
+ "quick-xml 0.36.2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1748,6 +1768,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tauri-plugin-updater",
  "tokio",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2529,6 +2550,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+dependencies = [
+ "encoding_rs",
+ "flate2",
+ "indexmap 2.14.0",
+ "itoa",
+ "log",
+ "md-5",
+ "nom",
+ "rangemap",
+ "time",
+ "weezl",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,6 +2645,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -2726,6 +2771,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num"
@@ -3125,6 +3180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-extract"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+dependencies = [
+ "adobe-cmap-parser",
+ "encoding_rs",
+ "euclid",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,7 +3454,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3415,6 +3485,18 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -3546,6 +3628,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3660,6 +3751,12 @@ checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "raw-window-handle"
@@ -5251,7 +5348,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5767,6 +5864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,6 +6348,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -7167,6 +7279,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -7182,6 +7311,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1305,6 +1305,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1756,7 +1757,7 @@ dependencies = [
  "keyring",
  "log",
  "pdf-extract",
- "quick-xml 0.36.2",
+ "quick-xml",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1768,7 +1769,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tauri-plugin-updater",
  "tokio",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
@@ -3454,7 +3455,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3624,15 +3625,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -5348,7 +5340,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip 4.6.1",
+ "zip",
 ]
 
 [[package]]
@@ -7279,32 +7271,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap 2.14.0",
- "memchr",
- "thiserror 2.0.18",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,9 @@ keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tokio = { version = "1", features = ["sync", "macros"] }
+zip = { version = "2", default-features = false, features = ["deflate"] }
+quick-xml = "0.36"
+pdf-extract = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,8 +30,8 @@ keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tokio = { version = "1", features = ["sync", "macros"] }
-zip = { version = "2", default-features = false, features = ["deflate"] }
-quick-xml = "0.36"
+zip = { version = "4", default-features = false, features = ["deflate"] }
+quick-xml = "0.38"
 pdf-extract = "0.7"
 
 [dev-dependencies]

--- a/src-tauri/src/documents.rs
+++ b/src-tauri/src/documents.rs
@@ -6,14 +6,22 @@ use quick_xml::Reader;
 
 #[tauri::command]
 pub async fn extract_docx_text(path: String) -> Result<String, String> {
-    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
-    extract_docx_text_from_bytes(&bytes)
+    tauri::async_runtime::spawn_blocking(move || {
+        let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+        extract_docx_text_from_bytes(&bytes)
+    })
+    .await
+    .map_err(|e| format!("Document extraction task failed: {}", e))?
 }
 
 #[tauri::command]
 pub async fn extract_pdf_text(path: String) -> Result<String, String> {
-    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
-    extract_pdf_text_from_bytes(&bytes)
+    tauri::async_runtime::spawn_blocking(move || {
+        let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+        extract_pdf_text_from_bytes(&bytes)
+    })
+    .await
+    .map_err(|e| format!("Document extraction task failed: {}", e))?
 }
 
 pub fn extract_docx_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
@@ -62,9 +70,11 @@ fn extract_text_from_document_xml(xml: &str) -> Result<String, String> {
             }
             Ok(Event::Text(event)) => {
                 if inside_text {
-                    let text = event
-                        .unescape()
+                    let decoded = event
+                        .decode()
                         .map_err(|e| format!("Failed to decode docx text: {}", e))?;
+                    let text = quick_xml::escape::unescape(&decoded)
+                        .map_err(|e| format!("Failed to unescape docx text: {}", e))?;
                     current.push_str(&text);
                 }
             }

--- a/src-tauri/src/documents.rs
+++ b/src-tauri/src/documents.rs
@@ -1,0 +1,203 @@
+use std::fs;
+use std::io::{Cursor, Read};
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+#[tauri::command]
+pub async fn extract_docx_text(path: String) -> Result<String, String> {
+    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    extract_docx_text_from_bytes(&bytes)
+}
+
+#[tauri::command]
+pub async fn extract_pdf_text(path: String) -> Result<String, String> {
+    let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+    extract_pdf_text_from_bytes(&bytes)
+}
+
+pub fn extract_docx_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
+    let cursor = Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor)
+        .map_err(|_| "Not a valid .docx file (expected a zip archive).".to_string())?;
+
+    let mut document_xml = String::new();
+    {
+        let mut document = archive
+            .by_name("word/document.xml")
+            .map_err(|_| "Not a valid .docx file (missing word/document.xml).".to_string())?;
+        document
+            .read_to_string(&mut document_xml)
+            .map_err(|e| format!("Failed to read document.xml: {}", e))?;
+    }
+
+    extract_text_from_document_xml(&document_xml)
+}
+
+fn extract_text_from_document_xml(xml: &str) -> Result<String, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+
+    let mut paragraphs: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut inside_text = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) => {
+                let name = element.name();
+                let local = name.as_ref();
+                if local.ends_with(b":t") || local == b"t" {
+                    inside_text = true;
+                }
+            }
+            Ok(Event::End(element)) => {
+                let name = element.name();
+                let local = name.as_ref();
+                if local.ends_with(b":t") || local == b"t" {
+                    inside_text = false;
+                } else if local.ends_with(b":p") || local == b"p" {
+                    paragraphs.push(std::mem::take(&mut current));
+                }
+            }
+            Ok(Event::Text(event)) => {
+                if inside_text {
+                    let text = event
+                        .unescape()
+                        .map_err(|e| format!("Failed to decode docx text: {}", e))?;
+                    current.push_str(&text);
+                }
+            }
+            Ok(Event::Empty(element)) => {
+                let name = element.name();
+                let local = name.as_ref();
+                if local.ends_with(b":br") || local == b"br" {
+                    current.push('\n');
+                } else if local.ends_with(b":tab") || local == b"tab" {
+                    current.push('\t');
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => {
+                return Err(format!("Failed to parse docx document.xml: {}", error));
+            }
+            _ => {}
+        }
+    }
+
+    if !current.is_empty() {
+        paragraphs.push(current);
+    }
+
+    let joined = paragraphs
+        .into_iter()
+        .map(|paragraph| paragraph.trim_end().to_string())
+        .filter(|paragraph| !paragraph.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    if joined.trim().is_empty() {
+        return Err("The .docx file did not contain any extractable text.".to_string());
+    }
+
+    Ok(joined)
+}
+
+pub fn extract_pdf_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
+    if !bytes.starts_with(b"%PDF-") {
+        return Err("Not a valid .pdf file (missing PDF header).".to_string());
+    }
+
+    let extracted = pdf_extract::extract_text_from_mem(bytes)
+        .map_err(|e| format!("Failed to extract text from PDF: {}", e))?;
+
+    let normalized = normalize_pdf_text(&extracted);
+    if normalized.trim().is_empty() {
+        return Err("The .pdf file did not contain any extractable text.".to_string());
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_pdf_text(text: &str) -> String {
+    text.lines()
+        .map(|line| line.trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    fn build_docx(document_xml: &str) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buffer);
+            let mut writer = zip::ZipWriter::new(cursor);
+            let options = SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            writer.start_file("word/document.xml", options).unwrap();
+            writer.write_all(document_xml.as_bytes()).unwrap();
+            writer.finish().unwrap();
+        }
+        buffer
+    }
+
+    #[test]
+    fn extracts_paragraph_text_from_docx() {
+        let xml = r#"<?xml version="1.0"?>
+<w:document xmlns:w="x">
+  <w:body>
+    <w:p><w:r><w:t>First paragraph.</w:t></w:r></w:p>
+    <w:p><w:r><w:t xml:space="preserve">Second </w:t><w:t>paragraph.</w:t></w:r></w:p>
+  </w:body>
+</w:document>"#;
+        let bytes = build_docx(xml);
+
+        let extracted = extract_docx_text_from_bytes(&bytes).expect("expected docx text");
+
+        assert_eq!(extracted, "First paragraph.\n\nSecond paragraph.");
+    }
+
+    #[test]
+    fn rejects_non_zip_input_for_docx() {
+        let result = extract_docx_text_from_bytes(b"plain text, not a zip");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_zip_without_document_xml() {
+        let mut buffer: Vec<u8> = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buffer);
+            let mut writer = zip::ZipWriter::new(cursor);
+            writer
+                .start_file("other.txt", SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(b"hello").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let result = extract_docx_text_from_bytes(&buffer);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_docx_with_only_whitespace() {
+        let xml = r#"<?xml version="1.0"?><w:document xmlns:w="x"><w:body><w:p><w:r><w:t>   </w:t></w:r></w:p></w:body></w:document>"#;
+        let bytes = build_docx(xml);
+        let result = extract_docx_text_from_bytes(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_input_without_pdf_header() {
+        let result = extract_pdf_text_from_bytes(b"this is not a pdf");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod documents;
 mod llm;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -43,6 +44,8 @@ pub fn run() {
       llm::test_provider_connection,
       llm::list_ollama_models,
       llm::check_ollama_status,
+      documents::extract_docx_text,
+      documents::extract_pdf_text,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src/services/fileService.test.ts
+++ b/src/services/fileService.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
+import { readTextFile } from '@tauri-apps/plugin-fs';
+import { importTextFile } from './fileService';
+
+const invokeMock = vi.mocked(invoke);
+const openMock = vi.mocked(open);
+const readTextFileMock = vi.mocked(readTextFile);
+
+describe('importTextFile', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    openMock.mockReset();
+    readTextFileMock.mockReset();
+  });
+
+  it('returns null when the user cancels the dialog', async () => {
+    openMock.mockResolvedValueOnce(null);
+
+    const result = await importTextFile();
+
+    expect(result).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(readTextFileMock).not.toHaveBeenCalled();
+  });
+
+  it('reads .txt files via the fs plugin', async () => {
+    openMock.mockResolvedValueOnce('/tmp/source.txt');
+    readTextFileMock.mockResolvedValueOnce('plain text');
+
+    const result = await importTextFile();
+
+    expect(readTextFileMock).toHaveBeenCalledWith('/tmp/source.txt');
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ path: '/tmp/source.txt', name: 'source.txt', text: 'plain text' });
+  });
+
+  it('routes .docx files through extract_docx_text', async () => {
+    openMock.mockResolvedValueOnce('/tmp/Doc.DOCX');
+    invokeMock.mockResolvedValueOnce('docx content');
+
+    const result = await importTextFile();
+
+    expect(invokeMock).toHaveBeenCalledWith('extract_docx_text', { path: '/tmp/Doc.DOCX' });
+    expect(readTextFileMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ path: '/tmp/Doc.DOCX', name: 'Doc.DOCX', text: 'docx content' });
+  });
+
+  it('routes .pdf files through extract_pdf_text', async () => {
+    openMock.mockResolvedValueOnce('/tmp/book.pdf');
+    invokeMock.mockResolvedValueOnce('pdf content');
+
+    const result = await importTextFile();
+
+    expect(invokeMock).toHaveBeenCalledWith('extract_pdf_text', { path: '/tmp/book.pdf' });
+    expect(readTextFileMock).not.toHaveBeenCalled();
+    expect(result?.text).toBe('pdf content');
+  });
+
+  it('handles Windows-style paths when extracting the basename', async () => {
+    openMock.mockResolvedValueOnce('C\\\\Users\\\\me\\\\report.docx');
+    invokeMock.mockResolvedValueOnce('win docx');
+
+    const result = await importTextFile();
+
+    expect(invokeMock).toHaveBeenCalledWith('extract_docx_text', { path: 'C\\\\Users\\\\me\\\\report.docx' });
+    expect(result?.name).toBe('report.docx');
+  });
+});

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -44,13 +44,6 @@ async function readImportedText(path: string): Promise<string> {
   return await readTextFile(path);
 }
 
-function extension(path: string): string {
-  const normalized = path.replace(/\\/g, '/');
-  const name = normalized.split('/').pop() ?? normalized;
-  const dot = name.lastIndexOf('.');
-  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
-}
-
 // ── Export ────────────────────────────────────────────────────────────
 
 export async function exportTranslation(
@@ -125,7 +118,17 @@ function buildMarkdown(chunks: TranslationChunk[]): string {
   return lines.join('\n');
 }
 
-function basename(path: string): string {
+function fileName(path: string): string {
   const normalized = path.replace(/\\/g, '/');
   return normalized.split('/').pop() || normalized;
+}
+
+function basename(path: string): string {
+  return fileName(path);
+}
+
+function extension(path: string): string {
+  const name = fileName(path);
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
 }

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import type { TranslationChunk } from '../types';
@@ -15,7 +16,10 @@ export async function importTextFile(): Promise<ImportedTextFile | null> {
   const path = await open({
     title: 'Import source text',
     filters: [
-      { name: 'Text files', extensions: ['txt', 'md', 'text'] },
+      { name: 'Documents', extensions: ['txt', 'md', 'text', 'docx', 'pdf'] },
+      { name: 'Plain text', extensions: ['txt', 'md', 'text'] },
+      { name: 'Word document', extensions: ['docx'] },
+      { name: 'PDF document', extensions: ['pdf'] },
       { name: 'All files', extensions: ['*'] },
     ],
     multiple: false,
@@ -25,8 +29,26 @@ export async function importTextFile(): Promise<ImportedTextFile | null> {
   return {
     path: resolvedPath,
     name: basename(resolvedPath),
-    text: await readTextFile(resolvedPath),
+    text: await readImportedText(resolvedPath),
   };
+}
+
+async function readImportedText(path: string): Promise<string> {
+  const ext = extension(path);
+  if (ext === 'docx') {
+    return await invoke<string>('extract_docx_text', { path });
+  }
+  if (ext === 'pdf') {
+    return await invoke<string>('extract_pdf_text', { path });
+  }
+  return await readTextFile(path);
+}
+
+function extension(path: string): string {
+  const normalized = path.replace(/\\/g, '/');
+  const name = normalized.split('/').pop() ?? normalized;
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
 }
 
 // ── Export ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Aggiunge i comandi Tauri `extract_docx_text` e `extract_pdf_text` (`src-tauri/src/documents.rs`): docx letto come zip + parsing di `word/document.xml` con `quick-xml`, pdf via `pdf-extract` con validazione header `%PDF-` e normalizzazione output.
- `fileService.importTextFile` ora propone i filter Plain text / Word / PDF e instrada al backend giusto in base all'estensione, lasciando intatto il resto del flusso (preview, chunking, autosave).
- Copertura: 5 cargo test (parse paragrafo, no-zip, zip senza document.xml, docx whitespace-only, header pdf mancante) + 5 vitest su `fileService` (cancel, txt, docx, pdf, path Windows).

Stacked sopra #40: la PR ha come base `feat/s4-t4-document-workflow`, GitHub la rebaserà su `main` automaticamente al merge della PR padre.

Chiude il gap di verifica S4-T4 in cui docx/pdf erano elencati come non supportati.

## Test plan
- [x] `cargo test --lib documents` (5/5)
- [x] `npx vitest run` (56/56 inclusi i 5 nuovi su `fileService`)
- [x] `npx tsc --noEmit`
- [ ] Smoke manuale: import di un `.docx` e un `.pdf` reali da Header → preview → conferma → testo nel reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)