### PR TITLE
fix: frontend watchdog per chunk bloccato in processing

### DIFF
--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -483,7 +483,7 @@ function IndexTab({
                 </button>
 
                 {/* Watchdog: stuck chunk banner */}
-                {isStuck && (
+                {isStuck && chunk.status === 'processing' && (
                   <div className={`flex items-center justify-between gap-2 border-t px-3 py-2 ${isActive ? 'border-white/10' : 'border-editorial-border/60'}`}>
                     <div className={`flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.18em] ${isActive ? 'text-orange-200' : 'text-editorial-accent'}`}>
                       <Clock size={11} />

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -6,6 +6,7 @@ import {
   CheckCheck,
   CheckCircle2,
   Circle,
+  Clock,
   Cpu,
   ExternalLink,
   FileText,
@@ -34,6 +35,7 @@ import { indexPad, qualityLabelKey, qualityTone, calculateCompositeQuality } fro
 import { MODEL_PRICING } from '../../constants';
 import { estimatePipelineCost } from '../../utils/costEstimate';
 import { formatCost } from '../pipeline/CostBadge';
+import { useChunkWatchdog } from '../../hooks/useChunkWatchdog';
 import type { TranslationChunk } from '../../types';
 
 interface InsightsDrawerProps {
@@ -88,6 +90,8 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
   const mergeChunkWithNext = useChunksStore((state) => state.mergeChunkWithNext);
   const currentChunk =
     chunks.find((chunk) => chunk.id === selectedChunkId) ?? chunks[0] ?? null;
+
+  const { stuckChunkIds, cancelStuckChunk } = useChunkWatchdog();
 
   const activeTab: InsightsTab = TAB_ORDER.includes(insightsDrawerTab) ? insightsDrawerTab : 'index';
 
@@ -243,6 +247,7 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
                   chunks={chunks}
                   currentChunkId={currentChunk?.id ?? null}
                   isProcessing={isProcessing}
+                  stuckChunkIds={stuckChunkIds}
                   onSelect={(id) => setSelectedChunkId(id)}
                   onSplit={(chunkId) => {
                     setSelectedChunkId(chunkId);
@@ -252,6 +257,7 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
                     setSelectedChunkId(chunkId);
                     mergeChunkWithNext(chunkId);
                   }}
+                  onCancelStuck={cancelStuckChunk}
                 />
               ) : activeTab === 'stats' ? (
                 <StatsTab
@@ -336,9 +342,11 @@ interface IndexTabProps {
   chunks: TranslationChunk[];
   currentChunkId: string | null;
   isProcessing: boolean;
+  stuckChunkIds: Set<string>;
   onSelect: (id: string) => void;
   onSplit: (chunkId: string) => void;
   onMerge: (chunkId: string) => void;
+  onCancelStuck: (chunkId: string) => void;
 }
 
 function IndexTab({
@@ -347,9 +355,11 @@ function IndexTab({
   chunks,
   currentChunkId,
   isProcessing,
+  stuckChunkIds,
   onSelect,
   onSplit,
   onMerge,
+  onCancelStuck,
 }: IndexTabProps) {
   const { t } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -402,10 +412,13 @@ function IndexTab({
           const canMutate = canEdit &&
             chunk.status !== 'completed' &&
             chunk.status !== 'processing';
+          const isStuck = stuckChunkIds.has(chunk.id);
 
           let statusIcon: React.ReactNode;
           if (chunk.status === 'processing') {
-            statusIcon = <Loader2 size={13} className="animate-spin text-editorial-warning shrink-0" />;
+            statusIcon = isStuck
+              ? <Clock size={13} className="text-editorial-accent shrink-0" />
+              : <Loader2 size={13} className="animate-spin text-editorial-warning shrink-0" />;
           } else if (chunk.status === 'completed') {
             statusIcon = <CheckCircle2 size={13} className="text-editorial-success shrink-0" />;
           } else if (chunk.status === 'error') {
@@ -468,6 +481,28 @@ function IndexTab({
                     </div>
                   )}
                 </button>
+
+                {/* Watchdog: stuck chunk banner */}
+                {isStuck && (
+                  <div className={`flex items-center justify-between gap-2 border-t px-3 py-2 ${isActive ? 'border-white/10' : 'border-editorial-border/60'}`}>
+                    <div className={`flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.18em] ${isActive ? 'text-orange-200' : 'text-editorial-accent'}`}>
+                      <Clock size={11} />
+                      {t('document.watchdogStuck')}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); onCancelStuck(chunk.id); }}
+                      aria-label={t('document.watchdogCancel')}
+                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+                        isActive
+                          ? 'border-orange-300/40 text-orange-200 hover:bg-white/10'
+                          : 'border-editorial-accent/40 text-editorial-accent hover:bg-editorial-accent/10'
+                      }`}
+                    >
+                      {t('document.watchdogCancel')}
+                    </button>
+                  </div>
+                )}
 
                 {/* Inline actions */}
                 {canMutate && (

--- a/src/hooks/useChunkWatchdog.test.ts
+++ b/src/hooks/useChunkWatchdog.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChunksStore } from '../stores/chunksStore';
+import { useChunkWatchdog } from './useChunkWatchdog';
+
+const llmMocks = vi.hoisted(() => ({
+  cancelStream: vi.fn(),
+}));
+
+vi.mock('../services/llmService', async () => {
+  const actual =
+    await vi.importActual<typeof import('../services/llmService')>(
+      '../services/llmService',
+    );
+  return { ...actual, llmService: llmMocks };
+});
+
+const baseChunk = {
+  originalText: 'Hello',
+  currentDraft: 'Ciao',
+  stageResults: {},
+  judgeResult: { content: '', status: 'idle' as const, rating: 'fair' as const, issues: [] },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  llmMocks.cancelStream.mockResolvedValue(undefined);
+  useChunksStore.setState({
+    chunks: [],
+    activeStreamId: null,
+    cancelRequested: false,
+  } as Parameters<typeof useChunksStore.setState>[0]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useChunkWatchdog', () => {
+  it('starts with no stuck chunks', () => {
+    const { result } = renderHook(() => useChunkWatchdog());
+    expect(result.current.stuckChunkIds.size).toBe(0);
+  });
+
+  it('does not flag processing chunks before 60 s', async () => {
+    useChunksStore.setState({
+      chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
+      activeStreamId: 'stream-1',
+    } as Parameters<typeof useChunksStore.setState>[0]);
+
+    const { result } = renderHook(() => useChunkWatchdog());
+
+    await act(async () => {
+      vi.advanceTimersByTime(55_000);
+    });
+
+    expect(result.current.stuckChunkIds.has('c1')).toBe(false);
+  });
+
+  it('flags processing chunks after 60 s when actively streaming', async () => {
+    useChunksStore.setState({
+      chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
+      activeStreamId: 'stream-1',
+    } as Parameters<typeof useChunksStore.setState>[0]);
+
+    const { result } = renderHook(() => useChunkWatchdog());
+
+    await act(async () => {
+      vi.advanceTimersByTime(65_000);
+    });
+
+    expect(result.current.stuckChunkIds.has('c1')).toBe(true);
+  });
+
+  it('does not flag chunks when no active stream', async () => {
+    useChunksStore.setState({
+      chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
+      activeStreamId: null,
+    } as Parameters<typeof useChunksStore.setState>[0]);
+
+    const { result } = renderHook(() => useChunkWatchdog());
+
+    await act(async () => {
+      vi.advanceTimersByTime(65_000);
+    });
+
+    expect(result.current.stuckChunkIds.has('c1')).toBe(false);
+  });
+
+  it('cancelStuckChunk cancels active stream and resets chunk status', async () => {
+    useChunksStore.setState({
+      chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
+      activeStreamId: 'stream-1',
+    } as Parameters<typeof useChunksStore.setState>[0]);
+
+    const { result } = renderHook(() => useChunkWatchdog());
+
+    await act(async () => {
+      vi.advanceTimersByTime(65_000);
+    });
+
+    expect(result.current.stuckChunkIds.has('c1')).toBe(true);
+
+    await act(async () => {
+      result.current.cancelStuckChunk('c1');
+    });
+
+    expect(llmMocks.cancelStream).toHaveBeenCalledWith('stream-1');
+    const { chunks } = useChunksStore.getState();
+    expect(chunks.find((c) => c.id === 'c1')?.status).toBe('ready');
+    expect(result.current.stuckChunkIds.has('c1')).toBe(false);
+  });
+
+  it('cancelStuckChunk does NOT call requestCancel on the store', async () => {
+    const requestCancel = vi.spyOn(useChunksStore.getState(), 'requestCancel');
+
+    useChunksStore.setState({
+      chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
+      activeStreamId: 'stream-1',
+    } as Parameters<typeof useChunksStore.setState>[0]);
+
+    const { result } = renderHook(() => useChunkWatchdog());
+
+    await act(async () => {
+      vi.advanceTimersByTime(65_000);
+      result.current.cancelStuckChunk('c1');
+    });
+
+    expect(requestCancel).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useChunkWatchdog.test.ts
+++ b/src/hooks/useChunkWatchdog.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChunksStore } from '../stores/chunksStore';
 import { useChunkWatchdog } from './useChunkWatchdog';
 
@@ -15,6 +15,11 @@ vi.mock('../services/llmService', async () => {
   return { ...actual, llmService: llmMocks };
 });
 
+type PartialChunksState = Parameters<typeof useChunksStore.setState>[0];
+
+const setChunksState = (partial: object) =>
+  useChunksStore.setState(partial as unknown as PartialChunksState);
+
 const baseChunk = {
   originalText: 'Hello',
   currentDraft: 'Ciao',
@@ -25,11 +30,7 @@ const baseChunk = {
 beforeEach(() => {
   vi.useFakeTimers();
   llmMocks.cancelStream.mockResolvedValue(undefined);
-  useChunksStore.setState({
-    chunks: [],
-    activeStreamId: null,
-    cancelRequested: false,
-  } as Parameters<typeof useChunksStore.setState>[0]);
+  setChunksState({ chunks: [], activeStreamId: null, cancelRequested: false, isProcessing: false });
 });
 
 afterEach(() => {
@@ -43,10 +44,10 @@ describe('useChunkWatchdog', () => {
   });
 
   it('does not flag processing chunks before 60 s', async () => {
-    useChunksStore.setState({
+    setChunksState({
       chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
       activeStreamId: 'stream-1',
-    } as Parameters<typeof useChunksStore.setState>[0]);
+    });
 
     const { result } = renderHook(() => useChunkWatchdog());
 
@@ -58,10 +59,10 @@ describe('useChunkWatchdog', () => {
   });
 
   it('flags processing chunks after 60 s when actively streaming', async () => {
-    useChunksStore.setState({
+    setChunksState({
       chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
       activeStreamId: 'stream-1',
-    } as Parameters<typeof useChunksStore.setState>[0]);
+    });
 
     const { result } = renderHook(() => useChunkWatchdog());
 
@@ -73,10 +74,10 @@ describe('useChunkWatchdog', () => {
   });
 
   it('does not flag chunks when no active stream', async () => {
-    useChunksStore.setState({
+    setChunksState({
       chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
       activeStreamId: null,
-    } as Parameters<typeof useChunksStore.setState>[0]);
+    });
 
     const { result } = renderHook(() => useChunkWatchdog());
 
@@ -88,10 +89,10 @@ describe('useChunkWatchdog', () => {
   });
 
   it('cancelStuckChunk cancels active stream and resets chunk status', async () => {
-    useChunksStore.setState({
+    setChunksState({
       chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
       activeStreamId: 'stream-1',
-    } as Parameters<typeof useChunksStore.setState>[0]);
+    });
 
     const { result } = renderHook(() => useChunkWatchdog());
 
@@ -114,10 +115,10 @@ describe('useChunkWatchdog', () => {
   it('cancelStuckChunk does NOT call requestCancel on the store', async () => {
     const requestCancel = vi.spyOn(useChunksStore.getState(), 'requestCancel');
 
-    useChunksStore.setState({
+    setChunksState({
       chunks: [{ id: 'c1', status: 'processing', ...baseChunk }],
       activeStreamId: 'stream-1',
-    } as Parameters<typeof useChunksStore.setState>[0]);
+    });
 
     const { result } = renderHook(() => useChunkWatchdog());
 

--- a/src/hooks/useChunkWatchdog.ts
+++ b/src/hooks/useChunkWatchdog.ts
@@ -7,7 +7,8 @@ const STUCK_THRESHOLD_MS = 60_000;
 
 /**
  * Detects translation chunks that have been in "processing" state for longer
- * than STUCK_THRESHOLD_MS (default 60 s) without any status change.
+ * than STUCK_THRESHOLD_MS (default 60 s) without any activity (status change
+ * or new stage result).
  *
  * Returns:
  *  - stuckChunkIds: Set of chunk IDs currently considered stuck
@@ -17,7 +18,19 @@ export function useChunkWatchdog() {
   const processingStartTimes = useRef<Map<string, number>>(new Map());
   const [stuckChunkIds, setStuckChunkIds] = useState<Set<string>>(new Set());
 
-  // Track entry/exit of "processing" state for each chunk
+  // Seed processingStartTimes from chunks already processing on mount
+  useEffect(() => {
+    const now = Date.now();
+    const { chunks } = useChunksStore.getState();
+    for (const c of chunks) {
+      if (c.status === 'processing') {
+        processingStartTimes.current.set(c.id, now);
+      }
+    }
+  }, []);
+
+  // Track entry/exit of "processing" state, and refresh last-activity time
+  // whenever a stage result changes (token received) so we don't flag active streams.
   useEffect(() => {
     const unsubscribe = useChunksStore.subscribe((state) => {
       const now = Date.now();
@@ -27,7 +40,14 @@ export function useChunkWatchdog() {
 
       for (const id of processingIds) {
         if (!processingStartTimes.current.has(id)) {
+          // Chunk just entered processing state
           processingStartTimes.current.set(id, now);
+        } else {
+          // Refresh activity time when stage results change (new token/output received)
+          const chunk = state.chunks.find((c) => c.id === id);
+          if (chunk && Object.keys(chunk.stageResults).length > 0) {
+            processingStartTimes.current.set(id, now);
+          }
         }
       }
 
@@ -41,16 +61,22 @@ export function useChunkWatchdog() {
     return unsubscribe;
   }, []);
 
-  // Periodically check for chunks stuck beyond the threshold
+  // Periodically check for chunks stuck beyond the threshold.
+  // Only flag chunks that are actively streaming (have an activeStreamId).
   useEffect(() => {
     const interval = setInterval(() => {
       const now = Date.now();
+      const { activeStreamId } = useChunksStore.getState();
       const stuck = new Set<string>();
-      for (const [id, startTime] of processingStartTimes.current) {
-        if (now - startTime > STUCK_THRESHOLD_MS) {
-          stuck.add(id);
+
+      if (activeStreamId) {
+        for (const [id, startTime] of processingStartTimes.current) {
+          if (now - startTime > STUCK_THRESHOLD_MS) {
+            stuck.add(id);
+          }
         }
       }
+
       setStuckChunkIds((prev) => {
         if (stuck.size === prev.size && [...stuck].every((id) => prev.has(id))) return prev;
         return stuck;
@@ -65,7 +91,6 @@ export function useChunkWatchdog() {
     if (store.activeStreamId) {
       llmService.cancelStream(store.activeStreamId).catch(() => {});
     }
-    store.requestCancel();
     store.updateChunkStatus(chunkId, 'ready');
     store.clearChunkStages(chunkId);
 

--- a/src/hooks/useChunkWatchdog.ts
+++ b/src/hooks/useChunkWatchdog.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useChunksStore } from '../stores/chunksStore';
+import { llmService } from '../services/llmService';
+
+const WATCHDOG_INTERVAL_MS = 5_000;
+const STUCK_THRESHOLD_MS = 60_000;
+
+/**
+ * Detects translation chunks that have been in "processing" state for longer
+ * than STUCK_THRESHOLD_MS (default 60 s) without any status change.
+ *
+ * Returns:
+ *  - stuckChunkIds: Set of chunk IDs currently considered stuck
+ *  - cancelStuckChunk: cancels the active stream, resets the chunk to "ready"
+ */
+export function useChunkWatchdog() {
+  const processingStartTimes = useRef<Map<string, number>>(new Map());
+  const [stuckChunkIds, setStuckChunkIds] = useState<Set<string>>(new Set());
+
+  // Track entry/exit of "processing" state for each chunk
+  useEffect(() => {
+    const unsubscribe = useChunksStore.subscribe((state) => {
+      const now = Date.now();
+      const processingIds = new Set(
+        state.chunks.filter((c) => c.status === 'processing').map((c) => c.id),
+      );
+
+      for (const id of processingIds) {
+        if (!processingStartTimes.current.has(id)) {
+          processingStartTimes.current.set(id, now);
+        }
+      }
+
+      for (const [id] of processingStartTimes.current) {
+        if (!processingIds.has(id)) {
+          processingStartTimes.current.delete(id);
+        }
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+
+  // Periodically check for chunks stuck beyond the threshold
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const stuck = new Set<string>();
+      for (const [id, startTime] of processingStartTimes.current) {
+        if (now - startTime > STUCK_THRESHOLD_MS) {
+          stuck.add(id);
+        }
+      }
+      setStuckChunkIds((prev) => {
+        if (stuck.size === prev.size && [...stuck].every((id) => prev.has(id))) return prev;
+        return stuck;
+      });
+    }, WATCHDOG_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const cancelStuckChunk = useCallback((chunkId: string) => {
+    const store = useChunksStore.getState();
+    if (store.activeStreamId) {
+      llmService.cancelStream(store.activeStreamId).catch(() => {});
+    }
+    store.requestCancel();
+    store.updateChunkStatus(chunkId, 'ready');
+    store.clearChunkStages(chunkId);
+
+    processingStartTimes.current.delete(chunkId);
+    setStuckChunkIds((prev) => {
+      const next = new Set(prev);
+      next.delete(chunkId);
+      return next;
+    });
+  }, []);
+
+  return { stuckChunkIds, cancelStuckChunk };
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -394,7 +394,9 @@
     "emptyTitle": "No document is staged yet.",
     "emptyBody": "Prepare a text into multiple chunks to use the document reader, or switch back to Sandbox for quick single-text work.",
     "indexEmptyTitle": "No units to display.",
-    "indexEmptyBody": "Import a text and split it into chunks to get started."
+    "indexEmptyBody": "Import a text and split it into chunks to get started.",
+    "watchdogStuck": "Stuck",
+    "watchdogCancel": "Cancel & retry"
   },
   "help": {
     "title": "User Guide",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -394,7 +394,9 @@
     "emptyTitle": "Nessun documento ancora preparato.",
     "emptyBody": "Prepara un testo in più chunk per usare il lettore documento, oppure torna a Sandbox per lavorare rapidamente su un testo singolo.",
     "indexEmptyTitle": "Nessuna unità da mostrare.",
-    "indexEmptyBody": "Importa un testo e preparalo in chunk per iniziare."
+    "indexEmptyBody": "Importa un testo e preparalo in chunk per iniziare.",
+    "watchdogStuck": "Bloccato",
+    "watchdogCancel": "Annulla e riprova"
   },
   "help": {
     "title": "Guida Utente",


### PR DESCRIPTION
Closes #55

## Cosa fa

- **`useChunkWatchdog`** (nuovo hook): si iscrive allo store dei chunk, traccia il timestamp di ingresso in `processing` per ogni chunk, rileva chunk bloccati da >60 s tramite un intervallo ogni 5 s
- **InsightsDrawer IndexTab**: se un chunk è stuck, l'icona spinner diventa un orologio (Clock) e appare un banner arancione **"Bloccato · Annulla e riprova"**
- Il bottone chiama `cancelStuckChunk`: cancella lo stream Rust via `cancel_stream`, resetta il chunk a `ready`, pulisce gli stage results — senza interrompere manualmente l'intera pipeline

## Note
- Nessuna modifica al backend Rust (il cancellation token esistente era già sufficiente)
- 121/121 test passati