### PR TITLE
feat: model catalog + token cost estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A desktop application that chains multiple LLM passes — draft, refinement, aud
 
 ## How it works
 
-Glossa runs your source text through a **configurable pipeline** of LLM stages, each with its own prompt, model, and provider. An AI judge then audits the final translation against your glossary and instructions, scoring it on accuracy, fluency, glossary adherence, and grammar.
+Glossa runs your source text through a **configurable pipeline** of LLM stages, each with its own prompt, model, and provider. An AI judge then audits the final translation against your glossary and instructions, assigning a semantic quality rating and reporting issues for accuracy, fluency, glossary adherence, and grammar.
 
 ```
 Source text
@@ -29,7 +29,7 @@ Source text
   │     ↓
   ├─► Stage N: (add as many as you need)
   │     ↓
-  └─► AI Judge: audit score + issues + suggested fixes
+  └─► AI Judge: quality rating + issues + suggested fixes
 ```
 
 Translations stream token-by-token in real time. You can edit the candidate translation manually before auditing, re-run only the audit, and iterate until the quality meets your standards.
@@ -41,11 +41,11 @@ Translations stream token-by-token in real time. You can edit the candidate tran
 | **5 LLM providers** | Gemini, OpenAI, Anthropic, DeepSeek, **Ollama** (local models) |
 | **Streaming** | Real-time token display during translation |
 | **Multi-stage pipeline** | Add/remove/reorder stages, each with its own model and prompt |
-| **AI Judge** | LLM-as-a-judge audit with score (0–100), categorized issues, and fixes |
+| **AI Judge** | LLM-as-a-judge audit with semantic quality ratings, categorized issues, and fixes |
 | **Glossary** | Keyword registry enforced across all stages and the audit |
 | **Auto-segmentation** | Splits source text by paragraphs for chunk-by-chunk processing |
 | **Project management** | Save/load projects with full pipeline config and translations |
-| **File I/O** | Import `.txt`/`.md`, export as plain text or bilingual Markdown |
+| **File I/O** | Import `.txt`, `.md`, `.docx`, `.pdf`; export `.txt`, `.md`, `.html`, `.docx`, or bilingual Markdown |
 | **Secure keys** | API keys stored in OS keychain (GNOME Keyring / macOS Keychain / Windows Credential Manager) |
 | **i18n** | English and Italian interface |
 | **Desktop native** | Tauri v2 — lightweight binaries, no browser runtime |
@@ -54,12 +54,37 @@ Translations stream token-by-token in real time. You can edit the candidate tran
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) ≥ 18
-- [Rust](https://rustup.rs/) ≥ 1.77
+- [Node.js](https://nodejs.org/) ≥ 18 (20 LTS recommended)
+- [Rust](https://rust-lang.org/tools/install/) ≥ 1.77.2
 - System libraries for Tauri (Linux only):
   ```bash
-  sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsecret-1-dev
+  sudo apt update
+  sudo apt install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
+    libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev \
+    libgtk-3-dev libsecret-1-dev
   ```
+
+### Install Rust
+
+Linux, macOS, or WSL:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+rustc --version
+cargo --version
+```
+
+Windows:
+
+1. Install Microsoft Visual Studio C++ Build Tools with **Desktop development with C++**.
+2. Install Rust with `winget install --id Rustlang.Rustup` or download `rustup-init.exe` from [rust-lang.org/tools/install](https://rust-lang.org/tools/install/).
+3. Use the MSVC toolchain:
+   ```powershell
+   rustup default stable-msvc
+   rustc --version
+   cargo --version
+   ```
 
 ### Install & run
 
@@ -78,6 +103,16 @@ npm run tauri:build
 
 Outputs `.deb`, `.rpm`, and `.AppImage` on Linux; `.dmg` on macOS; `.msi` on Windows.  
 Bundles are in `src-tauri/target/release/bundle/`.
+
+### Development checks
+
+```bash
+npm run lint
+npm test
+npm run build
+cd src-tauri
+cargo test
+```
 
 ### Verify release downloads
 
@@ -143,22 +178,22 @@ In the center panel (**Production Stream**):
 2. Click **"Stage Content to Stream"** to segment the text
 3. Click **"Begin Pipeline"** — tokens stream in real time for each stage
 4. Review the candidate translation, edit it manually if needed
-5. The AI Judge automatically scores the result
+5. The AI Judge automatically rates the result
 
 ### 3. Review the audit
 
 In the right panel (**Audit Logs**):
 
-- **Composite score** (0–100) across all chunks
+- **Composite quality rating** across all completed chunks
 - **Issues** categorized by type (glossary, fluency, accuracy, grammar) and severity
 - **Suggested fixes** for each issue
-- Click **"Re-Evaluate Drafts"** after manual edits to get an updated score
+- Click **"Re-Evaluate Drafts"** after manual edits to get an updated quality rating
 
 ### 4. Projects and files
 
 - **📂 Projects**: Save your entire pipeline config + translations. Reload anytime.
-- **⬆ Import**: Load `.txt` or `.md` files via native OS dialog
-- **⬇ Export**: Save as plain `.txt` (translation only) or bilingual `.md` (source + translation + audit)
+- **⬆ Import**: Load `.txt`, `.md`, `.docx`, or `.pdf` files via native OS dialog
+- **⬇ Export**: Save as `.txt`, `.md`, `.html`, `.docx`, or bilingual `.md` (source + translation + audit)
 - **💾 Save**: Persist the current project state to SQLite
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "tauri": "tauri",
-    "tauri:dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 tauri dev",
+    "tauri:dev": "tauri dev",
+    "tauri:dev:linux": "WEBKIT_DISABLE_DMABUF_RENDERER=1 tauri dev",
     "tauri:build": "tauri build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 tauri dev",
     "tauri:build": "tauri build"
   },
   "dependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "keyring",
  "log",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ export default function App() {
             <DocumentView
               onRetranslateChunk={runSingleChunk}
               onReauditChunk={auditSingleChunk}
+              onRunPipeline={runPipeline}
+              onCancelPipeline={cancelPipeline}
             />
             <InsightsDrawer onReauditChunk={auditSingleChunk} />
           </main>

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -5,20 +5,25 @@ import {
   Columns2,
   Copy,
   Highlighter,
+  Info,
+  Loader2,
   Lock,
   Pencil,
   PanelLeft,
   PanelRight,
+  Play,
   RotateCcw,
   ScanLine,
   Scissors,
+  Square,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useDeferredValue, useEffect, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
+import { usePricingStore } from '../../stores/pricingStore';
 import { confirm } from '../../stores/confirmStore';
 import type { TranslationChunk } from '../../types';
 import {
@@ -28,13 +33,17 @@ import {
   qualityTone,
 } from '../../utils';
 import { buildSplitPreview } from '../../utils/documentWorkflow';
+import { estimatePipelineCost } from '../../utils/costEstimate';
 import { CopyButton, MarkdownEditor, ProcessingLine } from '../common';
+import { CostBreakdownPanel } from '../pipeline/CostBadge';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useGlossaryHighlight } from '../../hooks/useGlossaryHighlight';
 
 interface DocumentViewProps {
   onRetranslateChunk: (chunkId: string) => void;
   onReauditChunk: (chunkId: string) => void;
+  onRunPipeline?: () => void;
+  onCancelPipeline?: () => void;
 }
 
 const QUALITY_TONE_COLOR: Record<ReturnType<typeof qualityTone>, string> = {
@@ -46,12 +55,16 @@ const QUALITY_TONE_COLOR: Record<ReturnType<typeof qualityTone>, string> = {
 export function DocumentView({
   onRetranslateChunk,
   onReauditChunk,
+  onRunPipeline,
+  onCancelPipeline,
 }: DocumentViewProps) {
   const { t } = useTranslation();
   const { config } = usePipelineStore();
+  const pricingOverrides = usePricingStore((s) => s.overrides);
   const {
     chunks,
     isProcessing,
+    cancelRequested,
     updateChunkDraft,
     updateChunkOriginalText,
     toggleChunkTranslationLock,
@@ -77,6 +90,12 @@ export function DocumentView({
   const [splitDraft, setSplitDraft] = useState<{ chunkId: string; splitAt: number } | null>(null);
   const [paneFocus, setPaneFocus] = useState<'both' | 'source' | 'translation'>('both');
   const [traceStageId, setTraceStageId] = useState<string | null>(null);
+  const [showCostPanel, setShowCostPanel] = useState(false);
+
+  const costEstimate = useMemo(
+    () => estimatePipelineCost(chunks, config, pricingOverrides),
+    [chunks, config, pricingOverrides],
+  );
 
   useEffect(() => {
     const onResize = () => setViewportWidth(window.innerWidth);
@@ -167,7 +186,77 @@ export function DocumentView({
   return (
     <section className="w-full bg-[#f7f3ec] overflow-y-auto min-h-0 h-full custom-scrollbar">
       <div className="mx-auto max-w-[1720px] px-5 py-4 md:px-6 md:py-5 space-y-5">
-        <div className="rounded-[22px] border border-editorial-border bg-editorial-bg/90 px-5 py-3 shadow-[0_16px_50px_rgba(26,26,26,0.05)]">
+        <div className="flex items-center gap-2">
+          {/* Run button: cerchio con stesso stile della navbar, si fonde con essa */}
+          {onRunPipeline && onCancelPipeline && (
+            <div className="relative flex h-[80px] w-[80px] flex-shrink-0 items-center justify-center rounded-full border border-editorial-border bg-editorial-bg/90 shadow-[0_16px_50px_rgba(26,26,26,0.05)]">
+              {isProcessing ? (
+                cancelRequested ? (
+                  <button
+                    type="button"
+                    disabled
+                    title={t('pipeline.stopping')}
+                    aria-label={t('pipeline.stopping')}
+                    className="flex h-[64px] w-[64px] items-center justify-center rounded-full border border-editorial-border bg-editorial-bg text-editorial-muted opacity-50 focus:outline-none"
+                  >
+                    <Loader2 size={24} className="animate-spin" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={onCancelPipeline}
+                    title={t('pipeline.stopPipeline')}
+                    aria-label={t('pipeline.stopPipeline')}
+                    className="flex h-[64px] w-[64px] items-center justify-center rounded-full border border-editorial-accent bg-editorial-bg text-editorial-accent transition-colors hover:bg-editorial-accent/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  >
+                    <Square size={22} fill="currentColor" />
+                  </button>
+                )
+              ) : (
+                <button
+                  type="button"
+                  onClick={onRunPipeline}
+                  title={t('pipeline.beginPipeline')}
+                  aria-label={t('pipeline.beginPipeline')}
+                  className="flex h-[64px] w-[64px] items-center justify-center rounded-full bg-editorial-ink text-white transition-colors hover:bg-editorial-ink/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                >
+                  <Play size={26} fill="currentColor" />
+                </button>
+              )}
+
+              {/* Cost info dot — più grande, angolo basso-sinistra esterno al cerchio */}
+              {costEstimate.stages.length > 0 && (
+                <div
+                  className="absolute -bottom-1.5 -left-1.5"
+                  onMouseEnter={() => setShowCostPanel(true)}
+                  onMouseLeave={() => setShowCostPanel(false)}
+                >
+                  <button
+                    type="button"
+                    onFocus={() => setShowCostPanel(true)}
+                    onBlur={() => setShowCostPanel(false)}
+                    aria-label={t('cost.breakdown')}
+                    className="flex h-[22px] w-[22px] items-center justify-center rounded-full border border-editorial-border bg-editorial-bg text-editorial-muted transition-colors hover:border-editorial-ink hover:text-editorial-ink focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                  >
+                    <Info size={11} />
+                  </button>
+                </div>
+              )}
+              {/* Popup costi: ancorato al cerchio (top-full = sotto la riga), non all'info dot */}
+              {showCostPanel && costEstimate.stages.length > 0 && (
+                <div
+                  className="absolute left-0 top-full z-50 mt-3 w-64"
+                  onMouseEnter={() => setShowCostPanel(true)}
+                  onMouseLeave={() => setShowCostPanel(false)}
+                >
+                  <CostBreakdownPanel estimate={costEstimate} />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Navigation bar */}
+          <div className="flex-1 rounded-[22px] border border-editorial-border bg-editorial-bg/90 px-5 py-3 shadow-[0_16px_50px_rgba(26,26,26,0.05)]">
           <div className="flex flex-wrap items-center justify-between gap-3">
             {/* Info + status indicators — tutto su una riga */}
             <div className="flex flex-wrap items-center gap-2.5 min-w-0">
@@ -332,6 +421,7 @@ export function DocumentView({
                 </ChunkIconButton>
               )}
             </div>
+          </div>
           </div>
         </div>
 

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -20,12 +20,15 @@ import {
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
-import { type KeyboardEvent, useRef } from 'react';
+import { type KeyboardEvent, useMemo, useRef } from 'react';
 import { useUiStore } from '../../stores/uiStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { usePipelineStore } from '../../stores/pipelineStore';
+import { usePricingStore } from '../../stores/pricingStore';
 import { indexPad, qualityLabelKey, qualityTone, calculateCompositeQuality } from '../../utils';
 import { MODEL_PRICING } from '../../constants';
+import { estimatePipelineCost } from '../../utils/costEstimate';
+import { formatCost } from '../pipeline/CostBadge';
 import type { TranslationChunk } from '../../types';
 
 interface InsightsDrawerProps {
@@ -400,6 +403,11 @@ interface StatsTabProps {
 function StatsTab({ panelId, labelledBy, chunks }: StatsTabProps) {
   const { t } = useTranslation();
   const config = usePipelineStore((state) => state.config);
+  const pricingOverrides = usePricingStore((s) => s.overrides);
+  const costEstimate = useMemo(
+    () => estimatePipelineCost(chunks, config, pricingOverrides),
+    [chunks, config, pricingOverrides],
+  );
 
   // Documento
   const sourceWords = chunks.reduce((acc, chunk) => acc + countWords(chunk.originalText), 0);
@@ -562,21 +570,31 @@ function StatsTab({ panelId, labelledBy, chunks }: StatsTabProps) {
         <dl className="space-y-2">
           <StatRow
             label={t('header.tokenCount')}
-            value={totalTokens > 0 ? totalTokens.toLocaleString() : '—'}
+            value={totalTokens > 0 ? totalTokens.toLocaleString() : (() => {
+              const est = [
+                ...costEstimate.stages,
+                ...(costEstimate.judge ? [costEstimate.judge] : []),
+              ].reduce((s, r) => s + r.inputTokens + r.outputTokens, 0);
+              return est > 0 ? `~${est.toLocaleString()}` : '—';
+            })()}
           />
-          {totalTokens > 0 && (
-            <>
-              <div className="flex items-baseline gap-1 pl-3">
-                <dt className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-muted/60">in</dt>
-                <dd className="font-display text-sm italic text-editorial-muted">{totalInput.toLocaleString()}</dd>
-                <dt className="ml-2 text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-muted/60">out</dt>
-                <dd className="font-display text-sm italic text-editorial-muted">{totalOutput.toLocaleString()}</dd>
-              </div>
-            </>
-          )}
+          {totalTokens > 0 ? (
+            <div className="flex items-baseline gap-1 pl-3">
+              <dt className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-muted/60">in</dt>
+              <dd className="font-display text-sm italic text-editorial-muted">{totalInput.toLocaleString()}</dd>
+              <dt className="ml-2 text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-muted/60">out</dt>
+              <dd className="font-display text-sm italic text-editorial-muted">{totalOutput.toLocaleString()}</dd>
+            </div>
+          ) : null}
           <StatRow
             label={t('header.estimatedCost')}
-            value={totalTokens > 0 ? `$${estimatedCostUsd.toFixed(4)}` : '—'}
+            value={totalTokens > 0
+              ? `$${estimatedCostUsd.toFixed(4)}`
+              : costEstimate.isFree
+                ? t('cost.free')
+                : costEstimate.totalUsd === null
+                  ? t('cost.unknown')
+                  : `~${formatCost(costEstimate.totalUsd)}`}
           />
         </dl>
         {modelNames.size > 0 && (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,14 +14,12 @@ import {
   LayoutTemplate,
   LibraryBig,
   Loader2,
-  Play,
   Save,
   Settings,
   SlidersHorizontal,
-  Square,
   Upload,
 } from 'lucide-react';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePipelineStore } from '../../stores/pipelineStore';
@@ -33,9 +31,6 @@ import { ImportPreviewDialog } from '../document';
 import { SaveProjectDialog } from '../projects';
 import { importTextFile, exportTranslation, exportBilingual } from '../../services/fileService';
 import { HelpGuide } from '../help';
-import { CostBadge } from '../pipeline/CostBadge';
-import { estimatePipelineCost } from '../../utils/costEstimate';
-import { usePricingStore } from '../../stores/pricingStore';
 
 interface PendingImport {
   fileName: string;
@@ -53,7 +48,7 @@ interface HeaderProps {
 
 export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
   const { config, setConfig } = usePipelineStore();
-  const { chunks, isProcessing, cancelRequested, loadDocument } = useChunksStore();
+  const { chunks, isProcessing, loadDocument } = useChunksStore();
   const {
     setShowSettings,
     setShowHelp,
@@ -71,11 +66,6 @@ export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
     saveState,
   } = useProjectStore();
   const setShowLibraryPanel = useLibraryStore((state) => state.setShowLibraryPanel);
-  const pricingOverrides = usePricingStore((s) => s.overrides);
-  const costEstimate = useMemo(
-    () => estimatePipelineCost(chunks, config, pricingOverrides),
-    [chunks, config, pricingOverrides],
-  );
   const { t, i18n } = useTranslation();
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
   const [showSaveProjectDialog, setShowSaveProjectDialog] = useState(false);
@@ -190,10 +180,6 @@ export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
             ? t('projects.statusSaved')
             : t('projects.statusDraft');
 
-  const runLabel = t('pipeline.beginPipeline');
-  const stopLabel = t('pipeline.stopPipeline');
-  const stoppingLabel = t('pipeline.stopping');
-
   return (
     <header className="border-b border-editorial-border bg-[linear-gradient(180deg,#fffdf8_0%,#f8f3ea_100%)] px-6 py-5 md:px-10">
       <div className="flex flex-col gap-5">
@@ -251,49 +237,6 @@ export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
                   )}
                 </div>
               </ActionCluster>
-            )}
-
-            {/* Pulsante Run/Stop pipeline – visibile solo in modalità documento */}
-            {viewMode === 'document' && onRunPipeline && onCancelPipeline && (
-              isProcessing ? (
-                cancelRequested ? (
-                  <button
-                    type="button"
-                    disabled
-                    title={stoppingLabel}
-                    aria-label={stoppingLabel}
-                    className="rounded-full border border-editorial-border p-3 text-editorial-muted opacity-50 focus:outline-none"
-                  >
-                    <Loader2 size={18} className="animate-spin" />
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={onCancelPipeline}
-                    title={stopLabel}
-                    aria-label={stopLabel}
-                    className="rounded-full border border-editorial-accent p-3 text-editorial-accent transition-colors hover:bg-editorial-accent/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                  >
-                    <Square size={16} fill="currentColor" />
-                  </button>
-                )
-              ) : (
-                <button
-                  type="button"
-                  onClick={onRunPipeline}
-                  title={runLabel}
-                  aria-label={runLabel}
-                  disabled={chunks.length === 0}
-                  className="rounded-full bg-editorial-ink p-3 text-white transition-colors hover:bg-editorial-ink/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40"
-                >
-                  <Play size={18} fill="currentColor" />
-                </button>
-              )
-            )}
-
-            {/* Cost estimate badge – visibile in modalità documento con chunk */}
-            {viewMode === 'document' && chunks.length > 0 && (
-              <CostBadge estimate={costEstimate} />
             )}
 
             {/* Sandbox – solo icona */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ import {
   Square,
   Upload,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { usePipelineStore } from '../../stores/pipelineStore';
@@ -33,6 +33,9 @@ import { ImportPreviewDialog } from '../document';
 import { SaveProjectDialog } from '../projects';
 import { importTextFile, exportTranslation, exportBilingual } from '../../services/fileService';
 import { HelpGuide } from '../help';
+import { CostBadge } from '../pipeline/CostBadge';
+import { estimatePipelineCost } from '../../utils/costEstimate';
+import { usePricingStore } from '../../stores/pricingStore';
 
 interface PendingImport {
   fileName: string;
@@ -68,6 +71,11 @@ export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
     saveState,
   } = useProjectStore();
   const setShowLibraryPanel = useLibraryStore((state) => state.setShowLibraryPanel);
+  const pricingOverrides = usePricingStore((s) => s.overrides);
+  const costEstimate = useMemo(
+    () => estimatePipelineCost(chunks, config, pricingOverrides),
+    [chunks, config, pricingOverrides],
+  );
   const { t, i18n } = useTranslation();
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
   const [showSaveProjectDialog, setShowSaveProjectDialog] = useState(false);
@@ -281,6 +289,11 @@ export function Header({ onRunPipeline, onCancelPipeline }: HeaderProps = {}) {
                   <Play size={18} fill="currentColor" />
                 </button>
               )
+            )}
+
+            {/* Cost estimate badge – visibile in modalità documento con chunk */}
+            {viewMode === 'document' && chunks.length > 0 && (
+              <CostBadge estimate={costEstimate} />
             )}
 
             {/* Sandbox – solo icona */}

--- a/src/components/pipeline/CostBadge.tsx
+++ b/src/components/pipeline/CostBadge.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { PipelineCostEstimate } from '../../utils/costEstimate';
+
+function formatCost(usd: number): string {
+  if (usd === 0) return '$0.00';
+  if (usd < 0.01) return `~$${usd.toFixed(4)}`;
+  return `~$${usd.toFixed(2)}`;
+}
+
+interface CostBadgeProps {
+  estimate: PipelineCostEstimate;
+}
+
+export function CostBadge({ estimate }: CostBadgeProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  if (estimate.stages.length === 0) return null;
+
+  const label = estimate.isFree
+    ? t('cost.free')
+    : estimate.totalUsd === null
+      ? t('cost.unknown')
+      : formatCost(estimate.totalUsd);
+
+  const allRows = estimate.judge ? [...estimate.stages, estimate.judge] : estimate.stages;
+
+  return (
+    <div className="relative inline-flex items-center">
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        aria-label={`${t('header.estimatedCost')}: ${label}`}
+        className="inline-flex items-center gap-1 rounded-full border border-editorial-border/70 bg-editorial-textbox/40 px-2.5 py-1 text-[10px] font-mono text-editorial-muted transition-colors hover:border-editorial-ink hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+      >
+        {estimate.isFree && <Sparkles size={10} />}
+        {label}
+      </button>
+
+      {open && allRows.length > 0 && (
+        <div
+          className="absolute bottom-full left-0 z-50 mb-2 w-64 rounded border border-editorial-border bg-editorial-bg shadow-lg"
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+        >
+          <div className="p-3 space-y-2">
+            <p className="text-[9px] font-bold uppercase tracking-widest text-editorial-muted">
+              {t('cost.breakdown')}
+            </p>
+            <table className="w-full text-[10px] font-mono">
+              <thead>
+                <tr className="text-editorial-muted/70">
+                  <th className="text-left pb-1">{t('cost.stage')}</th>
+                  <th className="text-right pb-1">{t('header.tokenCount')}</th>
+                  <th className="text-right pb-1">{t('header.estimatedCost')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allRows.map((row) => (
+                  <tr key={row.stageId} className="border-t border-editorial-border/40">
+                    <td className="py-1 pr-2 truncate max-w-[90px]">{row.stageName}</td>
+                    <td className="py-1 text-right text-editorial-muted">
+                      {(row.inputTokens + row.outputTokens).toLocaleString()}
+                    </td>
+                    <td className="py-1 text-right">
+                      {row.provider === 'ollama'
+                        ? <span className="text-editorial-muted">{t('cost.free')}</span>
+                        : row.costUsd === null
+                          ? <span className="text-editorial-muted">{t('cost.unknown')}</span>
+                          : formatCost(row.costUsd)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              {!estimate.isFree && (
+                <tfoot>
+                  <tr className="border-t border-editorial-ink/20 font-bold">
+                    <td className="pt-1" colSpan={2}>{t('cost.total')}</td>
+                    <td className="pt-1 text-right">
+                      {estimate.totalUsd === null ? t('cost.unknown') : formatCost(estimate.totalUsd)}
+                    </td>
+                  </tr>
+                </tfoot>
+              )}
+            </table>
+            <p className="text-[9px] text-editorial-muted/60 italic">{t('cost.disclaimer')}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pipeline/CostBadge.tsx
+++ b/src/components/pipeline/CostBadge.tsx
@@ -3,7 +3,7 @@ import { Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { PipelineCostEstimate } from '../../utils/costEstimate';
 
-function formatCost(usd: number): string {
+export function formatCost(usd: number): string {
   if (usd === 0) return '$0.00';
   if (usd < 0.01) return `~$${usd.toFixed(4)}`;
   return `~$${usd.toFixed(2)}`;
@@ -14,6 +14,60 @@ interface CostBadgeProps {
 }
 
 const TOOLTIP_ID = 'cost-badge-tooltip';
+
+export function CostBreakdownPanel({ estimate }: { estimate: PipelineCostEstimate }) {
+  const { t } = useTranslation();
+  const allRows = estimate.judge ? [...estimate.stages, estimate.judge] : estimate.stages;
+
+  if (allRows.length === 0) return null;
+
+  return (
+    <div className="rounded border border-editorial-border bg-editorial-bg shadow-lg">
+      <div className="p-3 space-y-2">
+        <p className="text-[9px] font-bold uppercase tracking-widest text-editorial-muted">
+          {t('cost.breakdown')}
+        </p>
+        <table className="w-full text-[10px] font-mono">
+          <thead>
+            <tr className="text-editorial-muted/70">
+              <th className="text-left pb-1">{t('cost.stage')}</th>
+              <th className="text-right pb-1">{t('header.tokenCount')}</th>
+              <th className="text-right pb-1">{t('header.estimatedCost')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {allRows.map((row) => (
+              <tr key={row.stageId} className="border-t border-editorial-border/40">
+                <td className="py-1 pr-2 truncate max-w-[90px]">{row.stageName}</td>
+                <td className="py-1 text-right text-editorial-muted">
+                  {(row.inputTokens + row.outputTokens).toLocaleString()}
+                </td>
+                <td className="py-1 text-right">
+                  {row.provider === 'ollama'
+                    ? <span className="text-editorial-muted">{t('cost.free')}</span>
+                    : row.costUsd === null
+                      ? <span className="text-editorial-muted">{t('cost.unknown')}</span>
+                      : formatCost(row.costUsd)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          {!estimate.isFree && (
+            <tfoot>
+              <tr className="border-t border-editorial-ink/20 font-bold">
+                <td className="pt-1" colSpan={2}>{t('cost.total')}</td>
+                <td className="pt-1 text-right">
+                  {estimate.totalUsd === null ? t('cost.unknown') : formatCost(estimate.totalUsd)}
+                </td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+        <p className="text-[9px] text-editorial-muted/60 italic">{t('cost.disclaimer')}</p>
+      </div>
+    </div>
+  );
+}
 
 export function CostBadge({ estimate }: CostBadgeProps) {
   const { t } = useTranslation();
@@ -26,8 +80,6 @@ export function CostBadge({ estimate }: CostBadgeProps) {
     : estimate.totalUsd === null
       ? t('cost.unknown')
       : formatCost(estimate.totalUsd);
-
-  const allRows = estimate.judge ? [...estimate.stages, estimate.judge] : estimate.stages;
 
   return (
     <div className="relative inline-flex items-center">
@@ -45,60 +97,15 @@ export function CostBadge({ estimate }: CostBadgeProps) {
         {label}
       </button>
 
-      {open && allRows.length > 0 && (
+      {open && (
         <div
+          id={TOOLTIP_ID}
+          role="tooltip"
           className="absolute bottom-full left-0 z-50 w-64 pb-2"
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
         >
-          <div
-            id={TOOLTIP_ID}
-            role="tooltip"
-            className="rounded border border-editorial-border bg-editorial-bg shadow-lg"
-          >
-            <div className="p-3 space-y-2">
-            <p className="text-[9px] font-bold uppercase tracking-widest text-editorial-muted">
-              {t('cost.breakdown')}
-            </p>
-            <table className="w-full text-[10px] font-mono">
-              <thead>
-                <tr className="text-editorial-muted/70">
-                  <th className="text-left pb-1">{t('cost.stage')}</th>
-                  <th className="text-right pb-1">{t('header.tokenCount')}</th>
-                  <th className="text-right pb-1">{t('header.estimatedCost')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {allRows.map((row) => (
-                  <tr key={row.stageId} className="border-t border-editorial-border/40">
-                    <td className="py-1 pr-2 truncate max-w-[90px]">{row.stageName}</td>
-                    <td className="py-1 text-right text-editorial-muted">
-                      {(row.inputTokens + row.outputTokens).toLocaleString()}
-                    </td>
-                    <td className="py-1 text-right">
-                      {row.provider === 'ollama'
-                        ? <span className="text-editorial-muted">{t('cost.free')}</span>
-                        : row.costUsd === null
-                          ? <span className="text-editorial-muted">{t('cost.unknown')}</span>
-                          : formatCost(row.costUsd)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              {!estimate.isFree && (
-                <tfoot>
-                  <tr className="border-t border-editorial-ink/20 font-bold">
-                    <td className="pt-1" colSpan={2}>{t('cost.total')}</td>
-                    <td className="pt-1 text-right">
-                      {estimate.totalUsd === null ? t('cost.unknown') : formatCost(estimate.totalUsd)}
-                    </td>
-                  </tr>
-                </tfoot>
-              )}
-            </table>
-            <p className="text-[9px] text-editorial-muted/60 italic">{t('cost.disclaimer')}</p>
-            </div>
-          </div>
+          <CostBreakdownPanel estimate={estimate} />
         </div>
       )}
     </div>

--- a/src/components/pipeline/CostBadge.tsx
+++ b/src/components/pipeline/CostBadge.tsx
@@ -13,6 +13,8 @@ interface CostBadgeProps {
   estimate: PipelineCostEstimate;
 }
 
+const TOOLTIP_ID = 'cost-badge-tooltip';
+
 export function CostBadge({ estimate }: CostBadgeProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -36,6 +38,7 @@ export function CostBadge({ estimate }: CostBadgeProps) {
         onFocus={() => setOpen(true)}
         onBlur={() => setOpen(false)}
         aria-label={`${t('header.estimatedCost')}: ${label}`}
+        aria-describedby={open ? TOOLTIP_ID : undefined}
         className="inline-flex items-center gap-1 rounded-full border border-editorial-border/70 bg-editorial-textbox/40 px-2.5 py-1 text-[10px] font-mono text-editorial-muted transition-colors hover:border-editorial-ink hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
       >
         {estimate.isFree && <Sparkles size={10} />}
@@ -44,11 +47,16 @@ export function CostBadge({ estimate }: CostBadgeProps) {
 
       {open && allRows.length > 0 && (
         <div
-          className="absolute bottom-full left-0 z-50 mb-2 w-64 rounded border border-editorial-border bg-editorial-bg shadow-lg"
+          className="absolute bottom-full left-0 z-50 w-64 pb-2"
           onMouseEnter={() => setOpen(true)}
           onMouseLeave={() => setOpen(false)}
         >
-          <div className="p-3 space-y-2">
+          <div
+            id={TOOLTIP_ID}
+            role="tooltip"
+            className="rounded border border-editorial-border bg-editorial-bg shadow-lg"
+          >
+            <div className="p-3 space-y-2">
             <p className="text-[9px] font-bold uppercase tracking-widest text-editorial-muted">
               {t('cost.breakdown')}
             </p>
@@ -89,6 +97,7 @@ export function CostBadge({ estimate }: CostBadgeProps) {
               )}
             </table>
             <p className="text-[9px] text-editorial-muted/60 italic">{t('cost.disclaimer')}</p>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/pipeline/CostBadge.tsx
+++ b/src/components/pipeline/CostBadge.tsx
@@ -17,7 +17,7 @@ export function CostBadge({ estimate }: CostBadgeProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
-  if (estimate.stages.length === 0) return null;
+  if (estimate.stages.length === 0 && estimate.judge === null) return null;
 
   const label = estimate.isFree
     ? t('cost.free')

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -4,11 +4,15 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { ModelProvider } from '../../types';
 import { MODEL_OPTIONS, LANGUAGES } from '../../constants';
+import { getModelStatus } from '../../models/catalog';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
 import { StageCard } from './StageCard';
+import { CostBadge } from './CostBadge';
+import { estimatePipelineCost } from '../../utils/costEstimate';
+import { usePricingStore } from '../../stores/pricingStore';
 import { llmService } from '../../services/llmService';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 
@@ -125,6 +129,12 @@ export function PipelineConfig({
 
   const judgeOllamaOffline =
     config.judgeProvider === 'ollama' && ollamaStatus === 'disconnected';
+
+  const pricingOverrides = usePricingStore((s) => s.overrides);
+  const costEstimate = useMemo(
+    () => estimatePipelineCost(chunks, config, pricingOverrides),
+    [chunks, config, pricingOverrides],
+  );
 
   const duplicateTermIds = useMemo(() => {
     const seen = new Map<string, string>();
@@ -306,7 +316,9 @@ export function PipelineConfig({
                     className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
                   >
                     {judgeModels.map((m) => (
-                      <option key={m} value={m}>{m}</option>
+                      <option key={m} value={m}>
+                        {m}{getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}
+                      </option>
                     ))}
                   </select>
                 ) : config.judgeProvider === 'ollama' ? (
@@ -323,7 +335,9 @@ export function PipelineConfig({
                     className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none"
                   >
                     {MODEL_OPTIONS[config.judgeProvider]?.map((m) => (
-                      <option key={m} value={m}>{m}</option>
+                      <option key={m} value={m}>
+                        {m}{getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}
+                      </option>
                     ))}
                   </select>
                 )}
@@ -549,6 +563,7 @@ export function PipelineConfig({
 
       {showActions && (
         <div className="mt-10 flex flex-col gap-3 shrink-0">
+          <CostBadge estimate={costEstimate} />
           <button
             type="button"
             onClick={onRunPipeline}

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { PipelineStageConfig, ModelProvider } from '../../types';
 import { MODEL_OPTIONS } from '../../constants';
+import { getModelStatus } from '../../models/catalog';
 import { useUiStore } from '../../stores/uiStore';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { confirm } from '../../stores/confirmStore';
@@ -202,7 +203,9 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {modelOptions.map((m) => (
-                  <option key={m} value={m}>{m}</option>
+                  <option key={m} value={m}>
+                    {m}{getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
+                  </option>
                 ))}
               </select>
             ) : stage.provider === 'ollama' ? (
@@ -219,7 +222,9 @@ export function StageCard({ stage, index, onUpdate, onRemove }: StageCardProps) 
                 className="flex-1 bg-editorial-textbox/60 rounded border border-editorial-border/60 px-2 py-1.5 text-[11px] font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {MODEL_OPTIONS[stage.provider]?.map((m) => (
-                  <option key={m} value={m}>{m}</option>
+                  <option key={m} value={m}>
+                    {m}{getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
+                  </option>
                 ))}
               </select>
             )}

--- a/src/components/pipeline/index.ts
+++ b/src/components/pipeline/index.ts
@@ -2,3 +2,4 @@ export { PipelineConfig } from './PipelineConfig';
 export { ProductionStream } from './ProductionStream';
 export { StageCard } from './StageCard';
 export { PipelineActions } from './PipelineActions';
+export { CostBadge } from './CostBadge';

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { X, AlertCircle, Server, RefreshCw, CheckCircle2, XCircle, HelpCircle, Sparkles, Columns2, BookOpen } from 'lucide-react';
+import { X, AlertCircle, Server, RefreshCw, CheckCircle2, XCircle, HelpCircle, Sparkles, Columns2, BookOpen, ChevronDown, ChevronUp } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -7,6 +7,9 @@ import { useUiStore } from '../../stores/uiStore';
 import { ApiKeyInput } from './ApiKeyInput';
 import { ollamaService } from '../../services/llmService';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { MODEL_CATALOG } from '../../models/catalog';
+import { MODEL_PRICING } from '../../constants';
+import { usePricingStore } from '../../stores/pricingStore';
 
 export function SettingsModal() {
   const {
@@ -21,7 +24,9 @@ export function SettingsModal() {
   } = useUiStore();
   const { t } = useTranslation();
   const [refreshing, setRefreshing] = useState(false);
+  const [showPricingOverrides, setShowPricingOverrides] = useState(false);
   const trapRef = useFocusTrap(showSettings, () => setShowSettings(false));
+  const { overrides, setOverride, resetOverride, resetAll } = usePricingStore();
 
   const refreshOllama = async () => {
     setRefreshing(true);
@@ -169,6 +174,94 @@ export function SettingsModal() {
                     </p>
                   )}
                 </div>
+              </div>
+
+              {/* Pricing Overrides */}
+              <div className="space-y-4">
+                <button
+                  type="button"
+                  onClick={() => setShowPricingOverrides(!showPricingOverrides)}
+                  className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  aria-expanded={showPricingOverrides}
+                >
+                  {showPricingOverrides ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                  {t('cost.pricingOverrides')}
+                </button>
+                {showPricingOverrides && (
+                  <div className="space-y-3">
+                    <p className="text-[10px] text-editorial-muted italic">{t('cost.overrideHint')}</p>
+                    <div className="border border-editorial-border overflow-x-auto">
+                      <table className="w-full text-[11px] font-mono">
+                        <thead>
+                          <tr className="border-b border-editorial-border bg-editorial-textbox/30">
+                            <th className="text-left px-3 py-2 font-bold uppercase tracking-widest text-editorial-muted">Model</th>
+                            <th className="text-right px-3 py-2 font-bold uppercase tracking-widest text-editorial-muted">Input $/1M</th>
+                            <th className="text-right px-3 py-2 font-bold uppercase tracking-widest text-editorial-muted">Output $/1M</th>
+                            <th className="px-3 py-2" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {MODEL_CATALOG.filter((e) => e.pricing).map((entry) => {
+                            const key = `${entry.provider}/${entry.id}`;
+                            const current = overrides[key] ?? MODEL_PRICING[key] ?? entry.pricing!;
+                            const isOverridden = !!overrides[key];
+                            return (
+                              <tr key={key} className="border-t border-editorial-border/40 hover:bg-editorial-textbox/20">
+                                <td className="px-3 py-2">
+                                  <span className={isOverridden ? 'text-editorial-ink font-bold' : 'text-editorial-muted'}>
+                                    {entry.provider}/{entry.id}
+                                  </span>
+                                </td>
+                                <td className="px-3 py-2 text-right">
+                                  <input
+                                    type="number"
+                                    step="0.001"
+                                    min="0"
+                                    value={current.input}
+                                    onChange={(e) => setOverride(key, { ...current, input: parseFloat(e.target.value) || 0 })}
+                                    className="w-20 bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-right outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                                  />
+                                </td>
+                                <td className="px-3 py-2 text-right">
+                                  <input
+                                    type="number"
+                                    step="0.001"
+                                    min="0"
+                                    value={current.output}
+                                    onChange={(e) => setOverride(key, { ...current, output: parseFloat(e.target.value) || 0 })}
+                                    className="w-20 bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-right outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                                  />
+                                </td>
+                                <td className="px-3 py-2 text-center">
+                                  {isOverridden && (
+                                    <button
+                                      type="button"
+                                      onClick={() => resetOverride(key)}
+                                      className="text-[9px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
+                                    >
+                                      {t('cost.resetOverride')}
+                                    </button>
+                                  )}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                    {Object.keys(overrides).length > 0 && (
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={resetAll}
+                          className="text-[10px] font-bold uppercase tracking-widest text-editorial-accent hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                        >
+                          {t('cost.resetAll')}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
 
               <div className="p-8 border border-editorial-border bg-editorial-textbox/20 flex gap-4 items-start">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import type { PipelineStageConfig, ModelProvider } from './types';
+import { MODEL_CATALOG } from './models/catalog';
 
 export const DEFAULT_STAGES: PipelineStageConfig[] = [
   {
@@ -30,20 +31,12 @@ export const MODEL_OPTIONS: Record<ModelProvider, string[]> = {
   ollama: [], // Dynamic — populated at runtime from local Ollama instance
 };
 
-// Prezzi in USD per 1M token (input/output). Aggiornare periodicamente.
-export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  'gemini/gemini-2.5-flash-preview':    { input: 0.15,  output: 0.60  },
-  'gemini/gemini-3-flash-preview':      { input: 0.075, output: 0.30  },
-  'gemini/gemini-3.1-pro-preview':      { input: 1.25,  output: 5.00  },
-  'gemini/gemini-2.5-flash-lite-preview': { input: 0.10, output: 0.40 },
-  'openai/gpt-4o':                      { input: 2.50,  output: 10.00 },
-  'openai/gpt-4o-mini':                 { input: 0.15,  output: 0.60  },
-  'openai/o1-preview':                  { input: 15.00, output: 60.00 },
-  'anthropic/claude-3-5-sonnet-latest': { input: 3.00,  output: 15.00 },
-  'anthropic/claude-3-haiku-latest':    { input: 0.25,  output: 1.25  },
-  'deepseek/deepseek-chat':             { input: 0.27,  output: 1.10  },
-  'deepseek/deepseek-reasoner':         { input: 0.55,  output: 2.19  },
-};
+// Derived from MODEL_CATALOG — edit catalog.ts to update prices
+export const MODEL_PRICING: Record<string, { input: number; output: number }> = Object.fromEntries(
+  MODEL_CATALOG
+    .filter((e) => e.pricing)
+    .map((e) => [`${e.provider}/${e.id}`, e.pricing!]),
+);
 
 export const LANGUAGES = [
   'English',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -553,5 +553,17 @@
     "glossaryHighlightToggle": "Highlight terms",
     "glossaryMatchBadge": "{{match}}/{{total}} terms",
     "glossaryNoGlossary": "No dictionary assigned"
+  },
+  "cost": {
+    "free": "Free",
+    "unknown": "—",
+    "breakdown": "Cost breakdown",
+    "stage": "Stage",
+    "total": "Total",
+    "disclaimer": "Rough estimate. Actual cost may vary.",
+    "pricingOverrides": "Pricing overrides",
+    "overrideHint": "Override default pricing for custom deployments or updated rates. Values are USD per 1M tokens.",
+    "resetOverride": "Reset",
+    "resetAll": "Reset all"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -553,5 +553,17 @@
     "glossaryHighlightToggle": "Evidenzia termini",
     "glossaryMatchBadge": "{{match}}/{{total}} termini",
     "glossaryNoGlossary": "Nessun dizionario assegnato"
+  },
+  "cost": {
+    "free": "Gratuito",
+    "unknown": "—",
+    "breakdown": "Dettaglio costi",
+    "stage": "Fase",
+    "total": "Totale",
+    "disclaimer": "Stima approssimativa. Il costo reale può variare.",
+    "pricingOverrides": "Override prezzi",
+    "overrideHint": "Personalizza i prezzi di default per deployment custom o tariffe aggiornate. Valori in USD per 1M di token.",
+    "resetOverride": "Ripristina",
+    "resetAll": "Ripristina tutti"
   }
 }

--- a/src/models/catalog.test.ts
+++ b/src/models/catalog.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getMissingPricingModels } from './catalog';
+import { MODEL_OPTIONS } from '../constants';
+
+describe('MODEL_CATALOG', () => {
+  it('has pricing for every non-ollama model in MODEL_OPTIONS', () => {
+    const missing = getMissingPricingModels(MODEL_OPTIONS);
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -28,21 +28,23 @@ export const MODEL_CATALOG: ModelEntry[] = [
   { id: 'deepseek-reasoner',             provider: 'deepseek',  status: 'stable',  pricing: { input: 0.55,  output: 2.19  } },
 ];
 
-export function getModelEntry(provider: string, modelId: string): ModelEntry | undefined {
+export function getModelEntry(provider: ModelProvider, modelId: string): ModelEntry | undefined {
   return MODEL_CATALOG.find((e) => e.provider === provider && e.id === modelId);
 }
 
-export function getModelStatus(provider: string, modelId: string): ModelStatus | undefined {
+export function getModelStatus(provider: ModelProvider, modelId: string): ModelStatus | undefined {
   return getModelEntry(provider, modelId)?.status;
 }
 
 /** Returns model IDs that are in MODEL_OPTIONS but lack a pricing entry (excluding ollama). */
-export function getMissingPricingModels(modelOptions: Record<string, string[]>): string[] {
+export function getMissingPricingModels(
+  modelOptions: Partial<Record<ModelProvider, string[]>>,
+): string[] {
   const missing: string[] = [];
   for (const [provider, models] of Object.entries(modelOptions)) {
     if (provider === 'ollama') continue;
-    for (const modelId of models) {
-      const entry = getModelEntry(provider, modelId);
+    for (const modelId of models ?? []) {
+      const entry = getModelEntry(provider as ModelProvider, modelId);
       if (!entry || !entry.pricing) {
         missing.push(`${provider}/${modelId}`);
       }

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -1,0 +1,52 @@
+import type { ModelProvider } from '../types';
+
+export type ModelStatus = 'stable' | 'preview' | 'deprecated';
+
+export interface ModelEntry {
+  id: string;
+  provider: ModelProvider;
+  status: ModelStatus;
+  pricing?: { input: number; output: number }; // USD per 1M tokens; undefined = free/local
+}
+
+// Last reviewed: 2026-05
+// Source: official provider pricing pages
+export const MODEL_CATALOG: ModelEntry[] = [
+  // Gemini
+  { id: 'gemini-3-flash-preview',        provider: 'gemini',    status: 'preview', pricing: { input: 0.075, output: 0.30  } },
+  { id: 'gemini-3.1-pro-preview',        provider: 'gemini',    status: 'preview', pricing: { input: 1.25,  output: 5.00  } },
+  { id: 'gemini-2.5-flash-lite-preview', provider: 'gemini',    status: 'preview', pricing: { input: 0.10,  output: 0.40  } },
+  // OpenAI
+  { id: 'gpt-4o',                        provider: 'openai',    status: 'stable',  pricing: { input: 2.50,  output: 10.00 } },
+  { id: 'gpt-4o-mini',                   provider: 'openai',    status: 'stable',  pricing: { input: 0.15,  output: 0.60  } },
+  { id: 'o1-preview',                    provider: 'openai',    status: 'preview', pricing: { input: 15.00, output: 60.00 } },
+  // Anthropic
+  { id: 'claude-3-5-sonnet-latest',      provider: 'anthropic', status: 'stable',  pricing: { input: 3.00,  output: 15.00 } },
+  { id: 'claude-3-haiku-latest',         provider: 'anthropic', status: 'stable',  pricing: { input: 0.25,  output: 1.25  } },
+  // DeepSeek
+  { id: 'deepseek-chat',                 provider: 'deepseek',  status: 'stable',  pricing: { input: 0.27,  output: 1.10  } },
+  { id: 'deepseek-reasoner',             provider: 'deepseek',  status: 'stable',  pricing: { input: 0.55,  output: 2.19  } },
+];
+
+export function getModelEntry(provider: string, modelId: string): ModelEntry | undefined {
+  return MODEL_CATALOG.find((e) => e.provider === provider && e.id === modelId);
+}
+
+export function getModelStatus(provider: string, modelId: string): ModelStatus | undefined {
+  return getModelEntry(provider, modelId)?.status;
+}
+
+/** Returns model IDs that are in MODEL_OPTIONS but lack a pricing entry (excluding ollama). */
+export function getMissingPricingModels(modelOptions: Record<string, string[]>): string[] {
+  const missing: string[] = [];
+  for (const [provider, models] of Object.entries(modelOptions)) {
+    if (provider === 'ollama') continue;
+    for (const modelId of models) {
+      const entry = getModelEntry(provider, modelId);
+      if (!entry || !entry.pricing) {
+        missing.push(`${provider}/${modelId}`);
+      }
+    }
+  }
+  return missing;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './catalog';

--- a/src/stores/pricingStore.ts
+++ b/src/stores/pricingStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface PricingState {
+  overrides: Record<string, { input: number; output: number }>;
+  setOverride: (key: string, pricing: { input: number; output: number }) => void;
+  resetOverride: (key: string) => void;
+  resetAll: () => void;
+}
+
+export const usePricingStore = create<PricingState>()(
+  persist(
+    (set) => ({
+      overrides: {},
+      setOverride: (key, pricing) =>
+        set((state) => ({ overrides: { ...state.overrides, [key]: pricing } })),
+      resetOverride: (key) =>
+        set((state) => {
+          const { [key]: _, ...rest } = state.overrides;
+          return { overrides: rest };
+        }),
+      resetAll: () => set({ overrides: {} }),
+    }),
+    {
+      name: 'glossa-pricing-overrides',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/src/utils/costEstimate.test.ts
+++ b/src/utils/costEstimate.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens, estimatePipelineCost } from './costEstimate';
+import type { PipelineConfig } from '../types';
+
+const baseConfig: PipelineConfig = {
+  sourceLanguage: 'English',
+  targetLanguage: 'Italian',
+  stages: [
+    { id: 'stg-1', name: 'Draft', prompt: 'Translate literally.', model: 'gpt-4o-mini', provider: 'openai', enabled: true },
+  ],
+  judgePrompt: 'Audit the translation.',
+  judgeModel: 'gpt-4o-mini',
+  judgeProvider: 'openai',
+  glossary: [],
+};
+
+describe('estimateTokens', () => {
+  it('returns positive count for non-empty text', () => {
+    expect(estimateTokens('hello world')).toBeGreaterThan(0);
+  });
+  it('returns 1 for empty string', () => {
+    expect(estimateTokens('')).toBe(1);
+  });
+});
+
+describe('estimatePipelineCost', () => {
+  it('returns zero cost for empty chunks', () => {
+    const result = estimatePipelineCost([], baseConfig);
+    expect(result.totalUsd).toBe(0);
+  });
+
+  it('returns a positive totalUsd for known-priced models', () => {
+    const chunks = [{ originalText: 'The quick brown fox jumps over the lazy dog.' }];
+    const result = estimatePipelineCost(chunks, baseConfig);
+    expect(result.totalUsd).toBeGreaterThan(0);
+  });
+
+  it('marks isFree=true when all stages use ollama', () => {
+    const ollamaConfig: PipelineConfig = {
+      ...baseConfig,
+      stages: [{ id: 's1', name: 'Draft', prompt: 'Translate.', model: 'llama3', provider: 'ollama', enabled: true }],
+      judgeProvider: 'ollama',
+      judgeModel: 'llama3',
+    };
+    const result = estimatePipelineCost([{ originalText: 'Hello world' }], ollamaConfig);
+    expect(result.isFree).toBe(true);
+    expect(result.totalUsd).toBeNull();
+  });
+
+  it('returns null totalUsd if any stage has unknown pricing', () => {
+    const unknownConfig: PipelineConfig = {
+      ...baseConfig,
+      stages: [{ id: 's1', name: 'Draft', prompt: 'Translate.', model: 'unknown-model-xyz', provider: 'openai', enabled: true }],
+      judgeProvider: 'openai',
+      judgeModel: 'unknown-model-xyz',
+    };
+    const result = estimatePipelineCost([{ originalText: 'Hello world' }], unknownConfig);
+    expect(result.totalUsd).toBeNull();
+  });
+});

--- a/src/utils/costEstimate.test.ts
+++ b/src/utils/costEstimate.test.ts
@@ -44,7 +44,7 @@ describe('estimatePipelineCost', () => {
     };
     const result = estimatePipelineCost([{ originalText: 'Hello world' }], ollamaConfig);
     expect(result.isFree).toBe(true);
-    expect(result.totalUsd).toBeNull();
+    expect(result.totalUsd).toBe(0);
   });
 
   it('returns null totalUsd if any stage has unknown pricing', () => {
@@ -56,5 +56,14 @@ describe('estimatePipelineCost', () => {
     };
     const result = estimatePipelineCost([{ originalText: 'Hello world' }], unknownConfig);
     expect(result.totalUsd).toBeNull();
+  });
+
+  it('keeps judge output estimate based on the original document size', () => {
+    const chunks = [{ originalText: 'one two three four five six seven eight nine ten' }];
+    const docTokens = estimateTokens(chunks[0].originalText);
+    const result = estimatePipelineCost(chunks, baseConfig);
+
+    expect(result.judge?.inputTokens).toBe(docTokens * 2 + estimateTokens(baseConfig.judgePrompt));
+    expect(result.judge?.outputTokens).toBe(Math.ceil(docTokens * 0.3));
   });
 });

--- a/src/utils/costEstimate.ts
+++ b/src/utils/costEstimate.ts
@@ -57,8 +57,11 @@ export function estimatePipelineCost(
     return { stages: [], judge: null, totalUsd: 0, isFree: false };
   }
 
-  const totalDocText = chunks.map((c) => c.originalText).join(' ');
-  const docTokens = estimateTokens(totalDocText);
+  const totalWords = chunks.reduce(
+    (sum, c) => sum + c.originalText.trim().split(/\s+/).filter(Boolean).length,
+    0,
+  );
+  const docTokens = Math.max(1, Math.ceil(totalWords * 1.35));
 
   const enabledStages = config.stages.filter((s) => s.enabled);
 

--- a/src/utils/costEstimate.ts
+++ b/src/utils/costEstimate.ts
@@ -1,0 +1,87 @@
+import type { PipelineConfig } from '../types';
+import { MODEL_PRICING } from '../constants';
+
+/** Approximate token count: ~1.35 tokens per word */
+export function estimateTokens(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words * 1.35));
+}
+
+export interface StageCostEstimate {
+  stageId: string;
+  stageName: string;
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number | null; // null = free (ollama) or unknown pricing
+}
+
+export interface PipelineCostEstimate {
+  stages: StageCostEstimate[];
+  judge: StageCostEstimate | null;
+  totalUsd: number | null; // null if any stage has unknown pricing; number if all known
+  isFree: boolean; // true if all stages + judge are free (all ollama)
+}
+
+function stageEstimate(
+  stageId: string,
+  stageName: string,
+  provider: string,
+  model: string,
+  docTokens: number,
+  promptTokens: number,
+  outputRatio: number,
+  pricingOverrides: Record<string, { input: number; output: number }>,
+): StageCostEstimate {
+  const inputTokens = docTokens + promptTokens;
+  const outputTokens = Math.ceil(docTokens * outputRatio);
+  const key = `${provider}/${model}`;
+  const pricing = pricingOverrides[key] ?? MODEL_PRICING[key];
+  const costUsd =
+    provider === 'ollama' || !model
+      ? null
+      : pricing
+        ? (inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000
+        : null;
+  return { stageId, stageName, provider, model, inputTokens, outputTokens, costUsd };
+}
+
+export function estimatePipelineCost(
+  chunks: { originalText: string }[],
+  config: PipelineConfig,
+  pricingOverrides: Record<string, { input: number; output: number }> = {},
+): PipelineCostEstimate {
+  if (chunks.length === 0) {
+    return { stages: [], judge: null, totalUsd: 0, isFree: false };
+  }
+
+  const totalDocText = chunks.map((c) => c.originalText).join(' ');
+  const docTokens = estimateTokens(totalDocText);
+
+  const enabledStages = config.stages.filter((s) => s.enabled);
+
+  const stageEstimates = enabledStages.map((stage) => {
+    const promptTokens = estimateTokens(stage.prompt);
+    return stageEstimate(stage.id, stage.name, stage.provider, stage.model, docTokens, promptTokens, 1.1, pricingOverrides);
+  });
+
+  const judgeEstimate =
+    config.judgeModel && config.judgeProvider
+      ? stageEstimate('judge', 'Audit Guard', config.judgeProvider, config.judgeModel, docTokens * 2, estimateTokens(config.judgePrompt), 0.3, pricingOverrides)
+      : null;
+
+  const allEstimates = judgeEstimate ? [...stageEstimates, judgeEstimate] : stageEstimates;
+
+  const isFree = allEstimates.every((e) => e.provider === 'ollama');
+
+  // If any non-free stage has null cost (unknown pricing), totalUsd is null
+  const hasUnknown = allEstimates.some((e) => e.provider !== 'ollama' && e.costUsd === null);
+  const totalUsd = isFree
+    ? null
+    : hasUnknown
+      ? null
+      : allEstimates.reduce((sum, e) => sum + (e.costUsd ?? 0), 0);
+
+  return { stages: stageEstimates, judge: judgeEstimate, totalUsd, isFree };
+}

--- a/src/utils/costEstimate.ts
+++ b/src/utils/costEstimate.ts
@@ -20,7 +20,7 @@ export interface StageCostEstimate {
 export interface PipelineCostEstimate {
   stages: StageCostEstimate[];
   judge: StageCostEstimate | null;
-  totalUsd: number | null; // null if any stage has unknown pricing; number if all known
+  totalUsd: number | null; // null if any stage has unknown pricing; 0 for fully free pipelines
   isFree: boolean; // true if all stages + judge are free (all ollama)
 }
 
@@ -29,13 +29,14 @@ function stageEstimate(
   stageName: string,
   provider: string,
   model: string,
-  docTokens: number,
+  inputDocTokens: number,
   promptTokens: number,
+  outputDocTokens: number,
   outputRatio: number,
   pricingOverrides: Record<string, { input: number; output: number }>,
 ): StageCostEstimate {
-  const inputTokens = docTokens + promptTokens;
-  const outputTokens = Math.ceil(docTokens * outputRatio);
+  const inputTokens = inputDocTokens + promptTokens;
+  const outputTokens = Math.ceil(outputDocTokens * outputRatio);
   const key = `${provider}/${model}`;
   const pricing = pricingOverrides[key] ?? MODEL_PRICING[key];
   const costUsd =
@@ -63,12 +64,32 @@ export function estimatePipelineCost(
 
   const stageEstimates = enabledStages.map((stage) => {
     const promptTokens = estimateTokens(stage.prompt);
-    return stageEstimate(stage.id, stage.name, stage.provider, stage.model, docTokens, promptTokens, 1.1, pricingOverrides);
+    return stageEstimate(
+      stage.id,
+      stage.name,
+      stage.provider,
+      stage.model,
+      docTokens,
+      promptTokens,
+      docTokens,
+      1.1,
+      pricingOverrides,
+    );
   });
 
   const judgeEstimate =
     config.judgeModel && config.judgeProvider
-      ? stageEstimate('judge', 'Audit Guard', config.judgeProvider, config.judgeModel, docTokens * 2, estimateTokens(config.judgePrompt), 0.3, pricingOverrides)
+      ? stageEstimate(
+          'judge',
+          'Audit Guard',
+          config.judgeProvider,
+          config.judgeModel,
+          docTokens * 2,
+          estimateTokens(config.judgePrompt),
+          docTokens,
+          0.3,
+          pricingOverrides,
+        )
       : null;
 
   const allEstimates = judgeEstimate ? [...stageEstimates, judgeEstimate] : stageEstimates;
@@ -78,7 +99,7 @@ export function estimatePipelineCost(
   // If any non-free stage has null cost (unknown pricing), totalUsd is null
   const hasUnknown = allEstimates.some((e) => e.provider !== 'ollama' && e.costUsd === null);
   const totalUsd = isFree
-    ? null
+    ? 0
     : hasUnknown
       ? null
       : allEstimates.reduce((sum, e) => sum + (e.costUsd ?? 0), 0);


### PR DESCRIPTION
## Summary

Closes #73 · Relates to #5

---

## Issue #73 — Model catalog maintenance strategy

- **`src/models/catalog.ts`** — single source of truth for all model metadata: `id`, `provider`, `status` (`stable` | `preview` | `deprecated`), `pricing`
- **`src/constants.ts`** — `MODEL_PRICING` is now derived from the catalog (backward compatible); edit `catalog.ts` to update prices
- **`StageCard.tsx` + `PipelineConfig.tsx`** — preview models show a `(preview)` suffix in model select dropdowns
- **`src/models/catalog.test.ts`** — validates that every non-ollama model in `MODEL_OPTIONS` has a pricing entry

## Issue #5 — Pre-run token/cost estimation

- **`src/utils/costEstimate.ts`** — `estimateTokens()` (~1.35 tokens/word) + `estimatePipelineCost()` with per-stage breakdown (1.1× output ratio for translation, 0.3× for audit)
- **`src/stores/pricingStore.ts`** — persisted pricing overrides via localStorage (Zustand persist)
- **`src/components/pipeline/CostBadge.tsx`** — inline `~$X.XX` badge with hover tooltip breakdown table; shows **Free** for all-Ollama pipelines, **—** for unknown pricing
- **`PipelineConfig.tsx`** — CostBadge shown above the Run button (sandbox view)
- **`Header.tsx`** — CostBadge shown near the Run button in document mode
- **`SettingsModal.tsx`** — collapsible **Pricing overrides** section with editable inputs and per-model reset
- **i18n** — new `cost.*` keys in both `en.json` and `it.json`

## Tests

All 111 tests pass · Build ✓ · No TypeScript errors