### PR TITLE
fix(judge): resilient JSON parsing for markdown-wrapped LLM responses

### DIFF
--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -1109,7 +1109,15 @@ pub async fn judge_translation(
 
     let sanitized = sanitize_llm_json_output(&result_text);
     let parsed: serde_json::Value = serde_json::from_str(sanitized)
-        .map_err(|e| format!("Failed to parse judge JSON: {e}. Raw: {result_text}"))?;
+        .map_err(|e| {
+            #[cfg(debug_assertions)]
+            {
+                let preview: String = result_text.chars().take(500).collect();
+                let truncated = if result_text.chars().nth(500).is_some() { "…" } else { "" };
+                eprintln!("Failed to parse judge JSON: {e}. Preview: {preview}{truncated}");
+            }
+            format!("Failed to parse judge JSON: {e}")
+        })?;
 
     let rating = parse_judge_rating(&parsed);
     let issues: Vec<JudgeIssue> = parsed["issues"]

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -635,7 +635,7 @@ async fn call_provider_for_judge(
             let body = serde_json::json!({
                 "model": model,
                 "max_tokens": 4096,
-                "system": format!("{system_prompt}\nIMPORTANT: Return ONLY valid JSON."),
+                "system": format!("{system_prompt}\nIMPORTANT: Return ONLY valid JSON, with no markdown formatting, code blocks, or extra text."),
                 "messages": [{"role": "user", "content": user_prompt}]
             });
             let resp = client.post("https://api.anthropic.com/v1/messages")
@@ -1005,6 +1005,15 @@ fn build_judge_prompts(
     (system_prompt, user_prompt)
 }
 
+/// Strips markdown code fences and any preamble text that LLMs sometimes wrap around JSON output.
+fn sanitize_llm_json_output(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    match (trimmed.find('{'), trimmed.rfind('}')) {
+        (Some(start), Some(end)) if end >= start => &trimmed[start..=end],
+        _ => trimmed,
+    }
+}
+
 fn parse_judge_rating(parsed: &serde_json::Value) -> String {
     if let Some(raw) = parsed["rating"].as_str() {
         match raw.trim().to_lowercase().as_str() {
@@ -1098,7 +1107,8 @@ pub async fn judge_translation(
         &system_prompt, &user_prompt, &api_key,
     ).await?;
 
-    let parsed: serde_json::Value = serde_json::from_str(&result_text)
+    let sanitized = sanitize_llm_json_output(&result_text);
+    let parsed: serde_json::Value = serde_json::from_str(sanitized)
         .map_err(|e| format!("Failed to parse judge JSON: {e}. Raw: {result_text}"))?;
 
     let rating = parse_judge_rating(&parsed);
@@ -1380,6 +1390,30 @@ mod tests {
     fn defaults_unknown_judge_rating_to_fair() {
         let parsed = parse_judge_rating(&serde_json::json!({"rating": "ambiguous"}));
         assert_eq!(parsed, "fair");
+    }
+
+    #[test]
+    fn sanitize_clean_json_passthrough() {
+        let s = r#"{"rating":"good","issues":[]}"#;
+        assert_eq!(sanitize_llm_json_output(s), s);
+    }
+
+    #[test]
+    fn sanitize_strips_json_fence() {
+        let s = "```json\n{\"rating\":\"good\"}\n```";
+        assert_eq!(sanitize_llm_json_output(s), r#"{"rating":"good"}"#);
+    }
+
+    #[test]
+    fn sanitize_strips_bare_fence() {
+        let s = "```\n{\"rating\":\"fair\"}\n```";
+        assert_eq!(sanitize_llm_json_output(s), r#"{"rating":"fair"}"#);
+    }
+
+    #[test]
+    fn sanitize_strips_preamble_and_fence() {
+        let s = "Sure! Here is the evaluation:\n```json\n{\"rating\":\"poor\"}\n```\n";
+        assert_eq!(sanitize_llm_json_output(s), r#"{"rating":"poor"}"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `sanitize_llm_json_output()` that strips markdown fences and preamble text by extracting the first `{` … last `}` span from the raw LLM output
- Apply sanitizer in `judge_translation` before `serde_json::from_str` (raw text kept in error message for debugging)
- Strengthen Anthropic system prompt to explicitly forbid markdown/code blocks
- Add 4 unit tests: clean passthrough, ` ```json ` fence, bare ` ``` ` fence, preamble+fence

## Test plan

- [ ] `cargo test sanitize` — 4 new tests pass
- [ ] `cargo test` — full suite green
- [ ] Manual: configure Anthropic o Ollama come judge provider e avviare una valutazione — nessun "Failed to parse judge JSON"

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)