### PR TITLE
feat: token tracking, prompt template library, ConfigDrawer redesign (S4-T5a)

### DIFF
--- a/MVP_TASKS.md
+++ b/MVP_TASKS.md
@@ -1,22 +1,21 @@
 # Glossa — MVP Tasks
 
 > Roadmap attiva e priorità operative.
-> Aggiornata al 2026-04-26 dopo il merge della PR `#40` (S4-T4) e della PR `#41` (import `docx`/`pdf`) su `main`.
+> Aggiornata al 2026-04-27 dopo il merge della PR `#45` (S4-T4b document drawers) e della PR `#46` (bugfix SQLite lock, header refactor, settings persistence) su `main`.
 
 ---
 
 ## Valutazione oggettiva
 
-- Il repo non è più un wireframe fragile: lo Sprint 1 è chiuso, `S4-T1`, `S4-T2`, `S4-T3` e `S4-T4` risultano integrati su `main`.
-- Il frontend è in uno stato sano per continuare il refactor: `npm run lint`, `npm test` e `npm run build` sono verdi; i test Vitest passano (`56/56`) e i test Rust su `documents` (`5/5`).
-- Il workflow documento è ora il default operativo: autosave con stato esplicito, anteprima import multi-formato (`txt` / `md` / `docx` / `pdf`), split manuale del chunk e promozione esplicita da Sandbox a Documento sono tutti su `main`. Il pezzo residuo è la semplificazione profonda dei pannelli di `DocumentView` (drawer audit/indice, riordino superfici), tracciato come `S4-T4b`.
+- Il repo non è più un wireframe fragile: lo Sprint 1 è chiuso, `S4-T1` → `S4-T4b` sono tutti integrati su `main`.
+- Il frontend è in uno stato sano: `npm run lint`, `npm test` e `npm run build` sono verdi.
+- Il workflow documento è completo e stabile: autosave, import multi-formato, split manuale, drawer audit/indice a scomparsa con tab-handle, InsightsDrawer aperto di default, header riorganizzato con Config/Export/Strumenti separati. Il bug critico del lock SQLite (busy_timeout da 5s) è risolto con write serializer + WAL mode. La preferenza layout lettura è ora persistita globalmente in localStorage.
 - Priorità reale oggi:
-  1. chiudere `S4-T4b` (semplificazione `DocumentView` con drawer/pannelli a scomparsa) per consolidare la UX documento prima di aprire nuove superfici;
-  2. sopra quella base, aggiungere librerie riusabili e rifiniture UX (`S4-T5a`, `S4-T5b`, `S4-T6`);
-  3. prima della prima release pubblica, chiudere i blocker di stabilità, sicurezza e packaging (`S2-*`);
-  4. solo dopo, affrontare il refactor profondo di `llm.rs` e il resto della qualità interna (`S3-*`).
+  1. aggiungere librerie prompt riusabili (`S4-T5a`) o dizionari (`S4-T5b`), in base a cosa vale di più per l'utente esperto;
+  2. prima della prima release pubblica, chiudere i blocker di stabilità, sicurezza e packaging (`S2-*`);
+  3. solo dopo, affrontare il refactor profondo di `llm.rs` e il resto della qualità interna (`S3-*`).
 
-In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sprint 3. La risposta è chiudere `S4-T4b` (drawer audit/indice in `DocumentView`) prima di passare a `S4-T5`.
+In breve: il blocco UX core è chiuso. Si può scegliere se andare verso feature (S4-T5a/b) o verso release-readiness (S2-*).
 
 ---
 
@@ -48,6 +47,7 @@ In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sp
 - `S4-T2` rilancio per blocco e drill-down audit
 - `S4-T3` split degli store (`uiStore` / `pipelineStore` / `chunksStore`) e selettore Sandbox/Documento
 - `S4-T4` workflow documento, anteprima import multi-formato (`txt` / `md` / `docx` / `pdf`), split manuale del chunk e autosave con stato esplicito
+- `S4-T4b` semplificazione `DocumentView`: InsightsDrawer a scomparsa con tab-handle, ConfigDrawer separato, header riorganizzato; + bugfix SQLite lock contention e persistenza `documentLayout`
 
 ### Evidenze concrete nel codice
 
@@ -64,7 +64,7 @@ In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sp
 
 ### Sequenza consigliata
 
-1. `S4-T4b` — semplificazione `DocumentView` con drawer/pannelli a scomparsa
+1. ~~`S4-T4b`~~ — ✅ completata
 2. `S4-T5a` — libreria prompt
 3. `S4-T5b` — dizionari riusabili
 4. `S4-T6` — export combinato e polish UX
@@ -83,15 +83,15 @@ In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sp
 
 ### S4-T4b — Semplificazione `DocumentView` (drawer audit/indice)
 
-- **Stato**: `da fare`
-- **Priorità**: prima cosa del blocco UX core, prosegue il lavoro di `S4-T4`.
-- **Esito atteso**:
-  - testo al centro come superficie dominante;
-  - trace degli stage compatta, sempre visibile;
-  - indice chunk e audit nello stesso pannello laterale a scomparsa, non più sempre aperti nel flusso verticale;
-  - colonna `PipelineConfig` meno dominante quando si è in Documento.
-- **Accettazione**:
-  - in Documento il canvas centrale è il testo, mentre indice chunk e audit non occupano in modo fisso il canvas centrale.
+- **Stato**: `completata`
+- **Mergiata in**: PR `#45` (drawer audit/indice) + PR `#46` (bugfix e rifinitura header/settings).
+- **Cosa è dentro**:
+  - InsightsDrawer (audit + indice chunk) aperto di default, chiudibile, con tab-handle verticale per riaprirlo senza passare dall'header;
+  - ConfigDrawer (prompt pipeline) separato dall'header, accessibile tramite icona SlidersHorizontal solo in modalità Documento;
+  - header riorganizzato: cluster PROGETTO e STRUMENTI senza label, chip TXT/MD per l'export, pulsante Sandbox testuale nella seconda riga;
+  - bugfix critico SQLite: rimosso `BEGIN/COMMIT` manuale (rotto con il connection pool Tauri), introdotta coda JS `serializeWrite` + WAL mode + `busy_timeout=10000`;
+  - `documentLayout` persistito in `localStorage` tramite `zustand/middleware/persist` (sopravvive ai riavvii, indipendente dal progetto);
+  - layout lettura spostato dal header al pannello Impostazioni.
 
 ### S4-T5a — Libreria di modelli di prompt
 
@@ -208,6 +208,7 @@ In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sp
 - [x] `S4-T1` — Protezione dei blocchi completati (`190aa11`)
 - [x] `S4-T2` — Rilancio per blocco e drill-down audit (`572dd17`)
 - [x] `S4-T3` — Suddivisione store e selettore Sandbox/Documento
+- [x] `S4-T4b` — Semplificazione DocumentView: drawer a scomparsa, header refactor, bugfix SQLite, persistenza layout (PR `#45` + PR `#46`)
 
 ---
 
@@ -227,9 +228,9 @@ In breve: se la domanda è "cosa fare adesso?", la risposta non è Sprint 2 o Sp
 
 ## Decisione operativa
 
-Se il focus resta il refactor che stai gia implementando, il prossimo lavoro corretto e:
+Il blocco UX core (`S4-T4b`) è chiuso. Il prossimo step dipende dalla direzione che si vuole dare:
 
-1. chiudere i residui di `S4-T4` (import `docx`/`pdf` e drawer audit/indice)
-2. poi scegliere fra `S4-T5a` e `S4-T5b` in base a cosa vuoi rendere riusabile per primo
+- **Feature per l'utente esperto**: iniziare da `S4-T5a` (libreria prompt) che porta valore immediato al workflow di traduzione.
+- **Avvicinarsi a una release pubblica**: anticipare `S2-T4` (watchdog stream bloccato) e `S2-T5` (whitelist ensureColumn) che sono i due blocker funzionali più concreti.
 
-Se invece il focus cambia da "finire il refactor" a "spedire una prima release pubblica", allora dopo `S4-T4` vanno anticipati `S2-T4`, `S2-T5` e `S2-T2`.
+I dizionari (`S4-T5b`) e l'export avanzato (`S4-T6`) vengono dopo, dipendono dalla stabilità del flusso progetto.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "keyring",
  "log",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,7 @@ pub fn run() {
       llm::run_stage_stream,
       llm::cancel_stream,
       llm::judge_translation,
-      llm::optimize_prompt,
+      llm::refine_prompt,
       llm::save_api_key,
       llm::get_api_key_status,
       llm::delete_api_key,

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -66,6 +66,10 @@ pub struct JudgeResponse {
     pub rating: String,
     pub issues: Vec<JudgeIssue>,
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,6 +78,10 @@ struct StreamToken {
     stream_id: String,
     token: String,
     done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_tokens: Option<u32>,
 }
 
 // ── Stream cancellation registry ─────────────────────────────────────
@@ -521,6 +529,123 @@ async fn call_anthropic(
         .ok_or_else(|| "No text in Anthropic response".to_string())
 }
 
+/// Non-streaming call that also returns token usage for judge calls.
+async fn call_provider_for_judge(
+    client: &Client,
+    provider: &str,
+    model: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+    api_key: &str,
+) -> Result<(String, Option<(u32, u32)>), String> {
+    match provider {
+        "gemini" => {
+            let url = format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
+            );
+            let body = serde_json::json!({
+                "systemInstruction": { "parts": [{"text": system_prompt}] },
+                "contents": [{ "role": "user", "parts": [{"text": user_prompt}] }],
+                "generationConfig": { "responseMimeType": "application/json" }
+            });
+            let resp = client.post(&url).json(&body).send().await
+                .map_err(|e| format!("Gemini request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.map_err(|e| format!("Failed to read response: {e}"))?;
+            if !status.is_success() {
+                return Err(format_api_error("Gemini", status, &text));
+            }
+            let json: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("Failed to parse Gemini response: {e}"))?;
+            let content = json["candidates"][0]["content"]["parts"][0]["text"]
+                .as_str().map(|s| s.to_string())
+                .ok_or_else(|| "No text in Gemini response".to_string())?;
+            let usage = match (
+                json["usageMetadata"]["promptTokenCount"].as_u64(),
+                json["usageMetadata"]["candidatesTokenCount"].as_u64(),
+            ) {
+                (Some(i), Some(o)) => Some((i as u32, o as u32)),
+                _ => None,
+            };
+            Ok((content, usage))
+        }
+        "openai" | "deepseek" | "ollama" => {
+            let base_url = match provider {
+                "openai" => "https://api.openai.com/v1".to_string(),
+                "deepseek" => "https://api.deepseek.com".to_string(),
+                "ollama" => format!("{OLLAMA_BASE_URL}/v1"),
+                _ => unreachable!(),
+            };
+            let url = format!("{base_url}/chat/completions");
+            let body = serde_json::json!({
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt}
+                ],
+                "response_format": {"type": "json_object"}
+            });
+            let mut req = client.post(&url).json(&body);
+            if !api_key.is_empty() {
+                req = req.header("Authorization", format!("Bearer {api_key}"));
+            }
+            let resp = req.send().await.map_err(|e| format!("API request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.map_err(|e| format!("Failed to read response: {e}"))?;
+            if !status.is_success() {
+                return Err(format_api_error(provider_label_from_url(&base_url), status, &text));
+            }
+            let json: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("Failed to parse response: {e}"))?;
+            let content = json["choices"][0]["message"]["content"]
+                .as_str().map(|s| s.to_string())
+                .ok_or_else(|| "No content in response".to_string())?;
+            let usage = match (
+                json["usage"]["prompt_tokens"].as_u64(),
+                json["usage"]["completion_tokens"].as_u64(),
+            ) {
+                (Some(i), Some(o)) => Some((i as u32, o as u32)),
+                _ => None,
+            };
+            Ok((content, usage))
+        }
+        "anthropic" => {
+            let body = serde_json::json!({
+                "model": model,
+                "max_tokens": 4096,
+                "system": format!("{system_prompt}\nIMPORTANT: Return ONLY valid JSON."),
+                "messages": [{"role": "user", "content": user_prompt}]
+            });
+            let resp = client.post("https://api.anthropic.com/v1/messages")
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .json(&body)
+                .send().await
+                .map_err(|e| format!("Anthropic request failed: {e}"))?;
+            let status = resp.status();
+            let text = resp.text().await.map_err(|e| format!("Failed to read response: {e}"))?;
+            if !status.is_success() {
+                return Err(format_api_error("Anthropic", status, &text));
+            }
+            let json: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("Failed to parse Anthropic response: {e}"))?;
+            let content = json["content"][0]["text"]
+                .as_str().map(|s| s.to_string())
+                .ok_or_else(|| "No text in Anthropic response".to_string())?;
+            let usage = match (
+                json["usage"]["input_tokens"].as_u64(),
+                json["usage"]["output_tokens"].as_u64(),
+            ) {
+                (Some(i), Some(o)) => Some((i as u32, o as u32)),
+                _ => None,
+            };
+            Ok((content, usage))
+        }
+        _ => Err(format!("Unsupported provider for judge: {provider}")),
+    }
+}
+
 /// Route a non-streaming call to the correct provider
 async fn call_provider(
     client: &Client,
@@ -606,7 +731,8 @@ async fn build_streaming_request(
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
                 ],
-                "stream": true
+                "stream": true,
+                "stream_options": {"include_usage": true}
             });
             let mut req = client.post(&url).json(&body);
             if !api_key.is_empty() {
@@ -650,6 +776,10 @@ async fn stream_response(
 ) -> Result<String, String> {
     let mut full_text = String::new();
     let mut buffer = String::new();
+    let mut latest_input_tokens: Option<u32> = None;
+    let mut latest_output_tokens: Option<u32> = None;
+    // Anthropic splits usage across two events; track input separately.
+    let mut anthropic_input_tokens: Option<u32> = None;
 
     loop {
         if cancel.is_cancelled() {
@@ -682,7 +812,50 @@ async fn stream_response(
                                     stream_id: stream_id.to_string(),
                                     token: text,
                                     done: false,
+                                    input_tokens: None,
+                                    output_tokens: None,
                                 });
+                            }
+                        }
+
+                        // Extract token usage from this SSE chunk.
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                            match provider {
+                                "openai" | "deepseek" | "ollama" => {
+                                    // Final chunk with stream_options.include_usage = true
+                                    if let (Some(i), Some(o)) = (
+                                        json["usage"]["prompt_tokens"].as_u64(),
+                                        json["usage"]["completion_tokens"].as_u64(),
+                                    ) {
+                                        latest_input_tokens = Some(i as u32);
+                                        latest_output_tokens = Some(o as u32);
+                                    }
+                                }
+                                "gemini" => {
+                                    if let (Some(i), Some(o)) = (
+                                        json["usageMetadata"]["promptTokenCount"].as_u64(),
+                                        json["usageMetadata"]["candidatesTokenCount"].as_u64(),
+                                    ) {
+                                        latest_input_tokens = Some(i as u32);
+                                        latest_output_tokens = Some(o as u32);
+                                    }
+                                }
+                                "anthropic" => {
+                                    match json["type"].as_str() {
+                                        Some("message_start") => {
+                                            anthropic_input_tokens = json["message"]["usage"]["input_tokens"]
+                                                .as_u64().map(|n| n as u32);
+                                        }
+                                        Some("message_delta") => {
+                                            if let Some(out) = json["usage"]["output_tokens"].as_u64() {
+                                                latest_input_tokens = anthropic_input_tokens;
+                                                latest_output_tokens = Some(out as u32);
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -697,6 +870,8 @@ async fn stream_response(
         stream_id: stream_id.to_string(),
         token: String::new(),
         done: true,
+        input_tokens: latest_input_tokens,
+        output_tokens: latest_output_tokens,
     });
 
     Ok(full_text)
@@ -896,9 +1071,9 @@ pub async fn judge_translation(
     let client = build_http_client()?;
     let (system_prompt, user_prompt) = build_judge_prompts(&original_text, &translation, &config);
 
-    let result_text = call_provider(
+    let (result_text, usage) = call_provider_for_judge(
         &client, &config.judge_provider, &config.judge_model,
-        &system_prompt, &user_prompt, &api_key, true,
+        &system_prompt, &user_prompt, &api_key,
     ).await?;
 
     let parsed: serde_json::Value = serde_json::from_str(&result_text)
@@ -925,6 +1100,8 @@ pub async fn judge_translation(
         rating,
         issues,
         content: translation,
+        input_tokens: usage.map(|(i, _)| i),
+        output_tokens: usage.map(|(_, o)| o),
     })
 }
 
@@ -1238,10 +1415,31 @@ mod tests {
             stream_id: "s1".into(),
             token: "hi".into(),
             done: false,
+            input_tokens: None,
+            output_tokens: None,
         };
         let json = serde_json::to_string(&token).unwrap();
         assert!(json.contains("streamId"));
         assert!(!json.contains("stream_id"));
+        // Optional None fields must not appear in the serialized output.
+        assert!(!json.contains("inputTokens"));
+        assert!(!json.contains("outputTokens"));
+    }
+
+    #[test]
+    fn stream_token_with_usage_serializes_token_counts() {
+        let token = StreamToken {
+            stream_id: "s1".into(),
+            token: String::new(),
+            done: true,
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+        };
+        let json = serde_json::to_string(&token).unwrap();
+        assert!(json.contains("inputTokens"));
+        assert!(json.contains("outputTokens"));
+        assert!(json.contains("100"));
+        assert!(json.contains("50"));
     }
 
     #[test]

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -184,6 +184,28 @@ const OLLAMA_BASE_URL: &str = "http://localhost:11434";
 const HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
 const HTTP_REQUEST_TIMEOUT_SECS: u64 = 120;
 
+const REFINE_STAGE_SYSTEM_PROMPT: &str = "\
+You are an expert prompt engineer specializing in multi-stage AI translation pipelines.\n\
+Your task: rewrite the user's translation-stage prompt to be clearer, more professional, \
+and more effective for modern LLMs.\n\
+Rules:\n\
+- Preserve the original intent exactly — do not change what the stage is supposed to do\n\
+- Use direct, imperative language\n\
+- Be specific about register, tone, and quality expectations where relevant\n\
+- Remove filler words and vague instructions\n\
+- Output ONLY the rewritten prompt text — no preamble, no explanation, no quotes";
+
+const REFINE_AUDIT_SYSTEM_PROMPT: &str = "\
+You are an expert prompt engineer specializing in AI translation quality assessment.\n\
+Your task: rewrite the user's audit/judge prompt to be more precise, structured, and \
+effective for systematic quality evaluation.\n\
+Rules:\n\
+- Preserve the original evaluation intent — do not add criteria the user did not imply\n\
+- Make evaluation criteria explicit and measurable\n\
+- Reference relevant quality dimensions: accuracy, fluency, register, glossary adherence, grammar\n\
+- Use professional translation-industry QA terminology where appropriate\n\
+- Output ONLY the rewritten prompt text — no preamble, no explanation, no quotes";
+
 fn keyring_entry(provider: &str) -> Result<keyring::Entry, String> {
     let username = format!("{}_API_KEY", provider.to_uppercase());
     keyring::Entry::new(KEYRING_SERVICE, &username)
@@ -1106,21 +1128,22 @@ pub async fn judge_translation(
 }
 
 #[tauri::command]
-pub async fn optimize_prompt(
+pub async fn refine_prompt(
     app: AppHandle,
-    current_prompt: String,
+    prompt: String,
+    provider: String,
+    model: String,
+    context: String,
 ) -> Result<String, String> {
-    let api_key = get_api_key(&app, "gemini")?;
+    let api_key = get_api_key(&app, &provider)?;
     let client = build_http_client()?;
-
-    let user_prompt = format!(
-        "The user is using the following prompt for an AI-powered translation pipeline. \
-         Analyze the prompt and provide a more effective, professional, and detailed version.\n\n\
-         Current Prompt: \"{current_prompt}\"\n\n\
-         Provide only the improved prompt text."
-    );
-
-    call_gemini(&client, "gemini-3-flash-preview", "", &user_prompt, &api_key, false).await
+    let system_prompt = if context == "audit" {
+        REFINE_AUDIT_SYSTEM_PROMPT
+    } else {
+        REFINE_STAGE_SYSTEM_PROMPT
+    };
+    let user_prompt = format!("Rewrite this prompt professionally:\n\n{prompt}");
+    call_provider(&client, &provider, &model, system_prompt, &user_prompt, &api_key, false).await
 }
 
 #[tauri::command]

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -50,7 +50,7 @@ export function Drawer({
             animate={{ x: 0 }}
             exit={{ x: xOffscreen }}
             transition={{ type: 'spring', damping: 28, stiffness: 280 }}
-            className={`relative ${positionClass} flex h-full w-full ${maxWidth} flex-col bg-editorial-bg ${borderClass} border-editorial-border shadow-2xl sm:w-[440px] md:w-[520px]`}
+            className={`relative ${positionClass} flex h-full w-full ${maxWidth} flex-col bg-editorial-bg ${borderClass} border-editorial-border shadow-2xl`}
           >
             {children}
           </motion.aside>

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -8,6 +8,7 @@ interface DrawerProps {
   onClose: () => void;
   ariaLabelledBy: string;
   ariaDescribedBy?: string;
+  maxWidth?: string;
   children: ReactNode;
 }
 
@@ -17,6 +18,7 @@ export function Drawer({
   onClose,
   ariaLabelledBy,
   ariaDescribedBy,
+  maxWidth = 'max-w-[520px]',
   children,
 }: DrawerProps) {
   const trapRef = useFocusTrap(open, onClose);
@@ -48,7 +50,7 @@ export function Drawer({
             animate={{ x: 0 }}
             exit={{ x: xOffscreen }}
             transition={{ type: 'spring', damping: 28, stiffness: 280 }}
-            className={`relative ${positionClass} flex h-full w-full max-w-[520px] flex-col bg-editorial-bg ${borderClass} border-editorial-border shadow-2xl sm:w-[440px] md:w-[480px]`}
+            className={`relative ${positionClass} flex h-full w-full ${maxWidth} flex-col bg-editorial-bg ${borderClass} border-editorial-border shadow-2xl sm:w-[440px] md:w-[520px]`}
           >
             {children}
           </motion.aside>

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -26,6 +26,7 @@ export function ConfigDrawer({
       onClose={() => setShowConfigDrawer(false)}
       ariaLabelledBy="config-drawer-title"
       ariaDescribedBy="config-drawer-hint"
+      maxWidth="max-w-[560px]"
     >
       <div className="flex items-start justify-between gap-3 border-b border-editorial-border px-6 py-4">
         <div className="min-w-0">

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Drawer } from '../common';
 import { PipelineConfig } from '../pipeline/PipelineConfig';
+import type { ConfigSection } from '../pipeline/PipelineConfig';
 import { useUiStore } from '../../stores/uiStore';
 
 interface ConfigDrawerProps {
@@ -9,6 +11,12 @@ interface ConfigDrawerProps {
   onRunAuditOnly: () => void;
   onCancelPipeline: () => void;
 }
+
+const TABS: { id: ConfigSection; labelKey: string }[] = [
+  { id: 'stages',  labelKey: 'pipeline.tabStages'  },
+  { id: 'audit',   labelKey: 'pipeline.tabAudit'   },
+  { id: 'glossary', labelKey: 'pipeline.tabGlossary' },
+];
 
 export function ConfigDrawer({
   onRunPipeline,
@@ -18,6 +26,7 @@ export function ConfigDrawer({
   const { t } = useTranslation();
   const showConfigDrawer = useUiStore((state) => state.showConfigDrawer);
   const setShowConfigDrawer = useUiStore((state) => state.setShowConfigDrawer);
+  const [activeTab, setActiveTab] = useState<ConfigSection>('stages');
 
   return (
     <Drawer
@@ -26,10 +35,11 @@ export function ConfigDrawer({
       onClose={() => setShowConfigDrawer(false)}
       ariaLabelledBy="config-drawer-title"
       ariaDescribedBy="config-drawer-hint"
-      maxWidth="max-w-[560px]"
+      maxWidth="max-w-[680px]"
     >
-      <div className="flex items-start justify-between gap-3 border-b border-editorial-border px-6 py-4">
-        <div className="min-w-0">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3 border-b border-editorial-border px-6 pt-4 pb-0">
+        <div className="min-w-0 pb-0">
           <div className="text-[10px] font-bold uppercase tracking-[0.35em] text-editorial-muted">
             {t('document.configDrawerTitle')}
           </div>
@@ -45,21 +55,43 @@ export function ConfigDrawer({
           >
             {t('document.configDrawerHint')}
           </p>
+
+          {/* Tab bar */}
+          <div className="mt-4 flex gap-0" role="tablist">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`px-4 py-2 text-[11px] font-bold uppercase tracking-widest transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent border-b-2 ${
+                  activeTab === tab.id
+                    ? 'border-editorial-ink text-editorial-ink'
+                    : 'border-transparent text-editorial-muted hover:text-editorial-ink'
+                }`}
+              >
+                {t(tab.labelKey)}
+              </button>
+            ))}
+          </div>
         </div>
         <button
           type="button"
           onClick={() => setShowConfigDrawer(false)}
-          className="shrink-0 rounded-full border border-editorial-border p-2 text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          className="shrink-0 mt-1 rounded-full border border-editorial-border p-2 text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
           aria-label={t('header.closeDrawer')}
         >
           <X size={16} />
         </button>
       </div>
+
       <PipelineConfig
         onRunPipeline={onRunPipeline}
         onRunAuditOnly={onRunAuditOnly}
         onCancelPipeline={onCancelPipeline}
         showActions={false}
+        visibleSection={activeTab}
         className="flex flex-1 flex-col gap-8 overflow-y-auto bg-editorial-bg/40 p-6 custom-scrollbar"
       />
     </Drawer>

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -57,13 +57,15 @@ export function ConfigDrawer({
           </p>
 
           {/* Tab bar */}
-          <div className="mt-4 flex gap-0" role="tablist">
+          <div className="mt-4 flex gap-0" role="tablist" aria-label={t('document.configDrawerTitle')}>
             {TABS.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
+                id={`config-tab-${tab.id}`}
                 role="tab"
                 aria-selected={activeTab === tab.id}
+                aria-controls="config-tabpanel"
                 onClick={() => setActiveTab(tab.id)}
                 className={`px-4 py-2 text-[11px] font-bold uppercase tracking-widest transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent border-b-2 ${
                   activeTab === tab.id
@@ -86,14 +88,21 @@ export function ConfigDrawer({
         </button>
       </div>
 
-      <PipelineConfig
-        onRunPipeline={onRunPipeline}
-        onRunAuditOnly={onRunAuditOnly}
-        onCancelPipeline={onCancelPipeline}
-        showActions={false}
-        visibleSection={activeTab}
-        className="flex flex-1 flex-col gap-8 overflow-y-auto bg-editorial-bg/40 p-6 custom-scrollbar"
-      />
+      <div
+        id="config-tabpanel"
+        role="tabpanel"
+        aria-labelledby={`config-tab-${activeTab}`}
+        className="flex flex-1 flex-col min-h-0"
+      >
+        <PipelineConfig
+          onRunPipeline={onRunPipeline}
+          onRunAuditOnly={onRunAuditOnly}
+          onCancelPipeline={onCancelPipeline}
+          showActions={false}
+          visibleSection={activeTab}
+          className="flex flex-1 flex-col gap-8 overflow-y-auto bg-editorial-bg/40 p-6 custom-scrollbar"
+        />
+      </div>
     </Drawer>
   );
 }

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -9,7 +9,7 @@ interface HelpGuideProps {
   onClose: () => void;
 }
 
-type Section = 'overview' | 'pipeline' | 'streaming' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts';
+type Section = 'overview' | 'pipeline' | 'features' | 'streaming' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts';
 
 export function HelpGuide({ open, onClose }: HelpGuideProps) {
   const [activeSection, setActiveSection] = useState<Section>('overview');
@@ -17,15 +17,16 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
   const trapRef = useFocusTrap(open, onClose);
 
   const sections: { id: Section; label: string }[] = [
-    { id: 'overview', label: t('help.sections.overview') },
-    { id: 'pipeline', label: t('help.sections.pipeline') },
-    { id: 'streaming', label: t('help.sections.streaming') },
-    { id: 'audit', label: t('help.sections.audit') },
-    { id: 'projects', label: t('help.sections.projects') },
-    { id: 'providers', label: t('help.sections.providers') },
-    { id: 'ollama', label: t('help.sections.ollama') },
-    { id: 'glossary', label: t('help.sections.glossary') },
-    { id: 'shortcuts', label: t('help.sections.shortcuts') },
+    { id: 'overview',   label: t('help.sections.overview') },
+    { id: 'pipeline',   label: t('help.sections.pipeline') },
+    { id: 'features',   label: t('help.sections.features') },
+    { id: 'streaming',  label: t('help.sections.streaming') },
+    { id: 'audit',      label: t('help.sections.audit') },
+    { id: 'projects',   label: t('help.sections.projects') },
+    { id: 'providers',  label: t('help.sections.providers') },
+    { id: 'ollama',     label: t('help.sections.ollama') },
+    { id: 'glossary',   label: t('help.sections.glossary') },
+    { id: 'shortcuts',  label: t('help.sections.shortcuts') },
   ];
 
   return (
@@ -45,27 +46,32 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
             className="absolute inset-0 bg-editorial-ink/60 backdrop-blur-sm"
             onClick={onClose}
           />
+          {/* Fixed height so the modal never resizes when switching sections */}
           <motion.div
-            initial={{ scale: 0.95, opacity: 0 }}
+            initial={{ scale: 0.96, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.95, opacity: 0 }}
-            className="relative bg-editorial-bg w-full max-w-4xl max-h-[85vh] shadow-2xl border border-editorial-border flex overflow-hidden"
+            exit={{ scale: 0.96, opacity: 0 }}
+            className="relative bg-editorial-bg w-full max-w-4xl h-[85vh] shadow-2xl border border-editorial-border flex overflow-hidden"
           >
             {/* Sidebar */}
-            <nav className="w-56 shrink-0 border-r border-editorial-border bg-editorial-textbox/30 p-6 overflow-y-auto">
-              <h3 id="help-title" className="font-display text-xl italic tracking-tight mb-6">{t('help.title')}</h3>
-              <ul className="space-y-1">
+            <nav className="w-64 shrink-0 border-r border-editorial-border bg-editorial-textbox/30 flex flex-col overflow-hidden">
+              <div className="px-6 pt-6 pb-4 shrink-0 border-b border-editorial-border/60">
+                <h3 id="help-title" className="font-display text-2xl italic tracking-tight text-editorial-ink">
+                  {t('help.title')}
+                </h3>
+              </div>
+              <ul className="space-y-0.5 p-3 overflow-y-auto custom-scrollbar flex-1">
                 {sections.map((s) => (
                   <li key={s.id}>
                     <button
                       onClick={() => setActiveSection(s.id)}
-                      className={`w-full text-left px-3 py-2 text-[11px] font-bold uppercase tracking-wider transition-colors flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+                      className={`w-full text-left px-3 py-2.5 text-xs font-bold uppercase tracking-wider transition-colors flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent rounded ${
                         activeSection === s.id
                           ? 'bg-editorial-ink text-white'
-                          : 'text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50'
+                          : 'text-editorial-ink/60 hover:text-editorial-ink hover:bg-editorial-textbox/60'
                       }`}
                     >
-                      <ChevronRight size={10} className={activeSection === s.id ? 'opacity-100' : 'opacity-0'} />
+                      <ChevronRight size={11} className={activeSection === s.id ? 'opacity-100' : 'opacity-0'} />
                       {s.label}
                     </button>
                   </li>
@@ -73,25 +79,26 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
               </ul>
             </nav>
 
-            {/* Content */}
-            <div className="flex-1 overflow-y-auto p-10 custom-scrollbar">
+            {/* Content — fills remaining height and scrolls independently */}
+            <div className="flex-1 overflow-y-auto p-8 custom-scrollbar">
               <button
                 onClick={onClose}
-                className="absolute top-6 right-6 text-editorial-muted hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                aria-label={t('settings.saveClose')}
+                className="absolute top-5 right-5 text-editorial-ink/50 hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                aria-label={t('settings.close')}
               >
-                <X size={20} />
+                <X size={18} />
               </button>
 
-              <div className="max-w-none">
-                {activeSection === 'overview' && <OverviewSection />}
-                {activeSection === 'pipeline' && <PipelineSection />}
+              <div className="max-w-none pr-4">
+                {activeSection === 'overview'  && <OverviewSection />}
+                {activeSection === 'pipeline'  && <PipelineSection />}
+                {activeSection === 'features'  && <FeaturesSection />}
                 {activeSection === 'streaming' && <StreamingSection />}
-                {activeSection === 'audit' && <AuditSection />}
-                {activeSection === 'projects' && <ProjectsSection />}
+                {activeSection === 'audit'     && <AuditSection />}
+                {activeSection === 'projects'  && <ProjectsSection />}
                 {activeSection === 'providers' && <ProvidersSection />}
-                {activeSection === 'ollama' && <OllamaSection />}
-                {activeSection === 'glossary' && <GlossarySection />}
+                {activeSection === 'ollama'    && <OllamaSection />}
+                {activeSection === 'glossary'  && <GlossarySection />}
                 {activeSection === 'shortcuts' && <ShortcutsSection />}
               </div>
             </div>
@@ -105,28 +112,49 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
 // ── Shared UI ────────────────────────────────────────────────────────
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h2 className="font-display text-2xl italic tracking-tight mb-6 pb-2 border-b border-editorial-ink">{children}</h2>;
+  return (
+    <h2 className="font-display text-3xl italic tracking-tight mb-6 pb-3 border-b border-editorial-ink text-editorial-ink">
+      {children}
+    </h2>
+  );
 }
 
 function P({ children }: { children: React.ReactNode }) {
-  return <p className="text-sm leading-relaxed text-editorial-ink mb-4">{children}</p>;
+  return <p className="text-[13px] leading-relaxed text-editorial-ink/80 mb-4">{children}</p>;
+}
+
+function SubTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-display text-lg italic tracking-tight mt-8 mb-3 text-editorial-ink border-l-2 border-editorial-accent pl-3">
+      {children}
+    </h3>
+  );
 }
 
 function Step({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
   return (
     <div className="flex gap-4 mb-6">
-      <span className="font-display italic text-2xl text-editorial-accent leading-none mt-0.5">{n}</span>
+      <span className="font-display italic text-2xl text-editorial-accent leading-none mt-0.5 shrink-0">{n}</span>
       <div>
-        <h4 className="text-xs font-bold uppercase tracking-widest mb-1">{title}</h4>
-        <div className="text-sm text-editorial-muted leading-relaxed">{children}</div>
+        <h4 className="text-xs font-bold uppercase tracking-widest mb-1.5 text-editorial-ink">{title}</h4>
+        <div className="text-[13px] text-editorial-ink/70 leading-relaxed">{children}</div>
       </div>
+    </div>
+  );
+}
+
+function Tip({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-6 p-4 bg-editorial-textbox/30 border border-editorial-border">
+      <h4 className="text-[10px] font-bold uppercase tracking-widest text-editorial-accent mb-2">{title}</h4>
+      <p className="text-[13px] text-editorial-ink/70 leading-relaxed">{children}</p>
     </div>
   );
 }
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="px-1.5 py-0.5 bg-editorial-textbox border border-editorial-border text-[10px] font-mono rounded-sm">
+    <kbd className="inline-flex items-center justify-center min-w-[24px] px-2 py-0.5 bg-editorial-textbox border border-editorial-border text-xs font-mono rounded-sm text-editorial-ink">
       {children}
     </kbd>
   );
@@ -142,20 +170,20 @@ function OverviewSection() {
       <P>{t('help.overview.p1')}</P>
       <P>{t('help.overview.p2')}</P>
 
-      <div className="my-8 p-6 bg-editorial-textbox/30 border border-editorial-border font-mono text-[11px] leading-loose">
-        <div className="text-editorial-muted mb-2">{t('help.overview.flowTitle')}</div>
-        <div className="pl-4 border-l-2 border-editorial-accent space-y-1">
-          <div>📝 {t('help.overview.step1')}</div>
-          <div className="text-editorial-muted">↓</div>
-          <div>⚙️ {t('help.overview.step2')}</div>
-          <div className="text-editorial-muted">↓</div>
-          <div>✨ {t('help.overview.step3')}</div>
-          <div className="text-editorial-muted">↓</div>
-          <div>🔍 {t('help.overview.step4')}</div>
-          <div className="text-editorial-muted">↓</div>
-          <div>✏️ {t('help.overview.step5')}</div>
-          <div className="text-editorial-muted">↓</div>
-          <div>📤 {t('help.overview.step6')}</div>
+      <div className="my-8 p-6 bg-editorial-textbox/30 border border-editorial-border font-mono text-xs leading-loose">
+        <div className="text-editorial-ink/50 mb-3 uppercase tracking-widest text-[10px] font-bold">{t('help.overview.flowTitle')}</div>
+        <div className="pl-4 border-l-2 border-editorial-accent space-y-2">
+          <div className="text-editorial-ink">📝 {t('help.overview.step1')}</div>
+          <div className="text-editorial-ink/40">↓</div>
+          <div className="text-editorial-ink">⚙️ {t('help.overview.step2')}</div>
+          <div className="text-editorial-ink/40">↓</div>
+          <div className="text-editorial-ink">✨ {t('help.overview.step3')}</div>
+          <div className="text-editorial-ink/40">↓</div>
+          <div className="text-editorial-ink">🔍 {t('help.overview.step4')}</div>
+          <div className="text-editorial-ink/40">↓</div>
+          <div className="text-editorial-ink">✏️ {t('help.overview.step5')}</div>
+          <div className="text-editorial-ink/40">↓</div>
+          <div className="text-editorial-ink">📤 {t('help.overview.step6')}</div>
         </div>
       </div>
 
@@ -184,10 +212,35 @@ function PipelineSection() {
         {t('help.pipeline.editDesc')}
       </Step>
 
-      <div className="mt-6 p-4 bg-editorial-textbox/20 border border-editorial-border">
-        <h4 className="text-[10px] font-bold uppercase tracking-widest text-editorial-accent mb-2">{t('help.pipeline.tipTitle')}</h4>
-        <p className="text-xs text-editorial-muted leading-relaxed">{t('help.pipeline.tipDesc')}</p>
-      </div>
+      <Tip title={t('help.pipeline.tipTitle')}>{t('help.pipeline.tipDesc')}</Tip>
+    </>
+  );
+}
+
+function FeaturesSection() {
+  const { t } = useTranslation();
+  return (
+    <>
+      <SectionTitle>{t('help.features.title')}</SectionTitle>
+      <P>{t('help.features.intro')}</P>
+
+      <SubTitle>{t('help.features.configDrawerTitle')}</SubTitle>
+      <P>{t('help.features.configDrawerDesc')}</P>
+
+      <SubTitle>{t('help.features.templatesTitle')}</SubTitle>
+      <P>{t('help.features.templatesDesc')}</P>
+
+      <SubTitle>{t('help.features.refineTitle')}</SubTitle>
+      <P>{t('help.features.refineDesc')}</P>
+
+      <SubTitle>{t('help.features.tokenTitle')}</SubTitle>
+      <P>{t('help.features.tokenDesc')}</P>
+
+      <SubTitle>{t('help.features.sandboxTitle')}</SubTitle>
+      <P>{t('help.features.sandboxDesc')}</P>
+
+      <SubTitle>{t('help.features.exportTitle')}</SubTitle>
+      <P>{t('help.features.exportDesc')}</P>
     </>
   );
 }
@@ -211,15 +264,15 @@ function AuditSection() {
       <SectionTitle>{t('help.audit.title')}</SectionTitle>
       <P>{t('help.audit.intro')}</P>
 
-      <div className="space-y-4 my-6">
+      <div className="space-y-3 my-6">
         {(['glossary', 'accuracy', 'fluency', 'grammar'] as const).map((type) => (
           <div key={type} className="flex items-start gap-3 p-4 bg-editorial-textbox/20 border border-editorial-border">
-            <span className={`text-[9px] font-bold uppercase px-1.5 py-0.5 shrink-0 ${
+            <span className={`text-[10px] font-bold uppercase px-2 py-0.5 shrink-0 tracking-wider ${
               type === 'grammar' ? 'bg-editorial-accent text-white' : 'bg-editorial-ink text-white'
             }`}>
               {type}
             </span>
-            <span className="text-xs text-editorial-muted">{t(`help.audit.${type}Issue`)}</span>
+            <span className="text-[13px] text-editorial-ink/75">{t(`help.audit.${type}Issue`)}</span>
           </div>
         ))}
       </div>
@@ -257,20 +310,20 @@ function ProvidersSection() {
       <P>{t('help.providers.intro')}</P>
 
       <div className="overflow-x-auto my-6">
-        <table className="w-full text-xs border-collapse">
+        <table className="w-full text-[13px] border-collapse">
           <thead>
             <tr className="border-b-2 border-editorial-ink">
-              <th className="text-left py-2 pr-4 font-bold uppercase tracking-widest text-[9px]">{t('help.providers.provider')}</th>
-              <th className="text-left py-2 pr-4 font-bold uppercase tracking-widest text-[9px]">{t('help.providers.models')}</th>
-              <th className="text-left py-2 font-bold uppercase tracking-widest text-[9px]">{t('help.providers.notes')}</th>
+              <th className="text-left py-2.5 pr-4 font-bold uppercase tracking-widest text-[10px] text-editorial-ink">{t('help.providers.provider')}</th>
+              <th className="text-left py-2.5 pr-4 font-bold uppercase tracking-widest text-[10px] text-editorial-ink">{t('help.providers.models')}</th>
+              <th className="text-left py-2.5 font-bold uppercase tracking-widest text-[10px] text-editorial-ink">{t('help.providers.notes')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-editorial-border">
-            <tr><td className="py-2 pr-4 font-bold">Gemini</td><td className="py-2 pr-4 font-mono text-[10px]">gemini-3-flash, pro, lite</td><td className="py-2 text-editorial-muted">{t('help.providers.geminiNote')}</td></tr>
-            <tr><td className="py-2 pr-4 font-bold">OpenAI</td><td className="py-2 pr-4 font-mono text-[10px]">gpt-4o, gpt-4o-mini, o1</td><td className="py-2 text-editorial-muted">{t('help.providers.openaiNote')}</td></tr>
-            <tr><td className="py-2 pr-4 font-bold">Anthropic</td><td className="py-2 pr-4 font-mono text-[10px]">claude-3.5-sonnet, haiku</td><td className="py-2 text-editorial-muted">{t('help.providers.anthropicNote')}</td></tr>
-            <tr><td className="py-2 pr-4 font-bold">DeepSeek</td><td className="py-2 pr-4 font-mono text-[10px]">deepseek-chat, reasoner</td><td className="py-2 text-editorial-muted">{t('help.providers.deepseekNote')}</td></tr>
-            <tr><td className="py-2 pr-4 font-bold">Ollama</td><td className="py-2 pr-4 font-mono text-[10px]">{t('help.providers.ollamaModels')}</td><td className="py-2 text-editorial-muted">{t('help.providers.ollamaNote')}</td></tr>
+            <tr><td className="py-2.5 pr-4 font-bold text-editorial-ink">Gemini</td><td className="py-2.5 pr-4 font-mono text-xs text-editorial-ink/70">gemini-3-flash, pro, lite</td><td className="py-2.5 text-editorial-ink/70">{t('help.providers.geminiNote')}</td></tr>
+            <tr><td className="py-2.5 pr-4 font-bold text-editorial-ink">OpenAI</td><td className="py-2.5 pr-4 font-mono text-xs text-editorial-ink/70">gpt-4o, gpt-4o-mini, o1</td><td className="py-2.5 text-editorial-ink/70">{t('help.providers.openaiNote')}</td></tr>
+            <tr><td className="py-2.5 pr-4 font-bold text-editorial-ink">Anthropic</td><td className="py-2.5 pr-4 font-mono text-xs text-editorial-ink/70">claude-3.5-sonnet, haiku</td><td className="py-2.5 text-editorial-ink/70">{t('help.providers.anthropicNote')}</td></tr>
+            <tr><td className="py-2.5 pr-4 font-bold text-editorial-ink">DeepSeek</td><td className="py-2.5 pr-4 font-mono text-xs text-editorial-ink/70">deepseek-chat, reasoner</td><td className="py-2.5 text-editorial-ink/70">{t('help.providers.deepseekNote')}</td></tr>
+            <tr><td className="py-2.5 pr-4 font-bold text-editorial-ink">Ollama</td><td className="py-2.5 pr-4 font-mono text-xs text-editorial-ink/70">{t('help.providers.ollamaModels')}</td><td className="py-2.5 text-editorial-ink/70">{t('help.providers.ollamaNote')}</td></tr>
           </tbody>
         </table>
       </div>
@@ -289,19 +342,19 @@ function OllamaSection() {
 
       <Step n={1} title={t('help.ollama.installTitle')}>
         <span>{t('help.ollama.installDesc')}</span>
-        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-[11px] font-mono">
+        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-xs font-mono text-editorial-ink">
           curl -fsSL https://ollama.com/install.sh | sh
         </code>
       </Step>
       <Step n={2} title={t('help.ollama.pullTitle')}>
         <span>{t('help.ollama.pullDesc')}</span>
-        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-[11px] font-mono">
+        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-xs font-mono text-editorial-ink">
           ollama pull llama3.2
         </code>
       </Step>
       <Step n={3} title={t('help.ollama.serveTitle')}>
         <span>{t('help.ollama.serveDesc')}</span>
-        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-[11px] font-mono">
+        <code className="block mt-2 p-3 bg-editorial-textbox border border-editorial-border text-xs font-mono text-editorial-ink">
           ollama serve
         </code>
       </Step>
@@ -309,10 +362,7 @@ function OllamaSection() {
         {t('help.ollama.useDesc')}
       </Step>
 
-      <div className="mt-6 p-4 bg-editorial-textbox/20 border border-editorial-border">
-        <h4 className="text-[10px] font-bold uppercase tracking-widest text-editorial-accent mb-2">{t('help.ollama.recommendedTitle')}</h4>
-        <p className="text-xs text-editorial-muted leading-relaxed">{t('help.ollama.recommendedDesc')}</p>
-      </div>
+      <Tip title={t('help.ollama.recommendedTitle')}>{t('help.ollama.recommendedDesc')}</Tip>
     </>
   );
 }
@@ -331,29 +381,48 @@ function GlossarySection() {
 
 function ShortcutsSection() {
   const { t } = useTranslation();
+
+  const toolbarItems = [
+    { label: t('help.shortcuts.openSettings'),  icon: '⚙' },
+    { label: t('help.shortcuts.openProjects'),  icon: '📂' },
+    { label: t('help.shortcuts.importFile'),    icon: '⬆' },
+    { label: t('help.shortcuts.saveProject'),   icon: '💾' },
+    { label: t('help.shortcuts.openConfig'),    icon: '⚙' },
+    { label: t('help.shortcuts.openInsights'),  icon: '📊' },
+    { label: t('help.shortcuts.sandbox'),       icon: '⬜' },
+    { label: t('help.shortcuts.switchLang'),    icon: '🌐' },
+  ];
+
+  const exportItems = [
+    { label: t('help.shortcuts.exportTxt'), icon: '⬇' },
+    { label: t('help.shortcuts.exportMd'),  icon: 'MD' },
+  ];
+
+  const promptItems = [
+    { label: t('help.shortcuts.refineButton'),  icon: '✦' },
+    { label: t('help.shortcuts.saveTemplate'),  icon: '🔖' },
+    { label: t('help.shortcuts.loadTemplate'),  icon: '📖' },
+  ];
+
+  const renderRow = ({ label, icon }: { label: string; icon: string }) => (
+    <div key={label} className="flex items-center justify-between py-2.5 border-b border-editorial-border last:border-0">
+      <span className="text-[13px] text-editorial-ink/80">{label}</span>
+      <Kbd>{icon}</Kbd>
+    </div>
+  );
+
   return (
     <>
       <SectionTitle>{t('help.shortcuts.title')}</SectionTitle>
 
-      <div className="space-y-3 my-6">
-        {[
-          { label: t('help.shortcuts.openSettings'), icon: '⚙️' },
-          { label: t('help.shortcuts.switchLang'), icon: '🌐' },
-          { label: t('help.shortcuts.openProjects'), icon: '📂' },
-          { label: t('help.shortcuts.importFile'), icon: '⬆' },
-          { label: t('help.shortcuts.saveProject'), icon: '💾' },
-          { label: t('help.shortcuts.exportTxt'), icon: '⬇' },
-          { label: t('help.shortcuts.exportMd'), icon: 'MD' },
-        ].map(({ label, icon }) => (
-          <div key={label} className="flex items-center justify-between py-2 border-b border-editorial-border">
-            <span className="text-xs">{label}</span>
-            <span className="flex items-center gap-1.5">
-              <Kbd>{icon}</Kbd>
-              <span className="text-[9px] text-editorial-muted uppercase">{t('help.shortcuts.headerIcon')}</span>
-            </span>
-          </div>
-        ))}
-      </div>
+      <SubTitle>{t('help.shortcuts.toolbarTitle')}</SubTitle>
+      <div className="my-4">{toolbarItems.map(renderRow)}</div>
+
+      <SubTitle>{t('help.shortcuts.exportTitle')}</SubTitle>
+      <div className="my-4">{exportItems.map(renderRow)}</div>
+
+      <SubTitle>{t('help.shortcuts.promptToolsTitle')}</SubTitle>
+      <div className="my-4">{promptItems.map(renderRow)}</div>
     </>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import {
   FolderOpen,
   Globe,
   HelpCircle,
+  LayoutTemplate,
   Save,
   Settings,
   SlidersHorizontal,
@@ -80,7 +81,6 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
 
   const handleConfirmImport = () => {
     if (!pendingImport) return;
-
     setConfig((prev) => ({
       ...prev,
       useChunking: pendingImport.useChunking,
@@ -116,14 +116,14 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
   };
 
   const importLabel = t('files.import');
-  const exportTxtLabel = t('files.exportTxt');
-  const exportMdLabel = t('files.exportBilingual');
   const projectsLabel = t('projects.title');
   const saveLabel = t('projects.save');
   const langLabel = t('language.label');
   const settingsLabel = t('header.settings');
   const helpLabel = t('help.title');
   const openConfigLabel = t('header.openConfig');
+  const sandboxLabel = viewMode === 'sandbox' ? t('header.exitSandbox') : t('header.sandbox');
+
   const sourceWords = useMemo(
     () => chunks.reduce((acc, chunk) => acc + countWords(chunk.originalText), 0),
     [chunks],
@@ -179,6 +179,7 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
       }, 0),
     [chunks, config.stages, config.judgeProvider, config.judgeModel],
   );
+
   const saveStatusLabel =
     saveState === 'dirty'
       ? t('projects.statusDirty')
@@ -193,6 +194,8 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
   return (
     <header className="border-b border-editorial-border bg-[linear-gradient(180deg,#fffdf8_0%,#f8f3ea_100%)] px-6 py-5 md:px-10">
       <div className="flex flex-col gap-5">
+
+        {/* ── Riga 1: logo + azioni ── */}
         <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
           <div className="flex flex-wrap items-center gap-4">
             <div>
@@ -226,7 +229,7 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
           </div>
 
           <div className="flex flex-wrap items-center justify-end gap-2">
-            {/* Azioni progetto: senza etichetta, le icone parlano da sole */}
+            {/* Azioni progetto */}
             <ActionCluster>
               <div className="flex flex-wrap items-center gap-1">
                 <IconButton
@@ -263,29 +266,7 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
               </div>
             </ActionCluster>
 
-            {/* Esporta: visibile solo quando ci sono chunk */}
-            {chunks.length > 0 && (
-              <ActionCluster label={t('header.exportLabel')}>
-                <div className="flex items-center gap-1">
-                  <TextChipButton
-                    onClick={() => handleExport('txt')}
-                    title={exportTxtLabel}
-                    ariaLabel={exportTxtLabel}
-                  >
-                    TXT
-                  </TextChipButton>
-                  <TextChipButton
-                    onClick={() => handleExport('bilingual')}
-                    title={exportMdLabel}
-                    ariaLabel={exportMdLabel}
-                  >
-                    MD
-                  </TextChipButton>
-                </div>
-              </ActionCluster>
-            )}
-
-            {/* Strumenti: lingua/impostazioni/aiuto senza etichetta */}
+            {/* Strumenti + sandbox */}
             <ActionCluster>
               <div className="flex flex-wrap items-center gap-1">
                 <button
@@ -307,44 +288,56 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
                 <IconButton onClick={() => setShowHelp(true)} title={helpLabel} ariaLabel={helpLabel}>
                   <HelpCircle size={16} />
                 </IconButton>
+                <span className="mx-1 h-5 w-px bg-editorial-border/70" aria-hidden="true" />
+                <button
+                  type="button"
+                  onClick={() => setViewMode(viewMode === 'sandbox' ? 'document' : 'sandbox')}
+                  title={sandboxLabel}
+                  aria-label={sandboxLabel}
+                  aria-pressed={viewMode === 'sandbox'}
+                  className={`flex items-center gap-1.5 rounded-full border px-3 py-2 text-[10px] font-bold uppercase tracking-[0.22em] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+                    viewMode === 'sandbox'
+                      ? 'border-editorial-ink bg-editorial-ink text-white'
+                      : 'border-editorial-border text-editorial-muted hover:bg-editorial-textbox/50 hover:text-editorial-ink'
+                  }`}
+                >
+                  <LayoutTemplate size={13} />
+                  {sandboxLabel}
+                </button>
               </div>
             </ActionCluster>
-
           </div>
         </div>
 
-        <div className="flex flex-col gap-3 border-t border-editorial-border/60 pt-4 xl:flex-row xl:items-center xl:justify-between">
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setViewMode(viewMode === 'sandbox' ? 'document' : 'sandbox')}
-              className="rounded-full border border-editorial-border px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.22em] text-editorial-muted transition-colors hover:border-editorial-ink hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            >
-              {viewMode === 'sandbox' ? t('header.exitSandbox') : t('header.sandbox')}
-            </button>
-            {viewMode === 'document' && (
-              <HeaderInfoBar
-                sourceWords={sourceWords}
-                translatedWords={translatedWords}
-                completedCount={completedCount}
-                chunkCount={chunks.length}
-                compositeLabel={compositeLabel}
-                totalTokens={totalTokens}
-                estimatedCostUsd={estimatedCostUsd}
-              />
+        {/* ── Riga 2: riepilogo + pipeline (solo documento) ── */}
+        {viewMode === 'document' && (
+          <div className="flex flex-col gap-3 border-t border-editorial-border/60 pt-4 xl:flex-row xl:items-center xl:justify-between">
+            <HeaderInfoBar
+              sourceWords={sourceWords}
+              translatedWords={translatedWords}
+              completedCount={completedCount}
+              chunkCount={chunks.length}
+              compositeLabel={compositeLabel}
+              totalTokens={totalTokens}
+              estimatedCostUsd={estimatedCostUsd}
+              hasChunks={chunks.length > 0}
+              onExportTxt={() => handleExport('txt')}
+              onExportMd={() => handleExport('bilingual')}
+              exportTxtLabel={t('files.exportTxt')}
+              exportMdLabel={t('files.exportBilingual')}
+            />
+            {onRunPipeline && onRunAuditOnly && onCancelPipeline && (
+              <div className="flex flex-wrap items-center justify-end">
+                <PipelineActions
+                  onRunPipeline={onRunPipeline}
+                  onRunAuditOnly={onRunAuditOnly}
+                  onCancelPipeline={onCancelPipeline}
+                  variant="compact"
+                />
+              </div>
             )}
           </div>
-          {viewMode === 'document' && onRunPipeline && onRunAuditOnly && onCancelPipeline && (
-            <div className="flex flex-wrap items-center justify-end">
-              <PipelineActions
-                onRunPipeline={onRunPipeline}
-                onRunAuditOnly={onRunAuditOnly}
-                onCancelPipeline={onCancelPipeline}
-                variant="compact"
-              />
-            </div>
-          )}
-        </div>
+        )}
       </div>
 
       <HelpGuide open={showHelp} onClose={() => setShowHelp(false)} />
@@ -433,30 +426,6 @@ function IconButton({
   );
 }
 
-function TextChipButton({
-  onClick,
-  children,
-  title,
-  ariaLabel,
-}: {
-  onClick: () => void;
-  children: React.ReactNode;
-  title: string;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-label={ariaLabel}
-      className="rounded-full px-3 py-2 text-[9px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-    >
-      {children}
-    </button>
-  );
-}
-
 function HeaderInfoBar({
   sourceWords,
   translatedWords,
@@ -465,6 +434,11 @@ function HeaderInfoBar({
   compositeLabel,
   totalTokens,
   estimatedCostUsd,
+  hasChunks,
+  onExportTxt,
+  onExportMd,
+  exportTxtLabel,
+  exportMdLabel,
 }: {
   sourceWords: number;
   translatedWords: number;
@@ -473,6 +447,11 @@ function HeaderInfoBar({
   compositeLabel: string | null;
   totalTokens: number;
   estimatedCostUsd: number;
+  hasChunks: boolean;
+  onExportTxt: () => void;
+  onExportMd: () => void;
+  exportTxtLabel: string;
+  exportMdLabel: string;
 }) {
   const { t } = useTranslation();
 
@@ -502,20 +481,17 @@ function HeaderInfoBar({
     });
   }
 
-  if (totalTokens > 0) {
-    items.push({
-      key: 'tokens',
-      label: t('header.tokenCount'),
-      value: totalTokens.toLocaleString(),
-    });
-    if (estimatedCostUsd > 0) {
-      items.push({
-        key: 'cost',
-        label: t('header.estimatedCost'),
-        value: `$${estimatedCostUsd.toFixed(4)}`,
-      });
-    }
-  }
+  items.push({
+    key: 'tokens',
+    label: t('header.tokenCount'),
+    value: totalTokens > 0 ? totalTokens.toLocaleString() : '—',
+  });
+
+  items.push({
+    key: 'cost',
+    label: t('header.estimatedCost'),
+    value: totalTokens > 0 ? `$${estimatedCostUsd.toFixed(4)}` : '—',
+  });
 
   return (
     <dl className="flex flex-wrap items-center gap-2 rounded-full border border-editorial-border bg-editorial-bg px-2 py-1.5 shadow-sm">
@@ -530,6 +506,29 @@ function HeaderInfoBar({
           <dd className="font-display text-sm italic text-editorial-ink">{item.value}</dd>
         </div>
       ))}
+      {hasChunks && (
+        <>
+          <span className="mx-1 h-5 w-px bg-editorial-border/70" aria-hidden="true" />
+          <button
+            type="button"
+            onClick={onExportTxt}
+            title={exportTxtLabel}
+            aria-label={exportTxtLabel}
+            className="rounded-full px-3 py-1 text-[9px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          >
+            TXT
+          </button>
+          <button
+            type="button"
+            onClick={onExportMd}
+            title={exportMdLabel}
+            aria-label={exportMdLabel}
+            className="rounded-full px-3 py-1 text-[9px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          >
+            MD
+          </button>
+        </>
+      )}
     </dl>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -165,9 +165,19 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
               result.tokenUsage.outputTokens * pricing.output) /
             1_000_000;
         }
+        const judgeUsage = chunk.judgeResult.tokenUsage;
+        if (judgeUsage) {
+          const judgePricing = MODEL_PRICING[`${config.judgeProvider}/${config.judgeModel}`];
+          if (judgePricing) {
+            cost +=
+              (judgeUsage.inputTokens * judgePricing.input +
+                judgeUsage.outputTokens * judgePricing.output) /
+              1_000_000;
+          }
+        }
         return total + cost;
       }, 0),
-    [chunks, config.stages],
+    [chunks, config.stages, config.judgeProvider, config.judgeModel],
   );
   const saveStatusLabel =
     saveState === 'dirty'

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,6 +19,7 @@ import { PipelineActions } from '../pipeline';
 import { calculateCompositeQuality, qualityLabelKey } from '../../utils';
 import { importTextFile, exportTranslation, exportBilingual } from '../../services/fileService';
 import { HelpGuide } from '../help';
+import { MODEL_PRICING } from '../../constants';
 
 interface PendingImport {
   fileName: string;
@@ -134,6 +135,40 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
   const completedCount = chunks.filter((chunk) => chunk.status === 'completed').length;
   const compositeQuality = useMemo(() => calculateCompositeQuality(chunks), [chunks]);
   const compositeLabel = compositeQuality ? t(qualityLabelKey(compositeQuality)) : null;
+
+  const totalTokens = useMemo(
+    () =>
+      chunks.reduce((sum, chunk) => {
+        const stageSum = Object.values(chunk.stageResults).reduce(
+          (s, r) => s + (r.tokenUsage?.inputTokens ?? 0) + (r.tokenUsage?.outputTokens ?? 0),
+          0,
+        );
+        const judgeSum =
+          (chunk.judgeResult.tokenUsage?.inputTokens ?? 0) +
+          (chunk.judgeResult.tokenUsage?.outputTokens ?? 0);
+        return sum + stageSum + judgeSum;
+      }, 0),
+    [chunks],
+  );
+
+  const estimatedCostUsd = useMemo(
+    () =>
+      chunks.reduce((total, chunk) => {
+        let cost = 0;
+        for (const [stageId, result] of Object.entries(chunk.stageResults)) {
+          const stage = config.stages.find((s) => s.id === stageId);
+          if (!stage || !result.tokenUsage) continue;
+          const pricing = MODEL_PRICING[`${stage.provider}/${stage.model}`];
+          if (!pricing) continue;
+          cost +=
+            (result.tokenUsage.inputTokens * pricing.input +
+              result.tokenUsage.outputTokens * pricing.output) /
+            1_000_000;
+        }
+        return total + cost;
+      }, 0),
+    [chunks, config.stages],
+  );
   const saveStatusLabel =
     saveState === 'dirty'
       ? t('projects.statusDirty')
@@ -284,6 +319,8 @@ export function Header({ onRunPipeline, onRunAuditOnly, onCancelPipeline }: Head
                 completedCount={completedCount}
                 chunkCount={chunks.length}
                 compositeLabel={compositeLabel}
+                totalTokens={totalTokens}
+                estimatedCostUsd={estimatedCostUsd}
               />
             )}
           </div>
@@ -416,16 +453,20 @@ function HeaderInfoBar({
   completedCount,
   chunkCount,
   compositeLabel,
+  totalTokens,
+  estimatedCostUsd,
 }: {
   sourceWords: number;
   translatedWords: number;
   completedCount: number;
   chunkCount: number;
   compositeLabel: string | null;
+  totalTokens: number;
+  estimatedCostUsd: number;
 }) {
   const { t } = useTranslation();
 
-  const items = [
+  const items: { key: string; label: string; value: string }[] = [
     {
       key: 'source',
       label: t('document.infoSourceWords'),
@@ -449,6 +490,21 @@ function HeaderInfoBar({
       label: t('document.infoQuality'),
       value: compositeLabel,
     });
+  }
+
+  if (totalTokens > 0) {
+    items.push({
+      key: 'tokens',
+      label: t('header.tokenCount'),
+      value: totalTokens.toLocaleString(),
+    });
+    if (estimatedCostUsd > 0) {
+      items.push({
+        key: 'cost',
+        label: t('header.estimatedCost'),
+        value: `$${estimatedCostUsd.toFixed(4)}`,
+      });
+    }
   }
 
   return (

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -109,14 +109,14 @@ export function PipelineConfig({
 
   return (
     <section className={className ?? DEFAULT_PIPELINE_CONFIG_CLASSNAME}>
-      <div className="space-y-10">
+      <div className="space-y-8">
         {/* Language Pair */}
         <div>
-          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-8 inline-block">
+          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
             {t('pipeline.globalSetup')}
           </h2>
           <div className="space-y-4">
-            <label className="block text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
+            <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
               {t('pipeline.languagePair')}
             </label>
             <div className="flex items-center gap-3">
@@ -163,16 +163,18 @@ export function PipelineConfig({
                 onChange={(e) => setConfig((prev) => ({ ...prev, useChunking: e.target.checked }))}
                 className="accent-editorial-ink w-3 h-3"
               />
-              <span className="text-[10px] uppercase font-bold tracking-widest text-editorial-muted group-hover:text-editorial-ink transition-colors">
+              <span className="text-[11px] uppercase font-bold tracking-widest text-editorial-muted group-hover:text-editorial-ink transition-colors">
                 {t('pipeline.autoSegment')}
               </span>
             </label>
           </div>
         </div>
 
+        <hr className="border-editorial-border/60" />
+
         {/* Stages */}
         <div>
-          <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-8">
+          <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-6">
             <h2 className="font-display text-sm uppercase tracking-wider">{t('pipeline.stages')}</h2>
             <button
               onClick={addStage}
@@ -197,9 +199,11 @@ export function PipelineConfig({
           </div>
         </div>
 
+        <hr className="border-editorial-border/60" />
+
         {/* Audit Guard */}
         <div>
-          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-8 inline-block">
+          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
             {t('pipeline.auditGuard')}
           </h2>
           <div className="space-y-4">
@@ -207,7 +211,7 @@ export function PipelineConfig({
               <select
                 value={config.judgeProvider}
                 onChange={(e) => handleJudgeProviderChange(e.target.value as ModelProvider)}
-                className="bg-editorial-textbox border-none px-2 py-1 text-[10px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                className="bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {Object.keys(MODEL_OPTIONS).map((p) => (
                   <option key={p} value={p}>{p}</option>
@@ -217,7 +221,7 @@ export function PipelineConfig({
                 <select
                   value={config.judgeModel}
                   onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
-                  className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
                 >
                   {judgeModels.map((m) => (
                     <option key={m} value={m}>{m}</option>
@@ -228,13 +232,13 @@ export function PipelineConfig({
                   value={config.judgeModel}
                   onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
                   placeholder={t('ollama.modelPlaceholder')}
-                  className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
                 />
               ) : (
                 <select
                   value={config.judgeModel}
                   onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
-                  className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none"
+                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
                 >
                   {MODEL_OPTIONS[config.judgeProvider]?.map((m) => (
                     <option key={m} value={m}>{m}</option>
@@ -252,16 +256,18 @@ export function PipelineConfig({
               value={config.judgePrompt}
               onChange={(e) => setConfig((prev) => ({ ...prev, judgePrompt: e.target.value }))}
               placeholder={t('pipeline.auditPlaceholder')}
-              rows={6}
-              className="w-full bg-editorial-textbox border-none p-4 text-xs font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              rows={5}
+              className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
             />
           </div>
         </div>
 
+        <hr className="border-editorial-border/60" />
+
         {/* Glossary */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <label className="block text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
+            <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
               {t('pipeline.keywordRegistry')}
               {config.glossary.length > 0 && (
                 <span className="ml-2 text-editorial-muted/70 normal-case font-mono tracking-normal">
@@ -278,56 +284,75 @@ export function PipelineConfig({
               <Plus size={14} />
             </button>
           </div>
-          <div className="space-y-2">
-            {config.glossary.map((g, i) => {
-              const rowKey = g.id ?? `gloss-fallback-${i}`;
-              const isDuplicate = g.id ? duplicateTermIds.has(g.id) : false;
-              const removeLabel = `${t('pipeline.removeGlossaryEntry')} ${i + 1}`;
-              return (
-                <div key={rowKey} className="space-y-1">
-                  <div className="flex gap-2 items-center">
+
+          {config.glossary.length === 0 ? (
+            <p className="text-[11px] text-editorial-muted/60 text-center py-4 border border-dashed border-editorial-border/60 rounded-lg">
+              {t('pipeline.glossaryEmpty')}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {config.glossary.map((g, i) => {
+                const rowKey = g.id ?? `gloss-fallback-${i}`;
+                const isDuplicate = g.id ? duplicateTermIds.has(g.id) : false;
+                const removeLabel = `${t('pipeline.removeGlossaryEntry')} ${i + 1}`;
+                return (
+                  <div
+                    key={rowKey}
+                    className={`rounded-lg border p-2 space-y-1.5 ${
+                      isDuplicate
+                        ? 'border-editorial-warning/60 bg-editorial-textbox/20'
+                        : 'border-editorial-border/40 bg-editorial-textbox/20'
+                    }`}
+                  >
+                    <div className="flex gap-2 items-center">
+                      <input
+                        value={g.term}
+                        onChange={(e) =>
+                          g.id ? updateGlossaryEntry(g.id, { term: e.target.value }) : undefined
+                        }
+                        className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
+                        placeholder={t('pipeline.source')}
+                        aria-label={`${t('pipeline.source')} ${i + 1}`}
+                      />
+                      <input
+                        value={g.translation}
+                        onChange={(e) =>
+                          g.id
+                            ? updateGlossaryEntry(g.id, { translation: e.target.value })
+                            : undefined
+                        }
+                        className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
+                        placeholder={t('pipeline.target')}
+                        aria-label={`${t('pipeline.target')} ${i + 1}`}
+                      />
+                      <button
+                        onClick={() => g.id && removeGlossaryEntry(g.id)}
+                        title={removeLabel}
+                        className="ml-auto text-editorial-muted/60 hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent shrink-0 p-1"
+                        aria-label={removeLabel}
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
                     <input
-                      value={g.term}
+                      value={g.notes ?? ''}
                       onChange={(e) =>
-                        g.id
-                          ? updateGlossaryEntry(g.id, { term: e.target.value })
-                          : undefined
+                        g.id ? updateGlossaryEntry(g.id, { notes: e.target.value }) : undefined
                       }
-                      className={`w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
-                        isDuplicate ? 'ring-1 ring-editorial-warning' : ''
-                      }`}
-                      placeholder={t('pipeline.source')}
-                      aria-label={`${t('pipeline.source')} ${i + 1}`}
+                      className="w-full bg-transparent rounded py-1.5 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/30 focus:border-editorial-accent/60 text-editorial-muted placeholder:text-editorial-muted/40"
+                      placeholder={t('pipeline.glossaryNotes')}
+                      aria-label={`${t('pipeline.glossaryNotes')} ${i + 1}`}
                     />
-                    <button
-                      onClick={() => g.id && removeGlossaryEntry(g.id)}
-                      title={removeLabel}
-                      className="text-editorial-muted/60 hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent shrink-0 p-1"
-                      aria-label={removeLabel}
-                    >
-                      <X size={12} />
-                    </button>
-                    <input
-                      value={g.translation}
-                      onChange={(e) =>
-                        g.id
-                          ? updateGlossaryEntry(g.id, { translation: e.target.value })
-                          : undefined
-                      }
-                      className="w-full bg-editorial-textbox border-none p-2 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                      placeholder={t('pipeline.target')}
-                      aria-label={`${t('pipeline.target')} ${i + 1}`}
-                    />
+                    {isDuplicate && (
+                      <span className="text-[9px] uppercase tracking-widest text-editorial-warning font-bold pl-1">
+                        {t('pipeline.duplicateTerm')}
+                      </span>
+                    )}
                   </div>
-                  {isDuplicate && (
-                    <span className="text-[9px] uppercase tracking-widest text-editorial-warning font-bold pl-1">
-                      {t('pipeline.duplicateTerm')}
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -1,5 +1,5 @@
-import { Plus, ArrowRightLeft, Play, Loader2, X, AlertTriangle, RotateCcw } from 'lucide-react';
-import { useMemo } from 'react';
+import { Plus, ArrowRightLeft, Play, Loader2, X, AlertTriangle, RotateCcw, Wand2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { ModelProvider } from '../../types';
@@ -9,6 +9,7 @@ import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
 import { StageCard } from './StageCard';
+import { llmService } from '../../services/llmService';
 
 export type ConfigSection = 'stages' | 'audit' | 'glossary';
 
@@ -52,6 +53,7 @@ export function PipelineConfig({
   const ollamaStatus = useUiStore((state) => state.ollamaStatus);
   const { t } = useTranslation();
   const judgeModels = useJudgeModelOptions(config.judgeProvider);
+  const [isRefiningJudge, setIsRefiningJudge] = useState(false);
 
   const cannotRun = isProcessing || chunks.length === 0;
   const completedCount = chunks.filter((c) => c.status === 'completed').length;
@@ -98,6 +100,22 @@ export function PipelineConfig({
     }
     return dupes;
   }, [config.glossary]);
+
+  const handleRefineJudgePrompt = async () => {
+    if (!config.judgePrompt.trim()) return;
+    setIsRefiningJudge(true);
+    try {
+      const refined = await llmService.refinePrompt(config.judgePrompt, config.judgeProvider, config.judgeModel, 'audit');
+      setConfig((prev) => ({ ...prev, judgePrompt: refined }));
+      toast.success(t('pipeline.refined'));
+    } catch (err: unknown) {
+      toast.error(t('pipeline.refineFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsRefiningJudge(false);
+    }
+  };
 
   const handleJudgeProviderChange = (newProvider: ModelProvider) => {
     const models =
@@ -213,9 +231,21 @@ export function PipelineConfig({
         {/* ── Audit Guard ── */}
         {showAudit && (
           <div>
-            <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
-              {t('pipeline.auditGuard')}
-            </h2>
+            <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-6">
+              <h2 className="font-display text-sm uppercase tracking-wider">
+                {t('pipeline.auditGuard')}
+              </h2>
+              <button
+                type="button"
+                onClick={handleRefineJudgePrompt}
+                disabled={isRefiningJudge || !config.judgePrompt.trim()}
+                title={t('pipeline.refinePrompt')}
+                aria-label={t('pipeline.refinePrompt')}
+                className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
+              >
+                {isRefiningJudge ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+              </button>
+            </div>
             <div className="space-y-4">
               <div className="flex gap-2">
                 <select

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -1,5 +1,5 @@
-import { Plus, ArrowRightLeft, Play, Loader2, X, AlertTriangle, RotateCcw, Wand2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Plus, ArrowRightLeft, Play, Loader2, X, AlertTriangle, RotateCcw, Wand2, BookmarkPlus, BookOpen, Check, Trash2 } from 'lucide-react';
+import { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { ModelProvider } from '../../types';
@@ -10,6 +10,7 @@ import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
 import { StageCard } from './StageCard';
 import { llmService } from '../../services/llmService';
+import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 
 export type ConfigSection = 'stages' | 'audit' | 'glossary';
 
@@ -54,6 +55,12 @@ export function PipelineConfig({
   const { t } = useTranslation();
   const judgeModels = useJudgeModelOptions(config.judgeProvider);
   const [isRefiningJudge, setIsRefiningJudge] = useState(false);
+  const [showJudgeSaveName, setShowJudgeSaveName] = useState(false);
+  const [judgeTemplateName, setJudgeTemplateName] = useState('');
+  const [showJudgeTemplateList, setShowJudgeTemplateList] = useState(false);
+  const [judgeTemplateSearch, setJudgeTemplateSearch] = useState('');
+
+  const { templates, loadTemplates, saveTemplate, deleteTemplate } = usePromptTemplateStore();
 
   const cannotRun = isProcessing || chunks.length === 0;
   const completedCount = chunks.filter((c) => c.status === 'completed').length;
@@ -62,6 +69,29 @@ export function PipelineConfig({
   const showStages = !visibleSection || visibleSection === 'stages';
   const showAudit = !visibleSection || visibleSection === 'audit';
   const showGlossary = !visibleSection || visibleSection === 'glossary';
+
+  useEffect(() => {
+    if (showAudit) loadTemplates();
+  }, [showAudit]);
+
+  const auditTemplates = templates.filter((tmpl) => tmpl.context === 'audit');
+  const filteredJudgeTemplates = auditTemplates.filter((tmpl) =>
+    tmpl.name.toLowerCase().includes(judgeTemplateSearch.toLowerCase()),
+  );
+
+  const handleSaveJudgeTemplate = async () => {
+    const name = judgeTemplateName.trim();
+    if (!name) return;
+    await saveTemplate(name, config.judgePrompt, 'audit');
+    toast.success(t('pipeline.templates.saved'));
+    setJudgeTemplateName('');
+    setShowJudgeSaveName(false);
+  };
+
+  const handleDeleteJudgeTemplate = async (id: string) => {
+    await deleteTemplate(id);
+    toast.success(t('pipeline.templates.deleted'));
+  };
 
   const handleRerunAll = async () => {
     const ok = await confirm({
@@ -292,13 +322,120 @@ export function PipelineConfig({
                   <span>{t('ollama.selectedButOffline')}</span>
                 </div>
               )}
-              <textarea
-                value={config.judgePrompt}
-                onChange={(e) => setConfig((prev) => ({ ...prev, judgePrompt: e.target.value }))}
-                placeholder={t('pipeline.auditPlaceholder')}
-                rows={5}
-                className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              />
+
+              {/* Prompt label + template controls */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
+                    {t('pipeline.prompt')}
+                  </span>
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => { setShowJudgeSaveName(!showJudgeSaveName); setShowJudgeTemplateList(false); }}
+                      title={t('pipeline.templates.save')}
+                      aria-label={t('pipeline.templates.save')}
+                      className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                    >
+                      <BookmarkPlus size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setShowJudgeTemplateList(!showJudgeTemplateList); setShowJudgeSaveName(false); }}
+                      title={t('pipeline.templates.load')}
+                      aria-label={t('pipeline.templates.load')}
+                      className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                    >
+                      <BookOpen size={14} />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Inline save name input */}
+                {showJudgeSaveName && (
+                  <div className="flex items-center gap-1.5">
+                    <input
+                      value={judgeTemplateName}
+                      onChange={(e) => setJudgeTemplateName(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') handleSaveJudgeTemplate(); if (e.key === 'Escape') setShowJudgeSaveName(false); }}
+                      placeholder={t('pipeline.templates.namePlaceholder')}
+                      autoFocus
+                      className="flex-1 rounded bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleSaveJudgeTemplate}
+                      disabled={!judgeTemplateName.trim()}
+                      className="text-editorial-ink hover:text-editorial-accent transition-colors disabled:opacity-40 focus:outline-none"
+                      aria-label={t('common.confirm')}
+                    >
+                      <Check size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setShowJudgeSaveName(false); setJudgeTemplateName(''); }}
+                      className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
+                      aria-label={t('common.cancel')}
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                )}
+
+                {/* Template list popover */}
+                {showJudgeTemplateList && (
+                  <div className="rounded-lg border border-editorial-border bg-editorial-bg shadow-lg overflow-hidden">
+                    <div className="p-2 border-b border-editorial-border/60">
+                      <input
+                        value={judgeTemplateSearch}
+                        onChange={(e) => setJudgeTemplateSearch(e.target.value)}
+                        placeholder={t('pipeline.templates.searchPlaceholder')}
+                        autoFocus
+                        className="w-full rounded bg-editorial-textbox/60 border border-editorial-border/40 px-2 py-1 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                      />
+                    </div>
+                    <ul className="max-h-48 overflow-y-auto custom-scrollbar">
+                      {filteredJudgeTemplates.length === 0 ? (
+                        <li className="px-3 py-4 text-[10px] text-editorial-muted text-center">
+                          {t('pipeline.templates.empty')}
+                        </li>
+                      ) : (
+                        filteredJudgeTemplates.map((tmpl) => (
+                          <li
+                            key={tmpl.id}
+                            className="flex items-start gap-2 px-3 py-2 hover:bg-editorial-textbox/40 group"
+                          >
+                            <button
+                              type="button"
+                              onClick={() => { setConfig((prev) => ({ ...prev, judgePrompt: tmpl.prompt })); setShowJudgeTemplateList(false); setJudgeTemplateSearch(''); }}
+                              className="flex-1 text-left min-w-0 focus:outline-none"
+                            >
+                              <div className="text-[11px] font-bold text-editorial-ink truncate">{tmpl.name}</div>
+                              <div className="text-[10px] text-editorial-muted truncate mt-0.5 font-mono">{tmpl.prompt}</div>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteJudgeTemplate(tmpl.id)}
+                              className="shrink-0 text-editorial-muted/40 hover:text-editorial-accent transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none mt-0.5"
+                              aria-label={t('common.delete')}
+                            >
+                              <Trash2 size={12} />
+                            </button>
+                          </li>
+                        ))
+                      )}
+                    </ul>
+                  </div>
+                )}
+
+                <textarea
+                  value={config.judgePrompt}
+                  onChange={(e) => setConfig((prev) => ({ ...prev, judgePrompt: e.target.value }))}
+                  placeholder={t('pipeline.auditPlaceholder')}
+                  rows={5}
+                  className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                />
+              </div>
             </div>
           </div>
         )}

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -82,15 +82,27 @@ export function PipelineConfig({
   const handleSaveJudgeTemplate = async () => {
     const name = judgeTemplateName.trim();
     if (!name) return;
-    await saveTemplate(name, config.judgePrompt, 'audit');
-    toast.success(t('pipeline.templates.saved'));
-    setJudgeTemplateName('');
-    setShowJudgeSaveName(false);
+    try {
+      await saveTemplate(name, config.judgePrompt, 'audit');
+      toast.success(t('pipeline.templates.saved'));
+      setJudgeTemplateName('');
+      setShowJudgeSaveName(false);
+    } catch (err: unknown) {
+      toast.error(t('errors.somethingWentWrong'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   const handleDeleteJudgeTemplate = async (id: string) => {
-    await deleteTemplate(id);
-    toast.success(t('pipeline.templates.deleted'));
+    try {
+      await deleteTemplate(id);
+      toast.success(t('pipeline.templates.deleted'));
+    } catch (err: unknown) {
+      toast.error(t('errors.somethingWentWrong'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   const handleRerunAll = async () => {
@@ -268,7 +280,7 @@ export function PipelineConfig({
               <button
                 type="button"
                 onClick={handleRefineJudgePrompt}
-                disabled={isRefiningJudge || !config.judgePrompt.trim()}
+                disabled={isRefiningJudge || !config.judgePrompt.trim() || !config.judgeModel.trim()}
                 title={t('pipeline.refinePrompt')}
                 aria-label={t('pipeline.refinePrompt')}
                 className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -10,12 +10,15 @@ import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
 import { StageCard } from './StageCard';
 
+export type ConfigSection = 'stages' | 'audit' | 'glossary';
+
 interface PipelineConfigProps {
   onRunPipeline: () => void;
   onRunAuditOnly: () => void;
   onCancelPipeline: () => void;
   className?: string;
   showActions?: boolean;
+  visibleSection?: ConfigSection;
 }
 
 const DEFAULT_PIPELINE_CONFIG_CLASSNAME =
@@ -33,6 +36,7 @@ export function PipelineConfig({
   onCancelPipeline,
   className,
   showActions = true,
+  visibleSection,
 }: PipelineConfigProps) {
   const {
     config,
@@ -53,6 +57,10 @@ export function PipelineConfig({
   const completedCount = chunks.filter((c) => c.status === 'completed').length;
   const canRerunAll = !isProcessing && completedCount > 0;
 
+  const showStages = !visibleSection || visibleSection === 'stages';
+  const showAudit = !visibleSection || visibleSection === 'audit';
+  const showGlossary = !visibleSection || visibleSection === 'glossary';
+
   const handleRerunAll = async () => {
     const ok = await confirm({
       title: t('pipeline.confirmRerunAllTitle'),
@@ -64,15 +72,16 @@ export function PipelineConfig({
     resetCompletedChunks();
     onRunPipeline();
   };
+
   const runReason = isProcessing
     ? t('pipeline.runDisabledProcessing')
     : chunks.length === 0
       ? t('pipeline.runDisabledNoChunks')
       : undefined;
+
   const judgeOllamaOffline =
     config.judgeProvider === 'ollama' && ollamaStatus === 'disconnected';
 
-  // Trimmed-lowercase view for duplicate detection (warn but do not block).
   const duplicateTermIds = useMemo(() => {
     const seen = new Map<string, string>();
     const dupes = new Set<string>();
@@ -110,250 +119,253 @@ export function PipelineConfig({
   return (
     <section className={className ?? DEFAULT_PIPELINE_CONFIG_CLASSNAME}>
       <div className="space-y-8">
-        {/* Language Pair */}
-        <div>
-          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
-            {t('pipeline.globalSetup')}
-          </h2>
-          <div className="space-y-4">
-            <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
-              {t('pipeline.languagePair')}
-            </label>
-            <div className="flex items-center gap-3">
-              <select
-                value={config.sourceLanguage}
-                onChange={(e) => setConfig((prev) => ({ ...prev, sourceLanguage: e.target.value }))}
-                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-                aria-label={t('pipeline.sourceLanguage')}
-              >
-                {LANGUAGES.map((lang) => (
-                  <option key={lang} value={lang}>{lang}</option>
-                ))}
-              </select>
-              <button
-                onClick={() =>
-                  setConfig((prev) => ({
-                    ...prev,
-                    sourceLanguage: prev.targetLanguage,
-                    targetLanguage: prev.sourceLanguage,
-                  }))
-                }
-                title={t('pipeline.swapLanguages')}
-                className="text-editorial-muted hover:text-editorial-ink transition-colors hover:scale-110 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                aria-label={t('pipeline.swapLanguages')}
-              >
-                <ArrowRightLeft size={14} />
-              </button>
-              <select
-                value={config.targetLanguage}
-                onChange={(e) => setConfig((prev) => ({ ...prev, targetLanguage: e.target.value }))}
-                className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-                aria-label={t('pipeline.targetLanguage')}
-              >
-                {LANGUAGES.map((lang) => (
-                  <option key={lang} value={lang}>{lang}</option>
-                ))}
-              </select>
+
+        {/* ── Fasi: coppia linguistica + stages ── */}
+        {showStages && (
+          <>
+            <div>
+              <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
+                {t('pipeline.globalSetup')}
+              </h2>
+              <div className="space-y-4">
+                <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
+                  {t('pipeline.languagePair')}
+                </label>
+                <div className="flex items-center gap-3">
+                  <select
+                    value={config.sourceLanguage}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, sourceLanguage: e.target.value }))}
+                    className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
+                    aria-label={t('pipeline.sourceLanguage')}
+                  >
+                    {LANGUAGES.map((lang) => (
+                      <option key={lang} value={lang}>{lang}</option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() =>
+                      setConfig((prev) => ({
+                        ...prev,
+                        sourceLanguage: prev.targetLanguage,
+                        targetLanguage: prev.sourceLanguage,
+                      }))
+                    }
+                    title={t('pipeline.swapLanguages')}
+                    className="text-editorial-muted hover:text-editorial-ink transition-colors hover:scale-110 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    aria-label={t('pipeline.swapLanguages')}
+                  >
+                    <ArrowRightLeft size={14} />
+                  </button>
+                  <select
+                    value={config.targetLanguage}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, targetLanguage: e.target.value }))}
+                    className="w-full bg-editorial-textbox border-none px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
+                    aria-label={t('pipeline.targetLanguage')}
+                  >
+                    {LANGUAGES.map((lang) => (
+                      <option key={lang} value={lang}>{lang}</option>
+                    ))}
+                  </select>
+                </div>
+                <label className="flex items-center gap-2 mt-4 cursor-pointer w-max group">
+                  <input
+                    type="checkbox"
+                    checked={config.useChunking !== false}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, useChunking: e.target.checked }))}
+                    className="accent-editorial-ink w-3 h-3"
+                  />
+                  <span className="text-[11px] uppercase font-bold tracking-widest text-editorial-muted group-hover:text-editorial-ink transition-colors">
+                    {t('pipeline.autoSegment')}
+                  </span>
+                </label>
+              </div>
             </div>
 
-            <label className="flex items-center gap-2 mt-4 cursor-pointer w-max group">
-              <input
-                type="checkbox"
-                checked={config.useChunking !== false}
-                onChange={(e) => setConfig((prev) => ({ ...prev, useChunking: e.target.checked }))}
-                className="accent-editorial-ink w-3 h-3"
-              />
-              <span className="text-[11px] uppercase font-bold tracking-widest text-editorial-muted group-hover:text-editorial-ink transition-colors">
-                {t('pipeline.autoSegment')}
-              </span>
-            </label>
-          </div>
-        </div>
+            <hr className="border-editorial-border/60" />
 
-        <hr className="border-editorial-border/60" />
-
-        {/* Stages */}
-        <div>
-          <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-6">
-            <h2 className="font-display text-sm uppercase tracking-wider">{t('pipeline.stages')}</h2>
-            <button
-              onClick={addStage}
-              title={t('pipeline.addStage')}
-              className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('pipeline.addStage')}
-            >
-              <Plus size={18} />
-            </button>
-          </div>
-
-          <div className="space-y-6">
-            {config.stages.map((stage, idx) => (
-              <StageCard
-                key={stage.id}
-                stage={stage}
-                index={idx}
-                onUpdate={(u) => updateStage(stage.id, u)}
-                onRemove={() => removeStage(stage.id)}
-              />
-            ))}
-          </div>
-        </div>
-
-        <hr className="border-editorial-border/60" />
-
-        {/* Audit Guard */}
-        <div>
-          <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
-            {t('pipeline.auditGuard')}
-          </h2>
-          <div className="space-y-4">
-            <div className="flex gap-2">
-              <select
-                value={config.judgeProvider}
-                onChange={(e) => handleJudgeProviderChange(e.target.value as ModelProvider)}
-                className="bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              >
-                {Object.keys(MODEL_OPTIONS).map((p) => (
-                  <option key={p} value={p}>{p}</option>
+            <div>
+              <div className="flex items-center justify-between border-b border-editorial-ink pb-2 mb-6">
+                <h2 className="font-display text-sm uppercase tracking-wider">{t('pipeline.stages')}</h2>
+                <button
+                  onClick={addStage}
+                  title={t('pipeline.addStage')}
+                  className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  aria-label={t('pipeline.addStage')}
+                >
+                  <Plus size={18} />
+                </button>
+              </div>
+              <div className="space-y-6">
+                {config.stages.map((stage, idx) => (
+                  <StageCard
+                    key={stage.id}
+                    stage={stage}
+                    index={idx}
+                    onUpdate={(u) => updateStage(stage.id, u)}
+                    onRemove={() => removeStage(stage.id)}
+                  />
                 ))}
-              </select>
-              {judgeModels.length > 0 ? (
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Audit Guard ── */}
+        {showAudit && (
+          <div>
+            <h2 className="font-display text-sm uppercase tracking-wider border-b border-editorial-ink pb-2 mb-6 inline-block">
+              {t('pipeline.auditGuard')}
+            </h2>
+            <div className="space-y-4">
+              <div className="flex gap-2">
                 <select
-                  value={config.judgeModel}
-                  onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
-                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
+                  value={config.judgeProvider}
+                  onChange={(e) => handleJudgeProviderChange(e.target.value as ModelProvider)}
+                  className="bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                 >
-                  {judgeModels.map((m) => (
-                    <option key={m} value={m}>{m}</option>
+                  {Object.keys(MODEL_OPTIONS).map((p) => (
+                    <option key={p} value={p}>{p}</option>
                   ))}
                 </select>
-              ) : config.judgeProvider === 'ollama' ? (
-                <input
-                  value={config.judgeModel}
-                  onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
-                  placeholder={t('ollama.modelPlaceholder')}
-                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
-                />
-              ) : (
-                <select
-                  value={config.judgeModel}
-                  onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
-                  className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
-                >
-                  {MODEL_OPTIONS[config.judgeProvider]?.map((m) => (
-                    <option key={m} value={m}>{m}</option>
-                  ))}
-                </select>
+                {judgeModels.length > 0 ? (
+                  <select
+                    value={config.judgeModel}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
+                    className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
+                  >
+                    {judgeModels.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                ) : config.judgeProvider === 'ollama' ? (
+                  <input
+                    value={config.judgeModel}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
+                    placeholder={t('ollama.modelPlaceholder')}
+                    className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
+                  />
+                ) : (
+                  <select
+                    value={config.judgeModel}
+                    onChange={(e) => setConfig((prev) => ({ ...prev, judgeModel: e.target.value }))}
+                    className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
+                  >
+                    {MODEL_OPTIONS[config.judgeProvider]?.map((m) => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
+              {judgeOllamaOffline && (
+                <div className="flex items-center gap-2 text-[10px] text-editorial-accent">
+                  <AlertTriangle size={12} />
+                  <span>{t('ollama.selectedButOffline')}</span>
+                </div>
               )}
+              <textarea
+                value={config.judgePrompt}
+                onChange={(e) => setConfig((prev) => ({ ...prev, judgePrompt: e.target.value }))}
+                placeholder={t('pipeline.auditPlaceholder')}
+                rows={5}
+                className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              />
             </div>
-            {judgeOllamaOffline && (
-              <div className="flex items-center gap-2 text-[10px] text-editorial-accent">
-                <AlertTriangle size={12} />
-                <span>{t('ollama.selectedButOffline')}</span>
+          </div>
+        )}
+
+        {/* ── Glossary ── */}
+        {showGlossary && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
+                {t('pipeline.keywordRegistry')}
+                {config.glossary.length > 0 && (
+                  <span className="ml-2 text-editorial-muted/70 normal-case font-mono tracking-normal">
+                    ({config.glossary.length})
+                  </span>
+                )}
+              </label>
+              <button
+                onClick={addGlossaryEntry}
+                title={t('pipeline.addGlossaryEntry')}
+                className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                aria-label={t('pipeline.addGlossaryEntry')}
+              >
+                <Plus size={14} />
+              </button>
+            </div>
+
+            {config.glossary.length === 0 ? (
+              <p className="text-[11px] text-editorial-muted/60 text-center py-4 border border-dashed border-editorial-border/60 rounded-lg">
+                {t('pipeline.glossaryEmpty')}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {config.glossary.map((g, i) => {
+                  const rowKey = g.id ?? `gloss-fallback-${i}`;
+                  const isDuplicate = g.id ? duplicateTermIds.has(g.id) : false;
+                  const removeLabel = `${t('pipeline.removeGlossaryEntry')} ${i + 1}`;
+                  return (
+                    <div
+                      key={rowKey}
+                      className={`rounded-lg border p-2 space-y-1.5 ${
+                        isDuplicate
+                          ? 'border-editorial-warning/60 bg-editorial-textbox/20'
+                          : 'border-editorial-border/40 bg-editorial-textbox/20'
+                      }`}
+                    >
+                      <div className="flex gap-2 items-center">
+                        <input
+                          value={g.term}
+                          onChange={(e) =>
+                            g.id ? updateGlossaryEntry(g.id, { term: e.target.value }) : undefined
+                          }
+                          className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
+                          placeholder={t('pipeline.source')}
+                          aria-label={`${t('pipeline.source')} ${i + 1}`}
+                        />
+                        <input
+                          value={g.translation}
+                          onChange={(e) =>
+                            g.id
+                              ? updateGlossaryEntry(g.id, { translation: e.target.value })
+                              : undefined
+                          }
+                          className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
+                          placeholder={t('pipeline.target')}
+                          aria-label={`${t('pipeline.target')} ${i + 1}`}
+                        />
+                        <button
+                          onClick={() => g.id && removeGlossaryEntry(g.id)}
+                          title={removeLabel}
+                          className="ml-auto text-editorial-muted/60 hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent shrink-0 p-1"
+                          aria-label={removeLabel}
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                      <input
+                        value={g.notes ?? ''}
+                        onChange={(e) =>
+                          g.id ? updateGlossaryEntry(g.id, { notes: e.target.value }) : undefined
+                        }
+                        className="w-full bg-transparent rounded py-1.5 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/30 focus:border-editorial-accent/60 text-editorial-muted placeholder:text-editorial-muted/40"
+                        placeholder={t('pipeline.glossaryNotes')}
+                        aria-label={`${t('pipeline.glossaryNotes')} ${i + 1}`}
+                      />
+                      {isDuplicate && (
+                        <span className="text-[9px] uppercase tracking-widest text-editorial-warning font-bold pl-1">
+                          {t('pipeline.duplicateTerm')}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
-            <textarea
-              value={config.judgePrompt}
-              onChange={(e) => setConfig((prev) => ({ ...prev, judgePrompt: e.target.value }))}
-              placeholder={t('pipeline.auditPlaceholder')}
-              rows={5}
-              className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            />
           </div>
-        </div>
+        )}
 
-        <hr className="border-editorial-border/60" />
-
-        {/* Glossary */}
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <label className="block text-[11px] font-bold uppercase tracking-widest text-editorial-muted">
-              {t('pipeline.keywordRegistry')}
-              {config.glossary.length > 0 && (
-                <span className="ml-2 text-editorial-muted/70 normal-case font-mono tracking-normal">
-                  ({config.glossary.length})
-                </span>
-              )}
-            </label>
-            <button
-              onClick={addGlossaryEntry}
-              title={t('pipeline.addGlossaryEntry')}
-              className="text-editorial-accent hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('pipeline.addGlossaryEntry')}
-            >
-              <Plus size={14} />
-            </button>
-          </div>
-
-          {config.glossary.length === 0 ? (
-            <p className="text-[11px] text-editorial-muted/60 text-center py-4 border border-dashed border-editorial-border/60 rounded-lg">
-              {t('pipeline.glossaryEmpty')}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {config.glossary.map((g, i) => {
-                const rowKey = g.id ?? `gloss-fallback-${i}`;
-                const isDuplicate = g.id ? duplicateTermIds.has(g.id) : false;
-                const removeLabel = `${t('pipeline.removeGlossaryEntry')} ${i + 1}`;
-                return (
-                  <div
-                    key={rowKey}
-                    className={`rounded-lg border p-2 space-y-1.5 ${
-                      isDuplicate
-                        ? 'border-editorial-warning/60 bg-editorial-textbox/20'
-                        : 'border-editorial-border/40 bg-editorial-textbox/20'
-                    }`}
-                  >
-                    <div className="flex gap-2 items-center">
-                      <input
-                        value={g.term}
-                        onChange={(e) =>
-                          g.id ? updateGlossaryEntry(g.id, { term: e.target.value }) : undefined
-                        }
-                        className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
-                        placeholder={t('pipeline.source')}
-                        aria-label={`${t('pipeline.source')} ${i + 1}`}
-                      />
-                      <input
-                        value={g.translation}
-                        onChange={(e) =>
-                          g.id
-                            ? updateGlossaryEntry(g.id, { translation: e.target.value })
-                            : undefined
-                        }
-                        className="w-full bg-transparent rounded py-2 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/40 focus:border-editorial-accent/60"
-                        placeholder={t('pipeline.target')}
-                        aria-label={`${t('pipeline.target')} ${i + 1}`}
-                      />
-                      <button
-                        onClick={() => g.id && removeGlossaryEntry(g.id)}
-                        title={removeLabel}
-                        className="ml-auto text-editorial-muted/60 hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent shrink-0 p-1"
-                        aria-label={removeLabel}
-                      >
-                        <X size={12} />
-                      </button>
-                    </div>
-                    <input
-                      value={g.notes ?? ''}
-                      onChange={(e) =>
-                        g.id ? updateGlossaryEntry(g.id, { notes: e.target.value }) : undefined
-                      }
-                      className="w-full bg-transparent rounded py-1.5 px-2 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent border border-editorial-border/30 focus:border-editorial-accent/60 text-editorial-muted placeholder:text-editorial-muted/40"
-                      placeholder={t('pipeline.glossaryNotes')}
-                      aria-label={`${t('pipeline.glossaryNotes')} ${i + 1}`}
-                    />
-                    {isDuplicate && (
-                      <span className="text-[9px] uppercase tracking-widest text-editorial-warning font-bold pl-1">
-                        {t('pipeline.duplicateTerm')}
-                      </span>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
       </div>
 
       {showActions && (

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -87,7 +87,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
   const handleSaveTemplate = async () => {
     const name = templateName.trim();
     if (!name) return;
-    await saveTemplate(name, stage.prompt);
+    await saveTemplate(name, stage.prompt, 'stage');
     toast.success(t('pipeline.templates.saved'));
     setTemplateName('');
     setShowSaveName(false);
@@ -114,7 +114,8 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
     }
   };
 
-  const filteredTemplates = templates.filter((tmpl) =>
+  const stageTemplates = templates.filter((tmpl) => tmpl.context === 'stage');
+  const filteredTemplates = stageTemplates.filter((tmpl) =>
     tmpl.name.toLowerCase().includes(templateSearch.toLowerCase()),
   );
 

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -4,11 +4,13 @@ import {
   BookOpen,
   ChevronUp,
   ChevronDown,
+  Loader2,
   Trash2,
   ShieldCheck,
   AlertTriangle,
   Check,
   X,
+  Wand2,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -17,6 +19,7 @@ import { MODEL_OPTIONS } from '../../constants';
 import { useUiStore } from '../../stores/uiStore';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { confirm } from '../../stores/confirmStore';
+import { llmService } from '../../services/llmService';
 
 interface StageCardProps {
   stage: PipelineStageConfig;
@@ -37,6 +40,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
   const [templateName, setTemplateName] = useState('');
   const [showTemplateList, setShowTemplateList] = useState(false);
   const [templateSearch, setTemplateSearch] = useState('');
+  const [isRefining, setIsRefining] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { t } = useTranslation();
   const modelOptions = useModelOptions(stage.provider);
@@ -92,6 +96,22 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
   const handleDeleteTemplate = async (id: string) => {
     await deleteTemplate(id);
     toast.success(t('pipeline.templates.deleted'));
+  };
+
+  const handleRefinePrompt = async () => {
+    if (!stage.prompt.trim()) return;
+    setIsRefining(true);
+    try {
+      const refined = await llmService.refinePrompt(stage.prompt, stage.provider, stage.model, 'stage');
+      onUpdate({ prompt: refined });
+      toast.success(t('pipeline.refined'));
+    } catch (err: unknown) {
+      toast.error(t('pipeline.refineFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsRefining(false);
+    }
   };
 
   const filteredTemplates = templates.filter((tmpl) =>
@@ -206,6 +226,17 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 {t('pipeline.prompt')}
               </span>
               <div className="flex items-center gap-1.5">
+                {/* Refine prompt */}
+                <button
+                  type="button"
+                  onClick={handleRefinePrompt}
+                  disabled={isRefining || !stage.prompt.trim()}
+                  title={t('pipeline.refinePrompt')}
+                  aria-label={t('pipeline.refinePrompt')}
+                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
+                >
+                  {isRefining ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+                </button>
                 {/* Save as template */}
                 <button
                   type="button"

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -203,7 +203,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
-                Prompt
+                {t('pipeline.prompt')}
               </span>
               <div className="flex items-center gap-1.5">
                 {/* Save as template */}

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -1,10 +1,21 @@
-import { useState } from 'react';
-import { ChevronUp, ChevronDown, Trash2, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import {
+  BookmarkPlus,
+  BookOpen,
+  ChevronUp,
+  ChevronDown,
+  Trash2,
+  ShieldCheck,
+  AlertTriangle,
+  Check,
+  X,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { PipelineStageConfig, ModelProvider } from '../../types';
 import { MODEL_OPTIONS } from '../../constants';
 import { useUiStore } from '../../stores/uiStore';
+import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { confirm } from '../../stores/confirmStore';
 
 interface StageCardProps {
@@ -22,21 +33,36 @@ function useModelOptions(provider: ModelProvider): string[] {
 
 export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showSaveName, setShowSaveName] = useState(false);
+  const [templateName, setTemplateName] = useState('');
+  const [showTemplateList, setShowTemplateList] = useState(false);
+  const [templateSearch, setTemplateSearch] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { t } = useTranslation();
   const modelOptions = useModelOptions(stage.provider);
   const ollamaStatus = useUiStore((s) => s.ollamaStatus);
   const showOllamaOfflineWarning =
     stage.provider === 'ollama' && ollamaStatus === 'disconnected';
 
+  const { templates, loadTemplates, saveTemplate, deleteTemplate } = usePromptTemplateStore();
+
+  useEffect(() => {
+    if (isExpanded) loadTemplates();
+  }, [isExpanded]);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [stage.prompt]);
+
   const handleProviderChange = (newProvider: ModelProvider) => {
     const models =
       newProvider === 'ollama'
         ? useUiStore.getState().ollamaModels
         : MODEL_OPTIONS[newProvider];
-    onUpdate({
-      provider: newProvider,
-      model: models[0] || '',
-    });
+    onUpdate({ provider: newProvider, model: models[0] || '' });
     if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'unknown') {
       toast.message(t('ollama.uncheckedHint'));
     } else if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'disconnected') {
@@ -54,15 +80,35 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
     if (ok) onRemove();
   };
 
+  const handleSaveTemplate = async () => {
+    const name = templateName.trim();
+    if (!name) return;
+    await saveTemplate(name, stage.prompt);
+    toast.success(t('pipeline.templates.saved'));
+    setTemplateName('');
+    setShowSaveName(false);
+  };
+
+  const handleDeleteTemplate = async (id: string) => {
+    await deleteTemplate(id);
+    toast.success(t('pipeline.templates.deleted'));
+  };
+
+  const filteredTemplates = templates.filter((tmpl) =>
+    tmpl.name.toLowerCase().includes(templateSearch.toLowerCase()),
+  );
+
   return (
     <div
-      className={`relative border border-editorial-border p-5 bg-editorial-bg transition-all ${
+      className={`relative rounded-lg border border-editorial-border bg-editorial-bg p-5 pb-6 transition-all ${
         !stage.enabled ? 'grayscale opacity-40' : 'shadow-sm'
       }`}
     >
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
-          <span className="font-display italic text-lg text-editorial-accent">#{index + 1}</span>
+          <span className="rounded-full bg-editorial-textbox/60 px-2 py-0.5 text-[10px] font-display italic text-editorial-accent">
+            #{index + 1}
+          </span>
           <input
             value={stage.name}
             onChange={(e) => onUpdate({ name: e.target.value })}
@@ -110,24 +156,20 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
             <select
               value={stage.provider}
               onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
-              className="bg-editorial-textbox border-none px-2 py-1 text-[10px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              className="bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
             >
               {Object.keys(MODEL_OPTIONS).map((p) => (
-                <option key={p} value={p}>
-                  {p}
-                </option>
+                <option key={p} value={p}>{p}</option>
               ))}
             </select>
             {modelOptions.length > 0 ? (
               <select
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {modelOptions.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
+                  <option key={m} value={m}>{m}</option>
                 ))}
               </select>
             ) : stage.provider === 'ollama' ? (
@@ -135,35 +177,144 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
                 placeholder={t('ollama.modelPlaceholder')}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               />
             ) : (
               <select
                 value={stage.model}
                 onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox border-none px-2 py-1 text-[10px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {MODEL_OPTIONS[stage.provider]?.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
+                  <option key={m} value={m}>{m}</option>
                 ))}
               </select>
             )}
           </div>
+
           {showOllamaOfflineWarning && (
             <div className="flex items-center gap-2 text-[10px] text-editorial-accent">
               <AlertTriangle size={12} />
               <span>{t('ollama.selectedButOffline')}</span>
             </div>
           )}
-          <textarea
-            value={stage.prompt}
-            onChange={(e) => onUpdate({ prompt: e.target.value })}
-            placeholder={t('pipeline.stagePromptPlaceholder')}
-            rows={6}
-            className="w-full bg-editorial-textbox border-none p-3 text-[11px] font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
-          />
+
+          {/* Prompt textarea with template controls */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-editorial-muted">
+                Prompt
+              </span>
+              <div className="flex items-center gap-1.5">
+                {/* Save as template */}
+                <button
+                  type="button"
+                  onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
+                  title={t('pipeline.templates.save')}
+                  aria-label={t('pipeline.templates.save')}
+                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                >
+                  <BookmarkPlus size={14} />
+                </button>
+                {/* Load template */}
+                <button
+                  type="button"
+                  onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
+                  title={t('pipeline.templates.load')}
+                  aria-label={t('pipeline.templates.load')}
+                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                >
+                  <BookOpen size={14} />
+                </button>
+              </div>
+            </div>
+
+            {/* Inline save name input */}
+            {showSaveName && (
+              <div className="flex items-center gap-1.5">
+                <input
+                  value={templateName}
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSaveTemplate(); if (e.key === 'Escape') setShowSaveName(false); }}
+                  placeholder={t('pipeline.templates.namePlaceholder')}
+                  autoFocus
+                  className="flex-1 rounded bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                />
+                <button
+                  type="button"
+                  onClick={handleSaveTemplate}
+                  disabled={!templateName.trim()}
+                  className="text-editorial-ink hover:text-editorial-accent transition-colors disabled:opacity-40 focus:outline-none"
+                  aria-label={t('common.confirm')}
+                >
+                  <Check size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowSaveName(false); setTemplateName(''); }}
+                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
+                  aria-label={t('common.cancel')}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            )}
+
+            {/* Template list popover */}
+            {showTemplateList && (
+              <div className="rounded-lg border border-editorial-border bg-editorial-bg shadow-lg overflow-hidden">
+                <div className="p-2 border-b border-editorial-border/60">
+                  <input
+                    value={templateSearch}
+                    onChange={(e) => setTemplateSearch(e.target.value)}
+                    placeholder={t('pipeline.templates.searchPlaceholder')}
+                    autoFocus
+                    className="w-full rounded bg-editorial-textbox/60 border border-editorial-border/40 px-2 py-1 text-[11px] font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                  />
+                </div>
+                <ul className="max-h-48 overflow-y-auto custom-scrollbar">
+                  {filteredTemplates.length === 0 ? (
+                    <li className="px-3 py-4 text-[10px] text-editorial-muted text-center">
+                      {t('pipeline.templates.empty')}
+                    </li>
+                  ) : (
+                    filteredTemplates.map((tmpl) => (
+                      <li
+                        key={tmpl.id}
+                        className="flex items-start gap-2 px-3 py-2 hover:bg-editorial-textbox/40 group"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => { onUpdate({ prompt: tmpl.prompt }); setShowTemplateList(false); setTemplateSearch(''); }}
+                          className="flex-1 text-left min-w-0 focus:outline-none"
+                        >
+                          <div className="text-[11px] font-bold text-editorial-ink truncate">{tmpl.name}</div>
+                          <div className="text-[10px] text-editorial-muted truncate mt-0.5 font-mono">{tmpl.prompt}</div>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteTemplate(tmpl.id)}
+                          className="shrink-0 text-editorial-muted/40 hover:text-editorial-accent transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none mt-0.5"
+                          aria-label={t('common.delete')}
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </div>
+            )}
+
+            <textarea
+              ref={textareaRef}
+              value={stage.prompt}
+              onChange={(e) => onUpdate({ prompt: e.target.value })}
+              placeholder={t('pipeline.stagePromptPlaceholder')}
+              rows={4}
+              className="w-full rounded-lg bg-editorial-textbox/40 border border-editorial-border/60 p-3 text-[12px] font-mono outline-none leading-relaxed resize-none overflow-hidden focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -87,19 +87,31 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
   const handleSaveTemplate = async () => {
     const name = templateName.trim();
     if (!name) return;
-    await saveTemplate(name, stage.prompt, 'stage');
-    toast.success(t('pipeline.templates.saved'));
-    setTemplateName('');
-    setShowSaveName(false);
+    try {
+      await saveTemplate(name, stage.prompt, 'stage');
+      toast.success(t('pipeline.templates.saved'));
+      setTemplateName('');
+      setShowSaveName(false);
+    } catch (err: unknown) {
+      toast.error(t('pipeline.templates.saved'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   const handleDeleteTemplate = async (id: string) => {
-    await deleteTemplate(id);
-    toast.success(t('pipeline.templates.deleted'));
+    try {
+      await deleteTemplate(id);
+      toast.success(t('pipeline.templates.deleted'));
+    } catch (err: unknown) {
+      toast.error(t('errors.somethingWentWrong'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   const handleRefinePrompt = async () => {
-    if (!stage.prompt.trim()) return;
+    if (!stage.prompt.trim() || !stage.model.trim()) return;
     setIsRefining(true);
     try {
       const refined = await llmService.refinePrompt(stage.prompt, stage.provider, stage.model, 'stage');
@@ -231,7 +243,7 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 <button
                   type="button"
                   onClick={handleRefinePrompt}
-                  disabled={isRefining || !stage.prompt.trim()}
+                  disabled={isRefining || !stage.prompt.trim() || !stage.model.trim()}
                   title={t('pipeline.refinePrompt')}
                   aria-label={t('pipeline.refinePrompt')}
                   className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,21 @@ export const MODEL_OPTIONS: Record<ModelProvider, string[]> = {
   ollama: [], // Dynamic — populated at runtime from local Ollama instance
 };
 
+// Prezzi in USD per 1M token (input/output). Aggiornare periodicamente.
+export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  'gemini/gemini-2.5-flash-preview':    { input: 0.15,  output: 0.60  },
+  'gemini/gemini-3-flash-preview':      { input: 0.075, output: 0.30  },
+  'gemini/gemini-3.1-pro-preview':      { input: 1.25,  output: 5.00  },
+  'gemini/gemini-2.5-flash-lite-preview': { input: 0.10, output: 0.40 },
+  'openai/gpt-4o':                      { input: 2.50,  output: 10.00 },
+  'openai/gpt-4o-mini':                 { input: 0.15,  output: 0.60  },
+  'openai/o1-preview':                  { input: 15.00, output: 60.00 },
+  'anthropic/claude-3-5-sonnet-latest': { input: 3.00,  output: 15.00 },
+  'anthropic/claude-3-haiku-latest':    { input: 0.25,  output: 1.25  },
+  'deepseek/deepseek-chat':             { input: 0.27,  output: 1.10  },
+  'deepseek/deepseek-reasoner':         { input: 0.55,  output: 2.19  },
+};
+
 export const LANGUAGES = [
   'English',
   'Italian',

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -6,7 +6,7 @@ import { useChunksStore } from '../stores/chunksStore';
 import { llmService, isStreamCancelledError } from '../services/llmService';
 import { withRetry, friendlyError } from '../utils/retry';
 import { qualityDefault, qualityFailure } from '../utils';
-import type { JudgeResult, TranslationChunk } from '../types';
+import type { JudgeResult, TokenUsage, TranslationChunk } from '../types';
 
 type ChunkOutcome = 'completed' | 'failed' | 'cancelled' | 'skipped';
 
@@ -30,7 +30,6 @@ export function usePipeline() {
     clearChunkStages,
     requestCancel,
     setIsProcessing,
-    setStageTokenUsage,
     setJudgeTokenUsage,
   } = useChunksStore();
   const { config } = usePipelineStore();
@@ -75,14 +74,15 @@ export function usePipeline() {
 
       updateChunkStage(chunk.id, stage.id, { content: '', status: 'processing' });
       try {
+        let capturedUsage: TokenUsage | undefined;
         const result = await withRetry(
           async () => {
-            // Reset content for each retry attempt
+            capturedUsage = undefined;
             updateChunkStage(chunk.id, stage.id, { content: '', status: 'processing' });
             return llmService.runStageStream(
               chunk.originalText, stage, config, lastResult || undefined,
               (token) => appendChunkStageContent(chunk.id, stage.id, token),
-              (usage) => setStageTokenUsage(chunk.id, stage.id, usage),
+              (usage) => { capturedUsage = usage; },
             );
           },
           { label: `Stage "${stage.name}"` },
@@ -91,7 +91,11 @@ export function usePipeline() {
           lastResult = result;
           producedOutput = true;
         }
-        updateChunkStage(chunk.id, stage.id, { content: result, status: 'completed' });
+        updateChunkStage(chunk.id, stage.id, {
+          content: result,
+          status: 'completed',
+          ...(capturedUsage ? { tokenUsage: capturedUsage } : {}),
+        });
       } catch (error: any) {
         if (isStreamCancelledError(error)) {
           updateChunkStage(chunk.id, stage.id, { content: '', status: 'idle' });
@@ -212,7 +216,7 @@ export function usePipeline() {
     } else {
       toast.warning(t('errors.pipelineCompletedWithErrors', { count: errorCount }));
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, setJudgeTokenUsage]);
 
   const runSingleChunk = useCallback(async (chunkId: string) => {
     if (useChunksStore.getState().isProcessing) return;
@@ -236,7 +240,7 @@ export function usePipeline() {
       // Per-chunk failure already raised a toast inside the helper; no
       // extra summary toast is needed.
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, setJudgeTokenUsage]);
 
   const runAuditOnly = useCallback(async () => {
     if (useChunksStore.getState().isProcessing) return;

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -30,7 +30,6 @@ export function usePipeline() {
     clearChunkStages,
     requestCancel,
     setIsProcessing,
-    setJudgeTokenUsage,
   } = useChunksStore();
   const { config } = usePipelineStore();
   const isProcessing = useChunksStore((state) => state.isProcessing);
@@ -156,16 +155,15 @@ export function usePipeline() {
         () => llmService.judgeTranslation(chunk.originalText, textToAudit, config),
         { label: 'Audit' },
       );
-      if (judgeData.inputTokens !== undefined && judgeData.outputTokens !== undefined) {
-        setJudgeTokenUsage(chunk.id, {
-          inputTokens: judgeData.inputTokens,
-          outputTokens: judgeData.outputTokens,
-        });
-      }
+      const judgeTokenUsage =
+        judgeData.inputTokens !== undefined && judgeData.outputTokens !== undefined
+          ? { inputTokens: judgeData.inputTokens, outputTokens: judgeData.outputTokens }
+          : undefined;
       updateChunkJudge(chunk.id, {
         ...judgeData,
         content: textToAudit,
         status: 'completed',
+        ...(judgeTokenUsage ? { tokenUsage: judgeTokenUsage } : {}),
       } as JudgeResult);
       updateChunkStatus(chunk.id, 'completed');
       return 'completed';
@@ -216,7 +214,7 @@ export function usePipeline() {
     } else {
       toast.warning(t('errors.pipelineCompletedWithErrors', { count: errorCount }));
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, setJudgeTokenUsage]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages]);
 
   const runSingleChunk = useCallback(async (chunkId: string) => {
     if (useChunksStore.getState().isProcessing) return;
@@ -240,7 +238,7 @@ export function usePipeline() {
       // Per-chunk failure already raised a toast inside the helper; no
       // extra summary toast is needed.
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, setJudgeTokenUsage]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages]);
 
   const runAuditOnly = useCallback(async () => {
     if (useChunksStore.getState().isProcessing) return;

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -30,6 +30,8 @@ export function usePipeline() {
     clearChunkStages,
     requestCancel,
     setIsProcessing,
+    setStageTokenUsage,
+    setJudgeTokenUsage,
   } = useChunksStore();
   const { config } = usePipelineStore();
   const isProcessing = useChunksStore((state) => state.isProcessing);
@@ -80,6 +82,7 @@ export function usePipeline() {
             return llmService.runStageStream(
               chunk.originalText, stage, config, lastResult || undefined,
               (token) => appendChunkStageContent(chunk.id, stage.id, token),
+              (usage) => setStageTokenUsage(chunk.id, stage.id, usage),
             );
           },
           { label: `Stage "${stage.name}"` },
@@ -149,6 +152,12 @@ export function usePipeline() {
         () => llmService.judgeTranslation(chunk.originalText, textToAudit, config),
         { label: 'Audit' },
       );
+      if (judgeData.inputTokens !== undefined && judgeData.outputTokens !== undefined) {
+        setJudgeTokenUsage(chunk.id, {
+          inputTokens: judgeData.inputTokens,
+          outputTokens: judgeData.outputTokens,
+        });
+      }
       updateChunkJudge(chunk.id, {
         ...judgeData,
         content: textToAudit,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -18,7 +18,9 @@
     "openInsights": "Open insights panel",
     "closeDrawer": "Close panel",
     "enterSandbox": "Switch to Sandbox",
-    "exitSandbox": "Exit Sandbox"
+    "exitSandbox": "Exit Sandbox",
+    "tokenCount": "Tokens",
+    "estimatedCost": "Est. cost"
   },
   "pipeline": {
     "globalSetup": "Global Setup",
@@ -102,7 +104,18 @@
     "auditSkippedNoDraft": "Nothing to audit yet — translate this chunk first.",
     "chunkActions": "Chunk actions",
     "retranslateChunk": "Re-translate this chunk",
-    "reauditChunk": "Re-audit this chunk"
+    "reauditChunk": "Re-audit this chunk",
+    "glossaryEmpty": "No terms in the registry. Use + to add one.",
+    "glossaryNotes": "Notes",
+    "templates": {
+      "save": "Save as template",
+      "load": "Load template",
+      "namePlaceholder": "Template name...",
+      "searchPlaceholder": "Search templates...",
+      "empty": "No saved templates",
+      "saved": "Template saved",
+      "deleted": "Template deleted"
+    }
   },
   "audit": {
     "title": "Audit Logs",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -106,6 +106,9 @@
     "retranslateChunk": "Re-translate this chunk",
     "reauditChunk": "Re-audit this chunk",
     "prompt": "Prompt",
+    "tabStages": "Stages",
+    "tabAudit": "Audit",
+    "tabGlossary": "Registry",
     "glossaryEmpty": "No terms in the registry. Use + to add one.",
     "glossaryNotes": "Notes",
     "templates": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -119,7 +119,11 @@
       "empty": "No saved templates",
       "saved": "Template saved",
       "deleted": "Template deleted"
-    }
+    },
+    "refinePrompt": "Refine prompt",
+    "refining": "Refining...",
+    "refined": "Prompt refined",
+    "refineFailed": "Refinement failed"
   },
   "audit": {
     "title": "Audit Logs",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -298,13 +298,14 @@
     "sections": {
       "overview": "Overview",
       "pipeline": "Pipeline",
+      "features": "Features",
       "streaming": "Streaming",
       "audit": "Audit",
       "projects": "Projects",
       "providers": "Providers",
       "ollama": "Ollama",
       "glossary": "Glossary",
-      "shortcuts": "Toolbar"
+      "shortcuts": "Interface"
     },
     "overview": {
       "title": "What is Glossa?",
@@ -321,17 +322,33 @@
     },
     "pipeline": {
       "title": "Pipeline Configuration",
-      "intro": "The left panel contains all pipeline settings. Here's how to set up a translation run:",
+      "intro": "All pipeline settings are accessible from the configuration panel (gear icon in the header). The panel opens as a side drawer with 3 tabs and does not obscure the document. Here's how to set up a translation run:",
       "configTitle": "Language pair",
       "configDesc": "Select source and target languages from the dropdowns. Use the swap button (⇄) to quickly reverse the direction. Enable 'Auto-Segment' to split the text into paragraph-level chunks for independent processing.",
       "stagesTitle": "Translation stages",
-      "stagesDesc": "Each stage represents one LLM pass. Click the + button to add stages. Expand a stage to configure its provider, model, and prompt. The prompt tells the LLM what to focus on — e.g., 'Focus on literal accuracy' for stage 1, 'Make it sound natural and fluent' for stage 2. You can disable stages without deleting them.",
+      "stagesDesc": "Each stage represents one LLM pass. Click + to add stages. Expand a stage to configure its provider, model, and prompt. Use the wand icon to have the AI rewrite the prompt, or save/load prompts as reusable templates with the bookmark buttons. You can disable stages without deleting them.",
       "runTitle": "Running the pipeline",
-      "runDesc": "After pasting your text in the center panel and clicking 'Stage Content to Stream', press 'Begin Pipeline'. Each stage runs sequentially per chunk, and you'll see tokens stream in real time. The judge runs automatically after all stages complete.",
+      "runDesc": "After pasting your text in the center panel and clicking 'Stage Content', press 'Begin Pipeline'. Each stage runs sequentially per chunk, and you'll see tokens stream in real time. The judge runs automatically after all stages complete.",
       "editTitle": "Editing the result",
       "editDesc": "The 'Candidate Translation' box is fully editable. Make manual corrections, then click 'Re-Evaluate Drafts' in the audit panel to get an updated quality judgment on your edits.",
       "tipTitle": "Pro tip: mix providers",
       "tipDesc": "Use different models for different stages. A fast model (Gemini Flash, DeepSeek) works well for initial drafts, while a stronger model (GPT-4o, Claude Sonnet) excels at refinement and judging. Ollama models are ideal for offline work or sensitive content."
+    },
+    "features": {
+      "title": "Advanced Features",
+      "intro": "This section covers the most recent additions to Glossa.",
+      "configDrawerTitle": "Configuration Panel (3 tabs)",
+      "configDrawerDesc": "The configuration panel opens via the gear icon in the header. It is organised into three tabs: Stages (model, provider and prompt for each translation stage), Audit (AI judge configuration and evaluation templates), Registry (glossary term management). The panel is a side drawer that overlays without obstructing the document text.",
+      "templatesTitle": "Prompt Templates",
+      "templatesDesc": "Every prompt textarea — in each stage and in the Audit Guard — has save and load template buttons. Click the bookmark (+) to save the current prompt under a name; click the open book to browse and load saved templates (with search). Templates are separated by context: stage templates do not appear in the Audit section and vice versa. Saving a template with an existing name updates it automatically.",
+      "refineTitle": "Refine Prompt",
+      "refineDesc": "The wand icon next to the Prompt label in each stage and in the Audit Guard sends the current prompt to the AI using the provider and model already selected for that stage. The AI rewrites it to be more professional and effective: a specialised meta-prompt for multi-stage translation pipelines is used for stages; a QA-evaluation meta-prompt is used for the Audit Guard. The result appears immediately in the textarea — edit it freely or press Ctrl+Z to undo.",
+      "tokenTitle": "Token Count and Estimated Cost",
+      "tokenDesc": "The header displays in real time the total tokens consumed and the estimated cost for the current session, based on official pricing for each provider. Tokens are tracked separately for each stage and for the judge. The counter updates after each completed chunk.",
+      "sandboxTitle": "Sandbox and Document Mode",
+      "sandboxDesc": "The Sandbox button in the header toggles between two working modes. Sandbox is ideal for quick tests, model comparisons, and short single-text translations without chunks. Document mode activates the chunk reader, navigable index, insights panel, and advanced segmentation controls — suited for longer texts translated in multiple independent chunks.",
+      "exportTitle": "Export",
+      "exportDesc": "Export buttons are located in the Summary section of the header (visible when there are completed chunks). Export as .txt for the translated text only, or as .md for a bilingual Markdown document that includes the original text, translation, audit quality, and any issues flagged per chunk."
     },
     "streaming": {
       "title": "Real-time Streaming",
@@ -352,15 +369,15 @@
       "title": "Projects & Files",
       "intro": "Glossa saves your work in local SQLite — all data stays on your machine.",
       "createTitle": "Create a project",
-      "createDesc": "Click the folder icon (📂) in the toolbar to open the Projects panel. Type a name and click Create. The project stores your pipeline configuration, glossary, and all translation results.",
+      "createDesc": "Click the folder icon in the header to open the Projects panel. Type a name and click Create. The project stores your pipeline configuration, glossary, and all translation results.",
       "saveTitle": "Save your work",
-      "saveDesc": "Click the save icon (💾) at any time to persist the current state. When you reopen a project, the full pipeline config, stages, glossary, and translations are restored exactly as you left them.",
+      "saveDesc": "Click the save icon at any time to persist the current state. When you reopen a project, the full pipeline config, stages, glossary, and translations are restored exactly as you left them.",
       "importExportTitle": "Import and export",
-      "importExportDesc": "Use the upload icon (⬆) to import a .txt or .md file as source text. Use the download icon (⬇) to export the translation as plain text, or click 'MD' for a bilingual Markdown document with original text, translation, audit quality, and issues."
+      "importExportDesc": "Use the upload icon to import a .txt or .md file as source text. Export buttons appear in the Summary section of the header when chunks are completed: export as .txt for the translated text, or as .md for a bilingual Markdown document with original text, translation, audit quality, and issues."
     },
     "providers": {
       "title": "LLM Providers",
-      "intro": "Glossa supports five providers. Each stage and the judge can use a different provider and model. Configure API keys in Settings (⚙️).",
+      "intro": "Glossa supports five providers. Each stage and the judge can use a different provider and model. Configure API keys in Settings.",
       "provider": "Provider",
       "models": "Models",
       "notes": "Notes",
@@ -389,19 +406,28 @@
     "glossary": {
       "title": "Keyword Registry (Glossary)",
       "intro": "The Keyword Registry lets you define mandatory term translations. For each entry, specify the source term and its required translation. These terms are enforced across all pipeline stages.",
-      "usage": "Add entries in the left panel under 'Keyword Registry'. For example: 'λόγος → discourse (not 'word' or 'reason')'. Each stage's system prompt includes the full glossary, instructing the LLM to use these exact translations.",
+      "usage": "Add entries in the configuration panel under the Registry tab. For example: 'λόγος → discourse (not word or reason)'. Each stage's system prompt includes the full glossary, instructing the LLM to use these exact translations.",
       "audit": "The AI Judge specifically checks glossary adherence. If the translation uses a different term than what's defined in the registry, it will flag a 'glossary' issue with severity and a suggested fix. This is especially valuable for technical, legal, or academic texts where terminology must be consistent."
     },
     "shortcuts": {
-      "title": "Toolbar Reference",
-      "openSettings": "Open Settings (API keys, Ollama)",
-      "switchLang": "Switch interface language (EN/IT)",
+      "title": "Interface Reference",
+      "toolbarTitle": "Header toolbar",
+      "openSettings": "Settings — API keys and Ollama",
+      "switchLang": "Switch interface language (EN / IT)",
       "openProjects": "Open Projects panel",
       "importFile": "Import source text file",
       "saveProject": "Save current project",
+      "openConfig": "Open pipeline configuration panel",
+      "openInsights": "Open insights panel (Document mode)",
+      "sandbox": "Toggle Sandbox / Document mode",
+      "exportTitle": "Export (in header summary)",
       "exportTxt": "Export translation as .txt",
-      "exportMd": "Export bilingual Markdown",
-      "headerIcon": "header icon"
+      "exportMd": "Export bilingual .md document",
+      "promptToolsTitle": "Prompt tools (in stages and Audit)",
+      "refineButton": "Wand — AI-rewrites the prompt",
+      "saveTemplate": "Bookmark (+) — save prompt as template",
+      "loadTemplate": "Open book — load a saved template",
+      "headerIcon": "icon"
     }
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -105,6 +105,7 @@
     "chunkActions": "Chunk actions",
     "retranslateChunk": "Re-translate this chunk",
     "reauditChunk": "Re-audit this chunk",
+    "prompt": "Prompt",
     "glossaryEmpty": "No terms in the registry. Use + to add one.",
     "glossaryNotes": "Notes",
     "templates": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -18,7 +18,9 @@
     "openInsights": "Apri pannello insight",
     "closeDrawer": "Chiudi pannello",
     "enterSandbox": "Passa a Sandbox",
-    "exitSandbox": "Esci da Sandbox"
+    "exitSandbox": "Esci da Sandbox",
+    "tokenCount": "Token",
+    "estimatedCost": "Costo stimato"
   },
   "pipeline": {
     "globalSetup": "Configurazione Globale",
@@ -102,7 +104,18 @@
     "auditSkippedNoDraft": "Nessuna traduzione da valutare — traduci prima questo blocco.",
     "chunkActions": "Azioni blocco",
     "retranslateChunk": "Ri-traduci questo blocco",
-    "reauditChunk": "Ri-valuta questo blocco"
+    "reauditChunk": "Ri-valuta questo blocco",
+    "glossaryEmpty": "Nessun termine nel registro. Usa + per aggiungerne uno.",
+    "glossaryNotes": "Note",
+    "templates": {
+      "save": "Salva come template",
+      "load": "Carica template",
+      "namePlaceholder": "Nome template...",
+      "searchPlaceholder": "Cerca template...",
+      "empty": "Nessun template salvato",
+      "saved": "Template salvato",
+      "deleted": "Template eliminato"
+    }
   },
   "audit": {
     "title": "Log Audit",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -105,6 +105,7 @@
     "chunkActions": "Azioni blocco",
     "retranslateChunk": "Ri-traduci questo blocco",
     "reauditChunk": "Ri-valuta questo blocco",
+    "prompt": "Prompt",
     "glossaryEmpty": "Nessun termine nel registro. Usa + per aggiungerne uno.",
     "glossaryNotes": "Note",
     "templates": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -119,7 +119,11 @@
       "empty": "Nessun template salvato",
       "saved": "Template salvato",
       "deleted": "Template eliminato"
-    }
+    },
+    "refinePrompt": "Rifinisci prompt",
+    "refining": "Rifinendo...",
+    "refined": "Prompt rifinito",
+    "refineFailed": "Rifinizione fallita"
   },
   "audit": {
     "title": "Log Audit",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -106,6 +106,9 @@
     "retranslateChunk": "Ri-traduci questo blocco",
     "reauditChunk": "Ri-valuta questo blocco",
     "prompt": "Prompt",
+    "tabStages": "Fasi",
+    "tabAudit": "Audit",
+    "tabGlossary": "Registro",
     "glossaryEmpty": "Nessun termine nel registro. Usa + per aggiungerne uno.",
     "glossaryNotes": "Note",
     "templates": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -298,13 +298,14 @@
     "sections": {
       "overview": "Panoramica",
       "pipeline": "Pipeline",
+      "features": "Funzionalità",
       "streaming": "Streaming",
       "audit": "Audit",
       "projects": "Progetti",
       "providers": "Provider",
       "ollama": "Ollama",
       "glossary": "Glossario",
-      "shortcuts": "Toolbar"
+      "shortcuts": "Interfaccia"
     },
     "overview": {
       "title": "Cos'è Glossa?",
@@ -321,17 +322,33 @@
     },
     "pipeline": {
       "title": "Configurazione Pipeline",
-      "intro": "Il pannello sinistro contiene tutte le impostazioni della pipeline. Ecco come configurare una sessione di traduzione:",
+      "intro": "Tutte le impostazioni della pipeline sono accessibili dal pannello di configurazione (icona ingranaggio nell'header). Il pannello si apre su 3 tab e non oscura il documento. Ecco come configurare una sessione di traduzione:",
       "configTitle": "Coppia linguistica",
       "configDesc": "Seleziona le lingue sorgente e destinazione dai menu a tendina. Usa il pulsante di scambio (⇄) per invertire rapidamente la direzione. Attiva 'Segmentazione Automatica' per dividere il testo in blocchi per paragrafo.",
       "stagesTitle": "Fasi di traduzione",
-      "stagesDesc": "Ogni fase rappresenta un passaggio LLM. Clicca + per aggiungere fasi. Espandi una fase per configurare provider, modello e prompt. Il prompt indica all'LLM su cosa concentrarsi — es. 'Concentrati sulla fedeltà letterale' per la fase 1, 'Rendi il testo naturale e fluido' per la fase 2. Puoi disabilitare le fasi senza eliminarle.",
+      "stagesDesc": "Ogni fase rappresenta un passaggio LLM. Clicca + per aggiungere fasi. Espandi una fase per configurare provider, modello e prompt. Usa la bacchetta magica per far riscrivere il prompt dall'IA, oppure salva/carica prompt come template riutilizzabili con i pulsanti segnalibro. Puoi disabilitare le fasi senza eliminarle.",
       "runTitle": "Esecuzione della pipeline",
       "runDesc": "Dopo aver incollato il testo nel pannello centrale e cliccato 'Prepara Contenuto', premi 'Avvia Pipeline'. Ogni fase viene eseguita in sequenza per ogni blocco e vedrai i token apparire in tempo reale. Il giudice si avvia automaticamente dopo tutte le fasi.",
       "editTitle": "Modifica del risultato",
       "editDesc": "Il box 'Traduzione Candidata' è completamente modificabile. Apporta le correzioni manuali, poi clicca 'Rivaluta Bozze' nel pannello audit per ottenere una valutazione aggiornata sulle tue modifiche.",
       "tipTitle": "Consiglio: mescola i provider",
       "tipDesc": "Usa modelli diversi per fasi diverse. Un modello veloce (Gemini Flash, DeepSeek) va bene per le bozze iniziali, mentre un modello più potente (GPT-4o, Claude Sonnet) eccelle nel raffinamento e nella valutazione. I modelli Ollama sono ideali per il lavoro offline o contenuti sensibili."
+    },
+    "features": {
+      "title": "Funzionalità Avanzate",
+      "intro": "Questa sezione descrive le funzionalità più recenti aggiunte a Glossa.",
+      "configDrawerTitle": "Pannello di Configurazione (3 tab)",
+      "configDrawerDesc": "Il pannello di configurazione si apre cliccando l'icona ingranaggio nell'header. È organizzato su tre tab: Fasi (modelli, provider e prompt per ogni fase di traduzione), Audit (configurazione del giudice AI e template di valutazione), Registro (gestione del glossario dei termini). Il pannello è un drawer laterale che si sovrappone al documento senza ostruire il testo.",
+      "templatesTitle": "Template Prompt",
+      "templatesDesc": "In ogni fase di traduzione e nel Controllo Qualità puoi salvare i prompt come template riutilizzabili. Clicca il segnalibro (+) per salvare il prompt corrente assegnandogli un nome; il libro aperto per sfogliare e caricare i template salvati (con ricerca). I template sono separati per contesto: quelli salvati in una fase non appaiono nell'Audit e viceversa. Salvare un template con un nome già esistente lo aggiorna automaticamente.",
+      "refineTitle": "Rifinisci Prompt",
+      "refineDesc": "L'icona bacchetta magica accanto all'etichetta 'Prompt' in ogni fase e nel Controllo Qualità invia il prompt corrente all'IA usando il provider e modello già selezionati per quella fase. L'IA lo riscrive in modo più professionale ed efficace: per le fasi di traduzione usa un meta-prompt specializzato per pipeline multi-stadio; per il Controllo Qualità usa uno specializzato per valutazione QA. Il risultato appare immediatamente nella textarea — modificalo liberamente o usa Ctrl+Z per annullare.",
+      "tokenTitle": "Conteggio Token e Costo Stimato",
+      "tokenDesc": "L'header mostra in tempo reale il numero totale di token consumati e il costo stimato per la sessione corrente, basato sui prezzi ufficiali di ciascun provider. I token vengono tracciati separatamente per ogni fase e per il giudice. Il contatore si aggiorna dopo ogni blocco completato.",
+      "sandboxTitle": "Modalità Sandbox e Documento",
+      "sandboxDesc": "Il pulsante Sandbox nell'header alterna tra due modalità di lavoro. Sandbox è ideale per test rapidi, confronto di modelli e traduzione di brevi estratti su un testo singolo senza blocchi. Documento attiva il lettore di chunk, l'indice navigabile, il pannello insight e i controlli avanzati di segmentazione — adatto per testi lunghi da tradurre in più blocchi.",
+      "exportTitle": "Esportazione",
+      "exportDesc": "I pulsanti di esportazione si trovano nel pannello Riepilogo dell'header (visibile quando ci sono blocchi completati). Esporta come .txt per il solo testo tradotto, o come .md per un documento Markdown bilingue che include il testo originale, la traduzione, la qualità dell'audit e i problemi rilevati per ogni blocco."
     },
     "streaming": {
       "title": "Streaming in Tempo Reale",
@@ -352,15 +369,15 @@
       "title": "Progetti e File",
       "intro": "Glossa salva il tuo lavoro in SQLite locale — tutti i dati rimangono sulla tua macchina.",
       "createTitle": "Crea un progetto",
-      "createDesc": "Clicca l'icona cartella (📂) nella toolbar per aprire il pannello Progetti. Digita un nome e clicca Crea. Il progetto memorizza la configurazione della pipeline, il glossario e tutti i risultati delle traduzioni.",
+      "createDesc": "Clicca l'icona cartella nell'header per aprire il pannello Progetti. Digita un nome e clicca Crea. Il progetto memorizza la configurazione della pipeline, il glossario e tutti i risultati delle traduzioni.",
       "saveTitle": "Salva il lavoro",
-      "saveDesc": "Clicca l'icona salvataggio (💾) in qualsiasi momento per persistere lo stato corrente. Quando riapri un progetto, la configurazione completa, le fasi, il glossario e le traduzioni vengono ripristinati esattamente come li avevi lasciati.",
+      "saveDesc": "Clicca l'icona salvataggio in qualsiasi momento per persistere lo stato corrente. Quando riapri un progetto, la configurazione completa, le fasi, il glossario e le traduzioni vengono ripristinati esattamente come li avevi lasciati.",
       "importExportTitle": "Importa ed esporta",
-      "importExportDesc": "Usa l'icona upload (⬆) per importare un file .txt o .md come testo sorgente. Usa l'icona download (⬇) per esportare la traduzione come testo semplice, o clicca 'MD' per un documento Markdown bilingue con testo originale, traduzione, qualità audit e problemi."
+      "importExportDesc": "Usa l'icona upload per importare un file .txt o .md come testo sorgente. I pulsanti di esportazione appaiono nel pannello Riepilogo dell'header quando ci sono blocchi completati: esporta come .txt per il testo tradotto, o come .md per un documento Markdown bilingue con testo originale, traduzione, qualità audit e problemi."
     },
     "providers": {
       "title": "Provider LLM",
-      "intro": "Glossa supporta cinque provider. Ogni fase e il giudice possono usare un provider e modello diverso. Configura le chiavi API nelle Impostazioni (⚙️).",
+      "intro": "Glossa supporta cinque provider. Ogni fase e il giudice possono usare un provider e modello diverso. Configura le chiavi API nelle Impostazioni.",
       "provider": "Provider",
       "models": "Modelli",
       "notes": "Note",
@@ -389,19 +406,28 @@
     "glossary": {
       "title": "Registro Termini (Glossario)",
       "intro": "Il Registro Termini ti permette di definire traduzioni obbligatorie per i termini chiave. Per ogni voce, specifica il termine sorgente e la sua traduzione richiesta. Questi termini vengono imposti in tutte le fasi della pipeline.",
-      "usage": "Aggiungi voci nel pannello sinistro sotto 'Registro Termini'. Ad esempio: 'λόγος → discorso (non 'parola' o 'ragione')'. Il prompt di sistema di ogni fase include il glossario completo, istruendo l'LLM a usare queste traduzioni esatte.",
+      "usage": "Aggiungi voci nel pannello di configurazione sotto il tab Registro. Ad esempio: 'λόγος → discorso (non parola o ragione)'. Il prompt di sistema di ogni fase include il glossario completo, istruendo l'LLM a usare queste traduzioni esatte.",
       "audit": "Il Giudice AI verifica specificamente l'aderenza al glossario. Se la traduzione usa un termine diverso da quello definito nel registro, segnalerà un problema di tipo 'glossary' con gravità e correzione suggerita. Questo è particolarmente prezioso per testi tecnici, giuridici o accademici dove la terminologia deve essere coerente."
     },
     "shortcuts": {
-      "title": "Riferimento Toolbar",
-      "openSettings": "Apri Impostazioni (chiavi API, Ollama)",
-      "switchLang": "Cambia lingua interfaccia (EN/IT)",
+      "title": "Riferimento Interfaccia",
+      "toolbarTitle": "Toolbar header",
+      "openSettings": "Impostazioni — chiavi API e Ollama",
+      "switchLang": "Cambia lingua interfaccia (EN / IT)",
       "openProjects": "Apri pannello Progetti",
       "importFile": "Importa file di testo sorgente",
       "saveProject": "Salva progetto corrente",
+      "openConfig": "Apri pannello configurazione pipeline",
+      "openInsights": "Apri pannello insight (Modalità Documento)",
+      "sandbox": "Attiva / disattiva modalità Sandbox",
+      "exportTitle": "Esportazione (nel riepilogo header)",
       "exportTxt": "Esporta traduzione come .txt",
-      "exportMd": "Esporta Markdown bilingue",
-      "headerIcon": "icona header"
+      "exportMd": "Esporta documento bilingue .md",
+      "promptToolsTitle": "Strumenti Prompt (nelle fasi e nell'Audit)",
+      "refineButton": "Bacchetta — rifinisce il prompt con l'IA",
+      "saveTemplate": "Segnalibro (+) — salva il prompt come template",
+      "loadTemplate": "Libro aperto — carica un template salvato",
+      "headerIcon": "icona"
     }
   }
 }

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -4,6 +4,7 @@ const dbState = vi.hoisted(() => {
   const columnsByTable = new Map<string, string[]>([
     ['pipeline_configs', ['id', 'project_id', 'stages', 'judge_prompt', 'judge_model', 'judge_provider', 'use_chunking']],
     ['translations', ['id', 'project_id', 'original_text', 'final_translation', 'stage_results', 'judge_issues', 'created_at']],
+    ['prompt_templates', []],
   ]);
 
   const execute = vi.fn(async (query: string) => {
@@ -41,6 +42,7 @@ describe('initDatabase migrations', () => {
     vi.clearAllMocks();
     dbState.columnsByTable.set('pipeline_configs', ['id', 'project_id', 'stages', 'judge_prompt', 'judge_model', 'judge_provider', 'use_chunking']);
     dbState.columnsByTable.set('translations', ['id', 'project_id', 'original_text', 'final_translation', 'stage_results', 'judge_issues', 'created_at']);
+    dbState.columnsByTable.set('prompt_templates', []);
   });
 
   it('adds new pipeline and translation columns for existing databases', async () => {
@@ -71,6 +73,19 @@ describe('initDatabase migrations', () => {
     );
     expect(dbState.db.execute).toHaveBeenCalledWith(
       expect.stringContaining('ALTER TABLE translations ADD COLUMN position INTEGER DEFAULT NULL'),
+    );
+  });
+
+  it('creates the prompt_templates table and unique index on name', async () => {
+    const { initDatabase } = await import('./dbService');
+
+    await initDatabase();
+
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE IF NOT EXISTS prompt_templates'),
+    );
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name'),
     );
   });
 });

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -85,7 +85,7 @@ describe('initDatabase migrations', () => {
       expect.stringContaining('CREATE TABLE IF NOT EXISTS prompt_templates'),
     );
     expect(dbState.db.execute).toHaveBeenCalledWith(
-      expect.stringContaining('CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name'),
+      expect.stringContaining('CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name_context'),
     );
   });
 });

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -148,9 +148,12 @@ export async function initDatabase(): Promise<void> {
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   `);
+  await ensureColumn('prompt_templates', 'context', "TEXT NOT NULL DEFAULT 'stage'");
+  // Migrate unique index from (name) to (name, context) so stage/audit can share names
+  await conn.execute('DROP INDEX IF EXISTS idx_prompt_templates_name');
   await conn.execute(`
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name
-    ON prompt_templates(name)
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name_context
+    ON prompt_templates(name, context)
   `);
 
   console.log('[Glossa] Database initialized');

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -137,6 +137,22 @@ export async function initDatabase(): Promise<void> {
     )
   `);
 
+  await conn.execute(`
+    CREATE TABLE IF NOT EXISTS prompt_templates (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      default_model TEXT DEFAULT '',
+      default_provider TEXT DEFAULT '',
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await conn.execute(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_templates_name
+    ON prompt_templates(name)
+  `);
+
   console.log('[Glossa] Database initialized');
 }
 

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -94,11 +94,10 @@ export const llmService = {
     translation: string,
     config: PipelineConfig,
   ): Promise<Omit<JudgeResult, 'status'> & { inputTokens?: number; outputTokens?: number }> {
-    return invoke('judge_translation', {
-      originalText,
-      translation,
-      config,
-    });
+    return invoke<Omit<JudgeResult, 'status'> & { inputTokens?: number; outputTokens?: number }>(
+      'judge_translation',
+      { originalText, translation, config },
+    );
   },
 
   async refinePrompt(

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import type { PipelineConfig, PipelineStageConfig, JudgeResult } from '../types';
+import type { PipelineConfig, PipelineStageConfig, JudgeResult, TokenUsage } from '../types';
 import { useChunksStore } from '../stores/chunksStore';
 
 /// Sentinel string returned by the Rust backend when a stream is
@@ -18,6 +18,8 @@ interface StreamTokenPayload {
   streamId: string;
   token: string;
   done: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
 }
 
 /**
@@ -50,12 +52,20 @@ export const llmService = {
     config: PipelineConfig,
     previousResult: string | undefined,
     onToken: (token: string) => void,
+    onUsage?: (usage: TokenUsage) => void,
   ): Promise<string> {
     const streamId = `stream-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
     const unlisten = await listen<StreamTokenPayload>('stream-token', (event) => {
-      if (event.payload.streamId === streamId && !event.payload.done) {
+      if (event.payload.streamId !== streamId) return;
+      if (!event.payload.done) {
         onToken(event.payload.token);
+      } else if (
+        onUsage &&
+        event.payload.inputTokens !== undefined &&
+        event.payload.outputTokens !== undefined
+      ) {
+        onUsage({ inputTokens: event.payload.inputTokens, outputTokens: event.payload.outputTokens });
       }
     });
 
@@ -83,8 +93,8 @@ export const llmService = {
     originalText: string,
     translation: string,
     config: PipelineConfig,
-  ): Promise<Omit<JudgeResult, 'status'>> {
-    return invoke<Omit<JudgeResult, 'status'>>('judge_translation', {
+  ): Promise<Omit<JudgeResult, 'status'> & { inputTokens?: number; outputTokens?: number }> {
+    return invoke('judge_translation', {
       originalText,
       translation,
       config,

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -101,8 +101,13 @@ export const llmService = {
     });
   },
 
-  async optimizePrompt(currentPrompt: string): Promise<string> {
-    return invoke<string>('optimize_prompt', { currentPrompt });
+  async refinePrompt(
+    prompt: string,
+    provider: string,
+    model: string,
+    context: 'stage' | 'audit',
+  ): Promise<string> {
+    return invoke<string>('refine_prompt', { prompt, provider, model, context });
   },
 
   async testConnection(provider: string): Promise<boolean> {

--- a/src/services/promptTemplateService.test.ts
+++ b/src/services/promptTemplateService.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock('./dbService', () => dbMocks);
+
+vi.mock('../utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils')>();
+  return { ...actual, generateId: vi.fn(() => 'tpl-test-id') };
+});
+
+const {
+  getPromptTemplates,
+  savePromptTemplate,
+  deletePromptTemplate,
+} = await import('./promptTemplateService');
+
+describe('promptTemplateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPromptTemplates', () => {
+    it('returns mapped templates ordered by name', async () => {
+      dbMocks.select.mockResolvedValueOnce([
+        { id: 'tpl-1', name: 'Alpha', prompt: 'Do alpha', default_model: 'gpt-4o', default_provider: 'openai', created_at: '2024-01-01' },
+        { id: 'tpl-2', name: 'Beta', prompt: 'Do beta', default_model: '', default_provider: '', created_at: '2024-01-02' },
+      ]);
+
+      const templates = await getPromptTemplates();
+
+      expect(dbMocks.select).toHaveBeenCalledWith(
+        expect.stringContaining('FROM prompt_templates'),
+      );
+      expect(templates).toHaveLength(2);
+      expect(templates[0]).toMatchObject({
+        id: 'tpl-1',
+        name: 'Alpha',
+        prompt: 'Do alpha',
+        defaultModel: 'gpt-4o',
+        defaultProvider: 'openai',
+        createdAt: '2024-01-01',
+      });
+      expect(templates[1].defaultModel).toBeUndefined();
+      expect(templates[1].defaultProvider).toBeUndefined();
+    });
+
+    it('returns empty array when no templates exist', async () => {
+      dbMocks.select.mockResolvedValueOnce([]);
+      const templates = await getPromptTemplates();
+      expect(templates).toEqual([]);
+    });
+  });
+
+  describe('savePromptTemplate', () => {
+    it('inserts a new template with a generated id', async () => {
+      await savePromptTemplate({ name: 'My prompt', prompt: 'Translate carefully' });
+
+      expect(dbMocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO prompt_templates'),
+        expect.arrayContaining(['tpl-test-id', 'My prompt', 'Translate carefully']),
+      );
+    });
+
+    it('uses ON CONFLICT upsert on name collision', async () => {
+      await savePromptTemplate({ name: 'Existing', prompt: 'Updated content' });
+
+      expect(dbMocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT(name) DO UPDATE SET'),
+        expect.any(Array),
+      );
+    });
+
+    it('returns void (does not return the id)', async () => {
+      const result = await savePromptTemplate({ name: 'Test', prompt: 'Test prompt' });
+      expect(result).toBeUndefined();
+    });
+
+    it('stores empty strings for missing optional fields', async () => {
+      await savePromptTemplate({ name: 'Minimal', prompt: 'Min prompt' });
+
+      const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
+      expect(callArgs[3]).toBe('');
+      expect(callArgs[4]).toBe('');
+    });
+
+    it('stores provided model and provider', async () => {
+      await savePromptTemplate({
+        name: 'Full',
+        prompt: 'Full prompt',
+        defaultModel: 'claude-3-5-sonnet-latest',
+        defaultProvider: 'anthropic',
+      });
+
+      const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
+      expect(callArgs[3]).toBe('claude-3-5-sonnet-latest');
+      expect(callArgs[4]).toBe('anthropic');
+    });
+  });
+
+  describe('deletePromptTemplate', () => {
+    it('deletes by id', async () => {
+      await deletePromptTemplate('tpl-99');
+
+      expect(dbMocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM prompt_templates'),
+        ['tpl-99'],
+      );
+    });
+  });
+});

--- a/src/services/promptTemplateService.test.ts
+++ b/src/services/promptTemplateService.test.ts
@@ -26,8 +26,8 @@ describe('promptTemplateService', () => {
   describe('getPromptTemplates', () => {
     it('returns mapped templates ordered by name', async () => {
       dbMocks.select.mockResolvedValueOnce([
-        { id: 'tpl-1', name: 'Alpha', prompt: 'Do alpha', default_model: 'gpt-4o', default_provider: 'openai', created_at: '2024-01-01' },
-        { id: 'tpl-2', name: 'Beta', prompt: 'Do beta', default_model: '', default_provider: '', created_at: '2024-01-02' },
+        { id: 'tpl-1', name: 'Alpha', prompt: 'Do alpha', context: 'stage', default_model: 'gpt-4o', default_provider: 'openai', created_at: '2024-01-01' },
+        { id: 'tpl-2', name: 'Beta', prompt: 'Do beta', context: 'audit', default_model: '', default_provider: '', created_at: '2024-01-02' },
       ]);
 
       const templates = await getPromptTemplates();
@@ -40,10 +40,12 @@ describe('promptTemplateService', () => {
         id: 'tpl-1',
         name: 'Alpha',
         prompt: 'Do alpha',
+        context: 'stage',
         defaultModel: 'gpt-4o',
         defaultProvider: 'openai',
         createdAt: '2024-01-01',
       });
+      expect(templates[1].context).toBe('audit');
       expect(templates[1].defaultModel).toBeUndefined();
       expect(templates[1].defaultProvider).toBeUndefined();
     });
@@ -57,7 +59,7 @@ describe('promptTemplateService', () => {
 
   describe('savePromptTemplate', () => {
     it('inserts a new template with a generated id', async () => {
-      await savePromptTemplate({ name: 'My prompt', prompt: 'Translate carefully' });
+      await savePromptTemplate({ name: 'My prompt', prompt: 'Translate carefully', context: 'stage' });
 
       expect(dbMocks.execute).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO prompt_templates'),
@@ -65,39 +67,41 @@ describe('promptTemplateService', () => {
       );
     });
 
-    it('uses ON CONFLICT upsert on name collision', async () => {
-      await savePromptTemplate({ name: 'Existing', prompt: 'Updated content' });
+    it('uses ON CONFLICT upsert on name+context collision', async () => {
+      await savePromptTemplate({ name: 'Existing', prompt: 'Updated content', context: 'stage' });
 
       expect(dbMocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining('ON CONFLICT(name) DO UPDATE SET'),
+        expect.stringContaining('ON CONFLICT(name, context) DO UPDATE SET'),
         expect.any(Array),
       );
     });
 
     it('returns void (does not return the id)', async () => {
-      const result = await savePromptTemplate({ name: 'Test', prompt: 'Test prompt' });
+      const result = await savePromptTemplate({ name: 'Test', prompt: 'Test prompt', context: 'stage' });
       expect(result).toBeUndefined();
     });
 
     it('stores empty strings for missing optional fields', async () => {
-      await savePromptTemplate({ name: 'Minimal', prompt: 'Min prompt' });
+      await savePromptTemplate({ name: 'Minimal', prompt: 'Min prompt', context: 'stage' });
 
       const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
-      expect(callArgs[3]).toBe('');
+      // callArgs: [id, name, prompt, context, defaultModel, defaultProvider]
       expect(callArgs[4]).toBe('');
+      expect(callArgs[5]).toBe('');
     });
 
     it('stores provided model and provider', async () => {
       await savePromptTemplate({
         name: 'Full',
         prompt: 'Full prompt',
+        context: 'stage',
         defaultModel: 'claude-3-5-sonnet-latest',
         defaultProvider: 'anthropic',
       });
 
       const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
-      expect(callArgs[3]).toBe('claude-3-5-sonnet-latest');
-      expect(callArgs[4]).toBe('anthropic');
+      expect(callArgs[4]).toBe('claude-3-5-sonnet-latest');
+      expect(callArgs[5]).toBe('anthropic');
     });
   });
 

--- a/src/services/promptTemplateService.ts
+++ b/src/services/promptTemplateService.ts
@@ -6,6 +6,7 @@ interface TemplateRow {
   id: string;
   name: string;
   prompt: string;
+  context: string;
   default_model: string;
   default_provider: string;
   created_at: string;
@@ -16,16 +17,22 @@ function rowToTemplate(row: TemplateRow): PromptTemplate {
     id: row.id,
     name: row.name,
     prompt: row.prompt,
+    context: (row.context === 'audit' ? 'audit' : 'stage') as 'stage' | 'audit',
     defaultModel: row.default_model || undefined,
     defaultProvider: row.default_provider || undefined,
     createdAt: row.created_at,
   };
 }
 
-export async function getPromptTemplates(): Promise<PromptTemplate[]> {
-  const rows = await select<TemplateRow>(
-    'SELECT id, name, prompt, default_model, default_provider, created_at FROM prompt_templates ORDER BY name ASC',
-  );
+export async function getPromptTemplates(context?: 'stage' | 'audit'): Promise<PromptTemplate[]> {
+  const rows = context
+    ? await select<TemplateRow>(
+        'SELECT id, name, prompt, context, default_model, default_provider, created_at FROM prompt_templates WHERE context = $1 ORDER BY name ASC',
+        [context],
+      )
+    : await select<TemplateRow>(
+        'SELECT id, name, prompt, context, default_model, default_provider, created_at FROM prompt_templates ORDER BY name ASC',
+      );
   return rows.map(rowToTemplate);
 }
 
@@ -34,14 +41,14 @@ export async function savePromptTemplate(
 ): Promise<void> {
   const id = generateId('tpl');
   await execute(
-    `INSERT INTO prompt_templates (id, name, prompt, default_model, default_provider)
-     VALUES ($1, $2, $3, $4, $5)
-     ON CONFLICT(name) DO UPDATE SET
+    `INSERT INTO prompt_templates (id, name, prompt, context, default_model, default_provider)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT(name, context) DO UPDATE SET
        prompt = excluded.prompt,
        default_model = excluded.default_model,
        default_provider = excluded.default_provider,
        updated_at = CURRENT_TIMESTAMP`,
-    [id, input.name, input.prompt, input.defaultModel ?? '', input.defaultProvider ?? ''],
+    [id, input.name, input.prompt, input.context, input.defaultModel ?? '', input.defaultProvider ?? ''],
   );
 }
 

--- a/src/services/promptTemplateService.ts
+++ b/src/services/promptTemplateService.ts
@@ -31,7 +31,7 @@ export async function getPromptTemplates(): Promise<PromptTemplate[]> {
 
 export async function savePromptTemplate(
   input: Omit<PromptTemplate, 'id' | 'createdAt'>,
-): Promise<string> {
+): Promise<void> {
   const id = generateId('tpl');
   await execute(
     `INSERT INTO prompt_templates (id, name, prompt, default_model, default_provider)
@@ -43,7 +43,6 @@ export async function savePromptTemplate(
        updated_at = CURRENT_TIMESTAMP`,
     [id, input.name, input.prompt, input.defaultModel ?? '', input.defaultProvider ?? ''],
   );
-  return id;
 }
 
 export async function deletePromptTemplate(id: string): Promise<void> {

--- a/src/services/promptTemplateService.ts
+++ b/src/services/promptTemplateService.ts
@@ -1,0 +1,51 @@
+import { select, execute } from './dbService';
+import type { PromptTemplate } from '../types';
+import { generateId } from '../utils';
+
+interface TemplateRow {
+  id: string;
+  name: string;
+  prompt: string;
+  default_model: string;
+  default_provider: string;
+  created_at: string;
+}
+
+function rowToTemplate(row: TemplateRow): PromptTemplate {
+  return {
+    id: row.id,
+    name: row.name,
+    prompt: row.prompt,
+    defaultModel: row.default_model || undefined,
+    defaultProvider: row.default_provider || undefined,
+    createdAt: row.created_at,
+  };
+}
+
+export async function getPromptTemplates(): Promise<PromptTemplate[]> {
+  const rows = await select<TemplateRow>(
+    'SELECT id, name, prompt, default_model, default_provider, created_at FROM prompt_templates ORDER BY name ASC',
+  );
+  return rows.map(rowToTemplate);
+}
+
+export async function savePromptTemplate(
+  input: Omit<PromptTemplate, 'id' | 'createdAt'>,
+): Promise<string> {
+  const id = generateId('tpl');
+  await execute(
+    `INSERT INTO prompt_templates (id, name, prompt, default_model, default_provider)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT(name) DO UPDATE SET
+       prompt = excluded.prompt,
+       default_model = excluded.default_model,
+       default_provider = excluded.default_provider,
+       updated_at = CURRENT_TIMESTAMP`,
+    [id, input.name, input.prompt, input.defaultModel ?? '', input.defaultProvider ?? ''],
+  );
+  return id;
+}
+
+export async function deletePromptTemplate(id: string): Promise<void> {
+  await execute('DELETE FROM prompt_templates WHERE id = $1', [id]);
+}

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -3,7 +3,6 @@ import type {
   ChunkStatus,
   JudgeResult,
   PipelineResult,
-  TokenUsage,
   TranslationChunk,
 } from '../types';
 import { usePipelineStore } from './pipelineStore';
@@ -43,8 +42,6 @@ interface ChunksState {
   resetCompletedChunks: () => void;
   unlockChunkForEdit: (chunkId: string) => void;
   clearChunkStages: (chunkId: string) => void;
-  setStageTokenUsage: (chunkId: string, stageId: string, usage: TokenUsage) => void;
-  setJudgeTokenUsage: (chunkId: string, usage: TokenUsage) => void;
 }
 
 export const useChunksStore = create<ChunksState>((set, get) => ({
@@ -224,30 +221,6 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
       ),
     })),
 
-  setStageTokenUsage: (chunkId, stageId, usage) =>
-    set((state) => ({
-      chunks: state.chunks.map((chunk) => {
-        if (chunk.id !== chunkId) return chunk;
-        const existing = chunk.stageResults[stageId];
-        if (!existing) return chunk;
-        return {
-          ...chunk,
-          stageResults: {
-            ...chunk.stageResults,
-            [stageId]: { ...existing, tokenUsage: usage },
-          },
-        };
-      }),
-    })),
-
-  setJudgeTokenUsage: (chunkId, usage) =>
-    set((state) => ({
-      chunks: state.chunks.map((chunk) =>
-        chunk.id === chunkId
-          ? { ...chunk, judgeResult: { ...chunk.judgeResult, tokenUsage: usage } }
-          : chunk,
-      ),
-    })),
 }));
 
 function createEmptyJudgeResult(): JudgeResult {

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -3,6 +3,7 @@ import type {
   ChunkStatus,
   JudgeResult,
   PipelineResult,
+  TokenUsage,
   TranslationChunk,
 } from '../types';
 import { usePipelineStore } from './pipelineStore';
@@ -42,6 +43,8 @@ interface ChunksState {
   resetCompletedChunks: () => void;
   unlockChunkForEdit: (chunkId: string) => void;
   clearChunkStages: (chunkId: string) => void;
+  setStageTokenUsage: (chunkId: string, stageId: string, usage: TokenUsage) => void;
+  setJudgeTokenUsage: (chunkId: string, usage: TokenUsage) => void;
 }
 
 export const useChunksStore = create<ChunksState>((set, get) => ({
@@ -218,6 +221,31 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
     set((state) => ({
       chunks: state.chunks.map((chunk) =>
         chunk.id === chunkId ? { ...chunk, stageResults: {} } : chunk,
+      ),
+    })),
+
+  setStageTokenUsage: (chunkId, stageId, usage) =>
+    set((state) => ({
+      chunks: state.chunks.map((chunk) => {
+        if (chunk.id !== chunkId) return chunk;
+        const existing = chunk.stageResults[stageId];
+        if (!existing) return chunk;
+        return {
+          ...chunk,
+          stageResults: {
+            ...chunk.stageResults,
+            [stageId]: { ...existing, tokenUsage: usage },
+          },
+        };
+      }),
+    })),
+
+  setJudgeTokenUsage: (chunkId, usage) =>
+    set((state) => ({
+      chunks: state.chunks.map((chunk) =>
+        chunk.id === chunkId
+          ? { ...chunk, judgeResult: { ...chunk.judgeResult, tokenUsage: usage } }
+          : chunk,
       ),
     })),
 }));

--- a/src/stores/promptTemplateStore.ts
+++ b/src/stores/promptTemplateStore.ts
@@ -13,6 +13,7 @@ interface PromptTemplateState {
   saveTemplate: (
     name: string,
     prompt: string,
+    context: 'stage' | 'audit',
     defaultModel?: string,
     defaultProvider?: string,
   ) => Promise<void>;
@@ -29,8 +30,8 @@ export const usePromptTemplateStore = create<PromptTemplateState>((set, get) => 
     set({ templates, isLoaded: true });
   },
 
-  saveTemplate: async (name, prompt, defaultModel, defaultProvider) => {
-    await savePromptTemplate({ name, prompt, defaultModel, defaultProvider });
+  saveTemplate: async (name, prompt, context, defaultModel, defaultProvider) => {
+    await savePromptTemplate({ name, prompt, context, defaultModel, defaultProvider });
     const templates = await getPromptTemplates();
     set({ templates });
   },

--- a/src/stores/promptTemplateStore.ts
+++ b/src/stores/promptTemplateStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import type { PromptTemplate } from '../types';
+import {
+  getPromptTemplates,
+  savePromptTemplate,
+  deletePromptTemplate,
+} from '../services/promptTemplateService';
+
+interface PromptTemplateState {
+  templates: PromptTemplate[];
+  isLoaded: boolean;
+  loadTemplates: () => Promise<void>;
+  saveTemplate: (
+    name: string,
+    prompt: string,
+    defaultModel?: string,
+    defaultProvider?: string,
+  ) => Promise<void>;
+  deleteTemplate: (id: string) => Promise<void>;
+}
+
+export const usePromptTemplateStore = create<PromptTemplateState>((set, get) => ({
+  templates: [],
+  isLoaded: false,
+
+  loadTemplates: async () => {
+    if (get().isLoaded) return;
+    const templates = await getPromptTemplates();
+    set({ templates, isLoaded: true });
+  },
+
+  saveTemplate: async (name, prompt, defaultModel, defaultProvider) => {
+    await savePromptTemplate({ name, prompt, defaultModel, defaultProvider });
+    const templates = await getPromptTemplates();
+    set({ templates });
+  },
+
+  deleteTemplate: async (id) => {
+    await deletePromptTemplate(id);
+    set((state) => ({ templates: state.templates.filter((t) => t.id !== id) }));
+  },
+}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,10 +30,25 @@ export interface TranslationChunk {
   currentDraft?: string;
 }
 
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface PromptTemplate {
+  id: string;
+  name: string;
+  prompt: string;
+  defaultModel?: string;
+  defaultProvider?: string;
+  createdAt: string;
+}
+
 export interface PipelineResult {
   content: string;
   status: 'idle' | 'processing' | 'completed' | 'error';
   error?: string;
+  tokenUsage?: TokenUsage;
 }
 
 export interface JudgeResult extends PipelineResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface PromptTemplate {
   id: string;
   name: string;
   prompt: string;
+  context: 'stage' | 'audit';
   defaultModel?: string;
   defaultProvider?: string;
   createdAt: string;


### PR DESCRIPTION
## Summary

- **Token tracking reale**: estrazione `usage` da tutti e 4 i provider (OpenAI/DeepSeek/Anthropic/Gemini) per streaming stage e judge non-streaming; passato al frontend via evento Tauri e mostrato in `HeaderInfoBar` con conteggio token e costo stimato in USD
- **Libreria template prompt**: salva/carica prompt per nome in ogni stage, lista ricercabile con delete; persistita in SQLite (`prompt_templates` table, upsert su conflitto)
- **StageCard redesign**: textarea auto-grow, bottoni BookmarkPlus/BookOpen per template, stile arrotondato coerente con la dashboard
- **ConfigDrawer più largo** (560px), `PipelineConfig` spacing/tipografia migliorati (font 11px), separatori di sezione
- **Glossario**: card style per ogni voce, campo note visibile, empty state, bottone rimuovi a destra
- `MODEL_PRICING` con 11 combinazioni provider/modello per calcolo costo lato client
- i18n IT+EN: `tokenCount`, `estimatedCost`, `templates.*`, `glossaryEmpty`, `glossaryNotes`

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` → 0 errori ✅
- [ ] Vitest: 68/68 test ✅
- [ ] Avviare pipeline su chunk → HeaderInfoBar mostra token + costo dopo completamento
- [ ] Salvare un prompt come template → appare nella lista di un altro stage
- [ ] Caricare template → textarea del stage si aggiorna
- [ ] Ricerca template → filtra per nome
- [ ] Eliminare template → sparisce dalla lista
- [ ] Riavviare app → template persistiti nel DB
- [ ] Glossario: aggiungere voce con note → note visibili
- [ ] Glossario vuoto → empty state visibile
- [ ] ConfigDrawer: pannello più largo, tipografia più leggibile

🤖 Generated with [Claude Code](https://claude.com/claude-code)