### PR TITLE
feat: InsightsDrawer UX improvements (issue #91)

### DIFF
--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -364,7 +364,7 @@ export function MarkdownEditor({
       {mode === 'write' && !readOnly && highlightHtml ? (
         <div className={fillHeight ? 'flex flex-col flex-1 min-h-0' : 'space-y-2'}>
           {textarea}
-          <HighlightedText html={highlightHtml} className={`${minHeightClassName} ${textClassName}`} />
+          <HighlightedText html={highlightHtml} className={fillHeight ? `flex-1 min-h-0 overflow-y-auto ${textClassName}` : `${minHeightClassName} ${textClassName}`} />
         </div>
       ) : null}
       {mode === 'write' && (!highlightHtml || readOnly) ? textarea : null}

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -27,6 +27,7 @@ interface MarkdownEditorProps {
   focusQuery?: string | null;
   focusRequestId?: number;
   onFocusQueryHandled?: () => void;
+  fillHeight?: boolean;
 }
 
 export function MarkdownEditor({
@@ -43,6 +44,7 @@ export function MarkdownEditor({
   focusQuery = null,
   focusRequestId = 0,
   onFocusQueryHandled,
+  fillHeight = false,
 }: MarkdownEditorProps) {
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -158,7 +160,7 @@ export function MarkdownEditor({
       onClick={syncSelection}
       onKeyUp={syncSelection}
       onSelect={syncSelection}
-      className={`${minHeightClassName} w-full resize-y bg-transparent outline-none ${textClassName} disabled:opacity-70 read-only:cursor-not-allowed`}
+      className={`${fillHeight ? 'flex-1 min-h-[100px] h-0' : minHeightClassName} w-full resize-y bg-transparent outline-none ${textClassName} disabled:opacity-70 read-only:cursor-not-allowed`}
       style={textSizeStyles[textSize]}
     />
   );
@@ -177,8 +179,8 @@ export function MarkdownEditor({
   );
 
   return (
-    <div className="space-y-3">
-      <div className="sticky top-0 z-20 rounded-2xl border border-editorial-border/70 bg-[#fcfaf5]/95 px-3 py-3 shadow-sm backdrop-blur">
+    <div className={fillHeight ? 'flex flex-col flex-1 min-h-0' : 'space-y-3'}>
+      <div className={`sticky top-0 z-20 rounded-2xl border border-editorial-border/70 bg-[#fcfaf5]/95 px-3 py-3 shadow-sm backdrop-blur${fillHeight ? ' shrink-0' : ''}`}>
         <div className="flex items-center justify-between gap-3">
           <button
             type="button"
@@ -360,7 +362,7 @@ export function MarkdownEditor({
         ) : null}
       </div>
       {mode === 'write' && !readOnly && highlightHtml ? (
-        <div className="space-y-2">
+        <div className={fillHeight ? 'flex flex-col flex-1 min-h-0' : 'space-y-2'}>
           {textarea}
           <HighlightedText html={highlightHtml} className={`${minHeightClassName} ${textClassName}`} />
         </div>

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -193,9 +193,9 @@ export function DocumentView({
   const chunkTone = qualityTone(currentChunk.judgeResult.rating);
 
   return (
-    <section className="w-full bg-[#f7f3ec] overflow-y-auto min-h-0 h-full custom-scrollbar">
-      <div className="mx-auto max-w-[1720px] px-5 py-4 md:px-6 md:py-5 space-y-5">
-        <div className="flex items-center gap-2">
+    <section className="w-full bg-[#f7f3ec] overflow-y-auto min-h-0 h-full custom-scrollbar flex flex-col">
+      <div className="mx-auto w-full max-w-[1720px] px-5 py-4 md:px-6 md:py-5 flex flex-col flex-1 min-h-0 gap-5">
+        <div className="flex items-center gap-2 shrink-0">
           {/* Run button: cerchio con stesso stile della navbar, si fonde con essa */}
           {onRunPipeline && onCancelPipeline && (
             <div className="relative flex h-[80px] w-[80px] flex-shrink-0 items-center justify-center rounded-full border border-editorial-border bg-editorial-bg/90 shadow-[0_16px_50px_rgba(26,26,26,0.05)]">
@@ -434,7 +434,7 @@ export function DocumentView({
           </div>
         </div>
 
-        <div className={`grid gap-5 ${paneFocus === 'both' ? (isBook ? '2xl:grid-cols-2' : 'grid-cols-1') : 'grid-cols-1'}`}>
+        <div className={`grid gap-5 flex-1 min-h-0 ${paneFocus === 'both' ? (isBook ? '2xl:grid-cols-2' : 'grid-cols-1') : 'grid-cols-1'}`}>
           {paneFocus !== 'translation' && (
             <DocumentPage
               label={t('pipeline.originalSource')}
@@ -451,7 +451,7 @@ export function DocumentView({
                 markdownEnabled={config.markdownAware === true}
                 disabled={isProcessing}
                 readOnly={currentChunk.status === 'completed'}
-                minHeightClassName="min-h-[280px]"
+                fillHeight
                 textClassName="text-[15px] leading-8 text-editorial-ink"
                 previewClassName="min-h-[280px] text-[15px] leading-8 text-editorial-ink"
                 highlightHtml={showHighlight && currentChunk.status !== 'completed' ? sourceHighlight.html : null}
@@ -479,7 +479,7 @@ export function DocumentView({
                 onChange={(nextValue) => updateChunkDraft(currentChunk.id, nextValue)}
                 markdownEnabled={config.markdownAware === true}
                 readOnly={currentChunk.translationLocked === true}
-                minHeightClassName="min-h-[280px]"
+                fillHeight
                 textClassName="text-[15px] leading-8 text-editorial-ink"
                 previewClassName="min-h-[280px] text-[15px] leading-8 text-editorial-ink"
                 placeholder={t('pipeline.candidatePlaceholder')}
@@ -607,10 +607,10 @@ function DocumentPage({
   children,
 }: DocumentPageProps) {
   return (
-    <section className={`relative rounded-[24px] bg-[#fffdf9] px-6 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.85),0_18px_45px_rgba(74,50,17,0.08)] ${
+    <section className={`relative rounded-[24px] bg-[#fffdf9] px-6 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.85),0_18px_45px_rgba(74,50,17,0.08)] flex flex-col ${
       highlighted ? 'border border-editorial-accent ring-2 ring-editorial-accent/30' : 'border border-[#d8cfbf]'
     }`}>
-      <div className="mb-4 flex items-center justify-between gap-4 border-b border-[#ede4d6] pb-3">
+      <div className="mb-4 shrink-0 flex items-center justify-between gap-4 border-b border-[#ede4d6] pb-3">
         <div className="min-w-0">
           <div className="text-[10px] font-bold uppercase tracking-[0.35em] text-editorial-muted">
             {eyebrow}
@@ -627,7 +627,7 @@ function DocumentPage({
           {actions}
         </div>
       </div>
-      <div className={readOnly ? 'opacity-90' : ''}>
+      <div className={`flex flex-col flex-1 min-h-0 ${readOnly ? 'opacity-90' : ''}`}>
         {children}
       </div>
     </section>

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -3,11 +3,11 @@ import {
   ChevronLeft,
   ChevronRight,
   Columns2,
-  Copy,
   Highlighter,
   Info,
   Loader2,
   Lock,
+  Merge,
   Pencil,
   PanelLeft,
   PanelRight,
@@ -82,6 +82,8 @@ export function DocumentView({
     focusedIssueQuery,
     focusedIssueRequestId,
     clearFocusedIssue,
+    pendingSplitChunkId,
+    setPendingSplitChunkId,
   } = useUiStore();
 
   const [viewportWidth, setViewportWidth] = useState(
@@ -145,6 +147,13 @@ export function DocumentView({
       Math.max(1, Math.floor(text.length / 2));
     setSplitDraft({ chunkId, splitAt: initialSplitAt });
   };
+
+  useEffect(() => {
+    if (!pendingSplitChunkId || !currentChunk || currentChunk.id !== pendingSplitChunkId) return;
+    openSplitDialog(currentChunk.id, currentChunk.originalText);
+    setPendingSplitChunkId(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSplitChunkId, currentChunk?.id]);
 
   // Hooks devono essere chiamati prima di qualsiasi return condizionale
   const hasGlossary = config.glossary.length > 0;
@@ -406,7 +415,7 @@ export function DocumentView({
                       chunks[currentIndex + 1]?.status === 'processing'
                     }
                   >
-                    <Copy size={16} />
+                    <Merge size={16} />
                   </ChunkIconButton>
                 </>
               )}
@@ -442,9 +451,9 @@ export function DocumentView({
                 markdownEnabled={config.markdownAware === true}
                 disabled={isProcessing}
                 readOnly={currentChunk.status === 'completed'}
-                minHeightClassName="min-h-[420px]"
+                minHeightClassName="min-h-[280px]"
                 textClassName="text-[15px] leading-8 text-editorial-ink"
-                previewClassName="min-h-[420px] text-[15px] leading-8 text-editorial-ink"
+                previewClassName="min-h-[280px] text-[15px] leading-8 text-editorial-ink"
                 highlightHtml={showHighlight && currentChunk.status !== 'completed' ? sourceHighlight.html : null}
               />
             </DocumentPage>
@@ -470,9 +479,9 @@ export function DocumentView({
                 onChange={(nextValue) => updateChunkDraft(currentChunk.id, nextValue)}
                 markdownEnabled={config.markdownAware === true}
                 readOnly={currentChunk.translationLocked === true}
-                minHeightClassName="min-h-[420px]"
+                minHeightClassName="min-h-[280px]"
                 textClassName="text-[15px] leading-8 text-editorial-ink"
-                previewClassName="min-h-[420px] text-[15px] leading-8 text-editorial-ink"
+                previewClassName="min-h-[280px] text-[15px] leading-8 text-editorial-ink"
                 placeholder={t('pipeline.candidatePlaceholder')}
                 highlightHtml={showHighlight ? translationHighlight.html : null}
                 focusQuery={focusedChunkId === currentChunk.id ? focusedIssueQuery : null}
@@ -618,7 +627,7 @@ function DocumentPage({
           {actions}
         </div>
       </div>
-      <div className={`max-h-[min(64vh,980px)] overflow-y-auto pr-1 custom-scrollbar ${readOnly ? 'opacity-90' : ''}`}>
+      <div className={readOnly ? 'opacity-90' : ''}>
         {children}
       </div>
     </section>

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -78,6 +78,7 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
   const setInsightsDrawerTab = useUiStore((state) => state.setInsightsDrawerTab);
   const selectedChunkId = useUiStore((state) => state.selectedChunkId);
   const setSelectedChunkId = useUiStore((state) => state.setSelectedChunkId);
+  const setPendingSplitChunkId = useUiStore((state) => state.setPendingSplitChunkId);
   const focusIssueInChunk = useUiStore((state) => state.focusIssueInChunk);
   const chunks = useChunksStore((state) => state.chunks);
   const isProcessing = useChunksStore((state) => state.isProcessing);
@@ -90,6 +91,12 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
     chunks.find((chunk) => chunk.id === selectedChunkId) ?? chunks[0] ?? null;
 
   const activeTab: InsightsTab = TAB_ORDER.includes(insightsDrawerTab) ? insightsDrawerTab : 'index';
+
+  const TAB_TITLE: Record<InsightsTab, string> = {
+    index: t('document.insightsTabIndex'),
+    stats: t('document.insightsTabStats'),
+    audit: t('document.insightsTabAudit'),
+  };
 
   const activateTab = (tab: InsightsTab) => {
     setInsightsDrawerTab(tab);
@@ -181,12 +188,13 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
             </div>
 
             {/* Tab bar */}
-            <div
-              role="tablist"
-              aria-orientation="horizontal"
-              aria-label={t('document.insightsDrawerTitle')}
-              className="flex gap-1 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2"
-            >
+            <div className="flex items-center gap-2 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2">
+              <div
+                role="tablist"
+                aria-orientation="horizontal"
+                aria-label={t('document.insightsDrawerTitle')}
+                className="flex gap-1"
+              >
               <TabButton
                 tab="index"
                 active={activeTab === 'index'}
@@ -223,6 +231,9 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
                   tabButtonRefs.current.audit = element;
                 }}
               />
+              </div>
+              <span className="mx-1 h-4 w-px bg-editorial-border/70" aria-hidden="true" />
+              <span className="font-display italic text-sm text-editorial-ink">{TAB_TITLE[activeTab]}</span>
             </div>
 
             <div className="flex flex-1 flex-col overflow-y-auto bg-editorial-bg/40 custom-scrollbar">
@@ -234,8 +245,14 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
                   currentChunkId={currentChunk?.id ?? null}
                   isProcessing={isProcessing}
                   onSelect={(id) => setSelectedChunkId(id)}
-                  onSplit={splitChunk}
-                  onMerge={mergeChunkWithNext}
+                  onSplit={(chunkId) => {
+                    setSelectedChunkId(chunkId);
+                    setPendingSplitChunkId(chunkId);
+                  }}
+                  onMerge={(chunkId) => {
+                    setSelectedChunkId(chunkId);
+                    mergeChunkWithNext(chunkId);
+                  }}
                 />
               ) : activeTab === 'stats' ? (
                 <StatsTab
@@ -419,10 +436,10 @@ function IndexTab({
                 >
                   <div className="flex items-center gap-2">
                     {statusIcon}
-                    <span className={`font-display text-sm italic ${isActive ? 'text-white' : 'text-editorial-ink'}`}>
+                    <span className={`font-display text-sm italic ${isActive ? 'text-white' : 'text-editorial-accent'}`}>
                       {indexPad(index + 1)}
                     </span>
-                    <span className={`flex-1 truncate text-[11px] leading-snug ${isActive ? 'text-white/80' : 'text-editorial-muted'}`}>
+                    <span className={`flex-1 line-clamp-2 text-[11px] leading-snug ${isActive ? 'text-white/80' : 'text-editorial-muted'}`}>
                       {truncateChunk(chunk.originalText)}
                     </span>
                     <span className={`shrink-0 text-[10px] font-mono ${isActive ? 'text-white/50' : 'text-editorial-muted/60'}`}>
@@ -618,6 +635,9 @@ function StatsTab({ panelId, labelledBy, chunks }: StatsTabProps) {
             className="h-full rounded-full bg-editorial-success transition-all"
             style={{ width: `${progressPct}%` }}
           />
+        </div>
+        <div className="mb-2 font-display text-lg italic text-editorial-ink">
+          {progressPct}%
         </div>
         <div className="flex flex-wrap gap-3">
           {idleCount > 0 && (

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -85,7 +85,6 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
   const allChunksTranslated = chunks.length > 0 && chunks.every((c) => c.currentDraft?.trim());
   const allChunksLocked = chunks.length > 0 && chunks.every((c) => c.translationLocked);
   const unlockedChunksCount = chunks.filter((c) => c.currentDraft?.trim() && !c.translationLocked).length;
-  const splitChunk = useChunksStore((state) => state.splitChunk);
   const mergeChunkWithNext = useChunksStore((state) => state.mergeChunkWithNext);
   const currentChunk =
     chunks.find((chunk) => chunk.id === selectedChunkId) ?? chunks[0] ?? null;
@@ -440,7 +439,7 @@ function IndexTab({
                       {indexPad(index + 1)}
                     </span>
                     <span className={`flex-1 line-clamp-2 text-[11px] leading-snug ${isActive ? 'text-white/80' : 'text-editorial-muted'}`}>
-                      {truncateChunk(chunk.originalText)}
+                      {chunk.originalText.replace(/\s+/g, ' ').trim()}
                     </span>
                     <span className={`shrink-0 text-[10px] font-mono ${isActive ? 'text-white/50' : 'text-editorial-muted/60'}`}>
                       {wordCount}w

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -109,7 +109,7 @@
     "singleChunkAudited": "Chunk audit refreshed",
     "auditSkippedNoDraft": "Nothing to audit yet — translate this chunk first.",
     "chunkActions": "Chunk actions",
-    "retranslateChunk": "Re-translate this chunk",
+    "retranslateChunk": "Re-run pipeline on this unit",
     "reauditChunk": "Re-audit this chunk",
     "prompt": "Prompt",
     "auditModelLabel": "Audit Model",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -109,7 +109,7 @@
     "singleChunkAudited": "Audit del blocco aggiornato",
     "auditSkippedNoDraft": "Nessuna traduzione da valutare — traduci prima questo blocco.",
     "chunkActions": "Azioni blocco",
-    "retranslateChunk": "Ri-traduci questo blocco",
+    "retranslateChunk": "Riesegui la pipeline su questa unità",
     "reauditChunk": "Ri-valuta questo blocco",
     "prompt": "Prompt",
     "auditModelLabel": "Modello Audit",

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -23,6 +23,7 @@ interface UiState {
   focusedChunkId: string | null;
   focusedIssueQuery: string | null;
   focusedIssueRequestId: number;
+  pendingSplitChunkId: string | null;
 
   setViewMode: (mode: ViewMode) => void;
   setDocumentLayout: (layout: DocumentLayoutPreference) => void;
@@ -38,6 +39,7 @@ interface UiState {
   setFocusedChunkId: (chunkId: string | null) => void;
   focusIssueInChunk: (chunkId: string, query?: string | null) => void;
   clearFocusedIssue: () => void;
+  setPendingSplitChunkId: (chunkId: string | null) => void;
 }
 
 export const useUiStore = create<UiState>()(
@@ -57,6 +59,7 @@ export const useUiStore = create<UiState>()(
   focusedChunkId: null,
   focusedIssueQuery: null,
   focusedIssueRequestId: 0,
+  pendingSplitChunkId: null,
 
   setViewMode: (mode) =>
     set({
@@ -123,6 +126,7 @@ export const useUiStore = create<UiState>()(
       focusedIssueRequestId: state.focusedIssueRequestId + 1,
     })),
   clearFocusedIssue: () => set({ focusedIssueQuery: null }),
+  setPendingSplitChunkId: (chunkId) => set({ pendingSplitChunkId: chunkId }),
     }),
     {
       name: 'glossa-ui-prefs',


### PR DESCRIPTION
Closes #91

## Modifiche

### InsightsDrawer
- **Tab name label**: aggiunto nome tab attiva nella tab bar (separatore + testo italic font-display), come in PipelineConfig
- **Numero chunk con accento rosso**: indice chunk inattivo usa `text-editorial-accent` invece di `text-editorial-ink`
- **Anteprima testo 2 righe**: da `truncate` a `line-clamp-2` nell'indice
- **Split da indice apre il dialog**: il pulsante taglia nell'indice ora naviga al chunk e apre il SplitChunkDialog (via `pendingSplitChunkId` in uiStore, gestito da DocumentView)
- **Merge da indice naviga prima**: il pulsante unisci nell'indice seleziona prima il chunk
- **StatsTab**: aggiunto display percentuale progresso

### DocumentView (barra navigazione)
- **Icona merge corretta**: sostituita icona `Copy` con `Merge` nel pulsante unisci della nav bar
- **Label retranslate**: aggiornata a "Riesegui la pipeline su questa unità" / "Re-run pipeline on this unit"

### Pannelli sorgente e traduzione — auto-adattamento altezza
- Rimosso `max-h-[min(64vh,980px)] overflow-y-auto` interno da `DocumentPage` (eliminata doppia scrollbar)
- Implementato flex chain completo: `section` → wrapper → grid → `DocumentPage` → contenuto
- Aggiunta prop `fillHeight` a `MarkdownEditor`: toolbar `shrink-0`, textarea `flex-1 h-0`, root `flex flex-col flex-1`
- I pannelli ora si estendono a riempire l'intera altezza disponibile del viewport

## Test
- 121/121 test passati
- Build TypeScript + Vite pulita