### PR TITLE
Reduce local Rust build footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 A desktop application that chains multiple LLM passes — draft, refinement, audit — to produce publication-quality translations. Built for philologists, classicists, and translators who need precision over speed.
 
 [![Tauri v2](https://img.shields.io/badge/Tauri-v2-blue?logo=tauri)](https://v2.tauri.app)
+[![Release](https://img.shields.io/github/v/release/nikazzio/glossa?display_name=tag)](https://github.com/nikazzio/glossa/releases/latest)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev)
 [![Rust](https://img.shields.io/badge/Rust-backend-orange?logo=rust)](https://rust-lang.org)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.14",
         "@tauri-apps/api": "^2.10.1",
-        "@tauri-apps/cli": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-sql": "^2.4.0",
@@ -27,6 +26,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@tauri-apps/cli": "^2.10.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.14",
     "@tauri-apps/api": "^2.10.1",
-    "@tauri-apps/cli": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-sql": "^2.4.0",
@@ -36,6 +35,7 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2.10.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.77.2"
 
 [lib]
 name = "glossa_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.6", features = [] }
@@ -36,3 +36,10 @@ pdf-extract = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
+
+[profile.dev]
+debug = 1
+incremental = true
+
+[profile.release]
+strip = "debuginfo"


### PR DESCRIPTION
## Summary
- reduce local Rust build artifact churn by limiting the Tauri library crate type to `rlib`
- tune Cargo profiles for lighter local debug builds and stripped release debuginfo
- move `@tauri-apps/cli` to `devDependencies` and add a README badge that tracks the latest GitHub release tag

## Verification
- `npm run lint`
- `cargo check`