### PR TITLE
chore: enable strict TypeScript and remove allowJs

### DIFF
--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -138,7 +138,7 @@ export function usePipeline() {
    */
   const runJudgeForChunk = async (
     chunk: TranslationChunk,
-    textToAudit: string,
+    textToAudit: string | undefined,
   ): Promise<ChunkOutcome> => {
     if (!textToAudit) return 'skipped';
     // We do NOT short-circuit on cancelRequested here — once we have a

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleResolution": "bundler",
     "isolatedModules": true,
     "moduleDetection": "force",
-    "allowJs": true,
+    "strict": true,
     "jsx": "react-jsx",
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary

Closes #75

### Changes

**`tsconfig.json`**
- Added `"strict": true` — enables the full strict family: `strictNullChecks`, `noImplicitAny`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`
- Removed `allowJs` — the entire source is TypeScript/TSX; no `.js` files exist under `src/`

**`src/hooks/usePipeline.ts`**

### Verification
- `npm run lint`: ✓ 0 errors
- `npm test`: ✓ 104/104 passing