### PR TITLE
fix: bug vari issue #98

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sqlx",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2.5.6", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "json"] }
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,69 @@
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use tauri::State;
+use tauri_plugin_sql::{DbInstances, DbPool};
+
+#[derive(Debug, Deserialize)]
+pub struct SqlStatement {
+    query: String,
+    #[serde(default)]
+    params: Vec<JsonValue>,
+}
+
+#[tauri::command]
+pub async fn execute_transaction(
+    db_instances: State<'_, DbInstances>,
+    db: String,
+    statements: Vec<SqlStatement>,
+) -> Result<(), String> {
+    let instances = db_instances.0.read().await;
+    let db_pool = instances
+        .get(&db)
+        .ok_or_else(|| format!("Database not loaded: {db}"))?;
+
+    match db_pool {
+        DbPool::Sqlite(pool) => {
+            let mut transaction = pool.begin().await.map_err(|error| error.to_string())?;
+
+            for statement in statements {
+                let mut query = sqlx::query(&statement.query);
+                for value in statement.params {
+                    query = bind_json_value(query, value);
+                }
+                query
+                    .execute(&mut *transaction)
+                    .await
+                    .map_err(|error| error.to_string())?;
+            }
+
+            transaction
+                .commit()
+                .await
+                .map_err(|error| error.to_string())?;
+            Ok(())
+        }
+        #[allow(unreachable_patterns)]
+        _ => Err("Only SQLite transactions are supported".to_string()),
+    }
+}
+
+fn bind_json_value<'q>(
+    query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    value: JsonValue,
+) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    if value.is_null() {
+        query.bind(None::<JsonValue>)
+    } else if let Some(value) = value.as_str() {
+        query.bind(value.to_owned())
+    } else if let Some(value) = value.as_bool() {
+        query.bind(value)
+    } else if let Some(value) = value.as_i64() {
+        query.bind(value)
+    } else if let Some(value) = value.as_u64() {
+        query.bind(value as i64)
+    } else if let Some(value) = value.as_f64() {
+        query.bind(value)
+    } else {
+        query.bind(value)
+    }
+}

--- a/src-tauri/src/documents.rs
+++ b/src-tauri/src/documents.rs
@@ -202,6 +202,8 @@ fn build_markdown_from_document_xml(
     let mut run_italic = false;
     let mut paragraph_style: Option<String> = None;
     let mut paragraph_is_list = false;
+    let mut footnote_number_by_id: BTreeMap<String, usize> = BTreeMap::new();
+    let mut referenced_footnotes: Vec<String> = Vec::new();
 
     loop {
         match reader.read_event() {
@@ -249,7 +251,17 @@ fn build_markdown_from_document_xml(
                         let value = id
                             .decode_and_unescape_value(reader.decoder())
                             .map_err(|e| format!("Failed to decode footnote id: {}", e))?;
-                        current_paragraph.push_str(&format!("[^{value}]"));
+                        let old_id = value.to_string();
+                        let number = match footnote_number_by_id.get(&old_id) {
+                            Some(existing) => *existing,
+                            None => {
+                                referenced_footnotes.push(old_id.clone());
+                                let next = referenced_footnotes.len();
+                                footnote_number_by_id.insert(old_id, next);
+                                next
+                            }
+                        };
+                        current_paragraph.push_str(&format!("[^{number}]"));
                     }
                 }
             }
@@ -291,10 +303,15 @@ fn build_markdown_from_document_xml(
     }
 
     let mut blocks = paragraphs;
-    if !footnotes.is_empty() {
-        let footnote_block = footnotes
+    if !referenced_footnotes.is_empty() {
+        let footnote_block = referenced_footnotes
             .iter()
-            .map(|(id, text)| format!("[^{id}]: {text}"))
+            .enumerate()
+            .filter_map(|(index, original_id)| {
+                footnotes
+                    .get(original_id)
+                    .map(|text| format!("[^{}]: {text}", index + 1))
+            })
             .collect::<Vec<_>>()
             .join("\n\n");
         if !footnote_block.trim().is_empty() {
@@ -1123,7 +1140,7 @@ mod tests {
 
         let extracted = extract_docx_markdown_from_bytes(&buffer).expect("expected markdown");
 
-        assert_eq!(extracted, "Alpha *beta* gamma[^2]\n\n[^2]: Footnote text");
+        assert_eq!(extracted, "Alpha *beta* gamma[^1]\n\n[^1]: Footnote text");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod db;
 mod documents;
 mod llm;
 
@@ -48,6 +49,7 @@ pub fn run() {
       Ok(())
     })
     .invoke_handler(tauri::generate_handler![
+      db::execute_transaction,
       llm::run_stage,
       llm::run_stage_stream,
       llm::cancel_stream,

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -1306,10 +1306,10 @@ fn build_stage_prompts(
         .iter()
         .map(|g| {
             format!(
-                "- {} -> {} ({})",
+                "- source: {}\n  target: {}\n  notes: {}",
                 g.term,
                 g.translation,
-                g.notes.as_deref().unwrap_or("")
+                g.notes.as_deref().unwrap_or("-")
             )
         })
         .collect::<Vec<_>>()
@@ -1324,18 +1324,32 @@ fn build_stage_prompts(
         ""
     };
 
+    let glossary_rules = if glossary_str.is_empty() {
+        "Glossary Constraints:\n- No glossary entries were provided.".to_string()
+    } else {
+        format!(
+            "Glossary Constraints:\n\
+             - Treat every glossary entry as mandatory terminology, not as a suggestion\n\
+             - When a source glossary term appears, use the required target term exactly unless the notes explicitly justify a variant\n\
+             - Preserve case, product names, abbreviations, and domain terminology consistently across the whole translation\n\
+             - Do not omit glossary terms, paraphrase them away, or replace them with near-synonyms\n\
+             - If a glossary term appears inside Markdown, links, or footnotes, still apply the glossary while preserving the surrounding syntax\n\
+             - Glossary entries:\n{}",
+            glossary_str,
+        )
+    };
+
     let system_prompt = format!(
         "You are an expert translator and linguist specialized in {} to {} translation.\n\n\
          Core Instructions:\n{}\n\n\
-         Glossary of Terms:\n{}{}",
+         Structural Preservation Rules:\n\
+         - Preserve paragraph boundaries and line breaks unless the source is clearly malformed\n\
+         - Do not collapse repeated spaces, tabs, list structure, or footnote placement when they carry formatting meaning\n\n\
+         {}{}",
         config.source_language,
         config.target_language,
         stage.prompt,
-        if glossary_str.is_empty() {
-            "No specific glossary entries.".to_string()
-        } else {
-            glossary_str
-        },
+        glossary_rules,
         markdown_rules,
     );
 
@@ -1889,7 +1903,8 @@ mod tests {
 
         assert!(system.contains("English to Italian"));
         assert!(system.contains("Translate accurately."));
-        assert!(system.contains("API -> API"));
+        assert!(system.contains("source: API"));
+        assert!(system.contains("target: API"));
         assert!(user.contains("Hello world"));
         assert!(!user.contains("Previous Iteration"));
         assert!(!user.contains("Previous Chunk Translation Context"));
@@ -1919,7 +1934,7 @@ mod tests {
         let stage = make_stage("gemini");
         let (system, _) = build_stage_prompts("text", &stage, &config, &None, &None);
 
-        assert!(system.contains("No specific glossary entries"));
+        assert!(system.contains("No glossary entries were provided"));
     }
 
     #[test]
@@ -1940,8 +1955,12 @@ mod tests {
         let stage = make_stage("gemini");
         let (system, _) = build_stage_prompts("text", &stage, &config, &None, &None);
 
-        assert!(system.contains("API -> API (tech)"));
-        assert!(system.contains("bug -> errore ()"));
+        assert!(system.contains("source: API"));
+        assert!(system.contains("target: API"));
+        assert!(system.contains("notes: tech"));
+        assert!(system.contains("source: bug"));
+        assert!(system.contains("target: errore"));
+        assert!(system.contains("Treat every glossary entry as mandatory terminology"));
     }
 
     #[test]
@@ -1954,6 +1973,7 @@ mod tests {
 
         assert!(system.contains("Markdown"));
         assert!(system.contains("Preserve every Markdown marker"));
+        assert!(system.contains("Preserve paragraph boundaries and line breaks"));
         assert!(user.contains("Text with note[^1]."));
     }
 

--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -12,7 +12,7 @@ export const HighlightedText = forwardRef<HTMLDivElement, Props>(
     return (
       <div
         ref={ref}
-        className={`w-full ${className}`}
+        className={`w-full whitespace-pre-wrap break-words ${className}`}
         style={style}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}

--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -1,14 +1,22 @@
+import { forwardRef } from 'react';
+import type { CSSProperties } from 'react';
+
 interface Props {
   html: string;
   className?: string;
+  style?: CSSProperties;
 }
 
-export function HighlightedText({ html, className = '' }: Props) {
-  return (
-    <div
-      className={`min-h-[420px] w-full resize-none text-[15px] leading-8 text-editorial-ink ${className}`}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
+export const HighlightedText = forwardRef<HTMLDivElement, Props>(
+  function HighlightedText({ html, className = '', style }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={`min-h-[420px] w-full resize-none text-[15px] leading-8 text-editorial-ink ${className}`}
+        style={style}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  },
+);

--- a/src/components/common/HighlightedText.tsx
+++ b/src/components/common/HighlightedText.tsx
@@ -12,7 +12,7 @@ export const HighlightedText = forwardRef<HTMLDivElement, Props>(
     return (
       <div
         ref={ref}
-        className={`min-h-[420px] w-full resize-none text-[15px] leading-8 text-editorial-ink ${className}`}
+        className={`w-full ${className}`}
         style={style}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -11,7 +11,9 @@ import {
 import { HighlightedText } from './HighlightedText';
 
 type EditorMode = 'write' | 'preview' | 'split';
-type TextSize = 'sm' | 'md' | 'lg';
+
+const TEXT_SIZE_STEPS = ['0.75rem', '0.825rem', '0.9rem', '1rem', '1.125rem', '1.25rem', '1.375rem'] as const;
+const DEFAULT_TEXT_SIZE_STEP = 3;
 
 interface MarkdownEditorProps {
   value: string;
@@ -49,18 +51,14 @@ export function MarkdownEditor({
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [mode, setMode] = useState<EditorMode>('write');
-  const [textSize, setTextSize] = useState<TextSize>('md');
+  const [textSizeStep, setTextSizeStep] = useState(DEFAULT_TEXT_SIZE_STEP);
   const [selection, setSelection] = useState({ start: 0, end: 0 });
   const [toolbarOpen, setToolbarOpen] = useState(false);
   const previewHtml = useMemo(() => {
     if (mode === 'write' && !readOnly) return '';
     return renderMarkdownToHtmlFragment(value);
   }, [mode, readOnly, value]);
-  const textSizeStyles: Record<TextSize, { fontSize: string }> = {
-    sm: { fontSize: '0.95rem' },
-    md: { fontSize: '1rem' },
-    lg: { fontSize: '1.125rem' },
-  };
+  const textSizeStyle = { fontSize: TEXT_SIZE_STEPS[textSizeStep] };
   const activeCommands = useMemo(() => {
     if (!markdownEnabled || mode === 'preview') {
       return {
@@ -161,14 +159,14 @@ export function MarkdownEditor({
       onKeyUp={syncSelection}
       onSelect={syncSelection}
       className={`${fillHeight ? 'flex-1 min-h-[100px] h-0' : minHeightClassName} w-full resize-y bg-transparent outline-none ${textClassName} disabled:opacity-70 read-only:cursor-not-allowed`}
-      style={textSizeStyles[textSize]}
+      style={textSizeStyle}
     />
   );
 
   const preview = (
     <div
       className={`${minHeightClassName} rounded-2xl border border-editorial-border/70 bg-editorial-bg/55 p-4 ${previewClassName}`}
-      style={textSizeStyles[textSize]}
+      style={textSizeStyle}
     >
       {value.trim() ? (
         <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
@@ -193,14 +191,14 @@ export function MarkdownEditor({
           </button>
           {/* Mode indicators — non-interactive, show current editor state */}
           <div className="flex items-center gap-1" aria-hidden="true">
-            <span className={`rounded-full p-1.5 transition-colors ${mode === 'write' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+            <span className={`rounded-full p-1.5 transition-colors ${mode === 'write' ? 'bg-editorial-accent text-white' : 'text-editorial-border'}`}>
               <Pencil size={11} />
             </span>
-            <span className={`rounded-full p-1.5 transition-colors ${mode === 'preview' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+            <span className={`rounded-full p-1.5 transition-colors ${mode === 'preview' ? 'bg-editorial-accent text-white' : 'text-editorial-border'}`}>
               <Eye size={11} />
             </span>
             {markdownEnabled ? (
-              <span className={`rounded-full p-1.5 transition-colors ${mode === 'split' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+              <span className={`rounded-full p-1.5 transition-colors ${mode === 'split' ? 'bg-editorial-accent text-white' : 'text-editorial-border'}`}>
                 <Columns2 size={11} />
               </span>
             ) : null}
@@ -244,16 +242,16 @@ export function MarkdownEditor({
             <div className="flex items-center gap-1">
               <ToolbarButton
                 active={false}
-                onClick={() => setTextSize((s) => s === 'lg' ? 'md' : 'sm')}
+                onClick={() => setTextSizeStep((s) => Math.max(0, s - 1))}
                 title={t('editor.textSmall')}
                 ariaLabel={t('editor.textSmall')}
-                disabled={textSize === 'sm'}
+                disabled={textSizeStep === 0}
               >
                 <Minus size={15} />
               </ToolbarButton>
               <ToolbarButton
-                active={textSize === 'md'}
-                onClick={() => setTextSize('md')}
+                active={textSizeStep === DEFAULT_TEXT_SIZE_STEP}
+                onClick={() => setTextSizeStep(DEFAULT_TEXT_SIZE_STEP)}
                 title={t('editor.textMedium')}
                 ariaLabel={t('editor.textMedium')}
               >
@@ -261,10 +259,10 @@ export function MarkdownEditor({
               </ToolbarButton>
               <ToolbarButton
                 active={false}
-                onClick={() => setTextSize((s) => s === 'sm' ? 'md' : 'lg')}
+                onClick={() => setTextSizeStep((s) => Math.min(TEXT_SIZE_STEPS.length - 1, s + 1))}
                 title={t('editor.textLarge')}
                 ariaLabel={t('editor.textLarge')}
-                disabled={textSize === 'lg'}
+                disabled={textSizeStep === TEXT_SIZE_STEPS.length - 1}
               >
                 <Plus size={15} />
               </ToolbarButton>

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -163,6 +163,8 @@ export function MarkdownEditor({
     });
   };
 
+  const textareaClassName = `${fillHeight ? 'flex-1 min-h-[100px] h-0' : minHeightClassName} w-full resize-y bg-transparent outline-none ${textClassName} disabled:opacity-70 read-only:cursor-not-allowed`;
+
   const textarea = (
     <textarea
       ref={textareaRef}
@@ -174,7 +176,7 @@ export function MarkdownEditor({
       onClick={syncSelection}
       onKeyUp={syncSelection}
       onSelect={syncSelection}
-      className={`${fillHeight ? 'flex-1 min-h-[100px] h-0' : minHeightClassName} w-full resize-y bg-transparent outline-none ${textClassName} disabled:opacity-70 read-only:cursor-not-allowed`}
+      className={textareaClassName}
       style={textSizeStyle}
     />
   );
@@ -381,7 +383,7 @@ export function MarkdownEditor({
       {mode === 'write' && !readOnly && highlightHtml ? (
         fillHeight ? (
           // Overlay: HighlightedText behind transparent textarea — styled text visible while editing
-          <div className={`relative flex-1 min-h-0${disabled ? ' opacity-70' : ''}`}>
+          <div className="relative flex-1 min-h-0">
             <HighlightedText
               ref={highlightLayerRef}
               html={highlightHtml}
@@ -398,7 +400,7 @@ export function MarkdownEditor({
               onKeyUp={syncSelection}
               onSelect={syncSelection}
               onScroll={syncHighlightLayer}
-              className="absolute inset-0 h-full w-full resize-none bg-transparent outline-none"
+              className={`${textareaClassName} absolute inset-0 h-full w-full resize-none`}
               style={{ ...textSizeStyle, color: 'transparent', caretColor: 'var(--color-editorial-ink)' }}
             />
           </div>
@@ -504,4 +506,3 @@ function ToolbarLabel({ children }: { children: ReactNode }) {
 function ToolbarSeparator() {
   return <span className="mx-1 h-5 w-px bg-editorial-border/80" aria-hidden="true" />;
 }
-

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -12,7 +12,15 @@ import { HighlightedText } from './HighlightedText';
 
 type EditorMode = 'write' | 'preview' | 'split';
 
-const TEXT_SIZE_STEPS = ['0.75rem', '0.825rem', '0.9rem', '1rem', '1.125rem', '1.25rem', '1.375rem'] as const;
+const TEXT_SIZE_STEPS = [
+  { fontSize: '0.75rem', lineHeight: '1.5rem' },
+  { fontSize: '0.825rem', lineHeight: '1.65rem' },
+  { fontSize: '0.9rem', lineHeight: '1.8rem' },
+  { fontSize: '1rem', lineHeight: '2rem' },
+  { fontSize: '1.125rem', lineHeight: '2.25rem' },
+  { fontSize: '1.25rem', lineHeight: '2.5rem' },
+  { fontSize: '1.375rem', lineHeight: '2.75rem' },
+] as const;
 const DEFAULT_TEXT_SIZE_STEP = 3;
 
 interface MarkdownEditorProps {
@@ -50,6 +58,7 @@ export function MarkdownEditor({
 }: MarkdownEditorProps) {
   const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const highlightLayerRef = useRef<HTMLDivElement | null>(null);
   const [mode, setMode] = useState<EditorMode>('write');
   const [textSizeStep, setTextSizeStep] = useState(DEFAULT_TEXT_SIZE_STEP);
   const [selection, setSelection] = useState({ start: 0, end: 0 });
@@ -58,7 +67,7 @@ export function MarkdownEditor({
     if (mode === 'write' && !readOnly) return '';
     return renderMarkdownToHtmlFragment(value);
   }, [mode, readOnly, value]);
-  const textSizeStyle = { fontSize: TEXT_SIZE_STEPS[textSizeStep] };
+  const textSizeStyle = TEXT_SIZE_STEPS[textSizeStep];
   const activeCommands = useMemo(() => {
     if (!markdownEnabled || mode === 'preview') {
       return {
@@ -111,10 +120,17 @@ export function MarkdownEditor({
       element.focus();
       element.setSelectionRange(matchIndex, matchIndex + normalizedQuery.length);
       element.scrollTop = Math.max(0, element.scrollHeight * (matchIndex / Math.max(1, value.length)) - 120);
+      syncHighlightLayer();
       updateSelection(matchIndex, matchIndex + normalizedQuery.length);
       onFocusQueryHandled?.();
     });
   }, [focusQuery, focusRequestId, onFocusQueryHandled, value]);
+
+  const syncHighlightLayer = () => {
+    if (highlightLayerRef.current && textareaRef.current) {
+      highlightLayerRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
+  };
 
   const updateSelection = (start: number, end: number) => {
     setSelection((current) =>
@@ -363,13 +379,38 @@ export function MarkdownEditor({
         ) : null}
       </div>
       {mode === 'write' && !readOnly && highlightHtml ? (
-        <div className={fillHeight ? 'flex flex-col flex-1 min-h-0' : 'space-y-2'}>
-          {textarea}
-          <HighlightedText html={highlightHtml} className={fillHeight ? `flex-1 min-h-0 overflow-y-auto ${textClassName}` : `${minHeightClassName} ${textClassName}`} />
-        </div>
+        fillHeight ? (
+          // Overlay: HighlightedText behind transparent textarea — styled text visible while editing
+          <div className={`relative flex-1 min-h-0${disabled ? ' opacity-70' : ''}`}>
+            <HighlightedText
+              ref={highlightLayerRef}
+              html={highlightHtml}
+              style={{ ...textSizeStyle, minHeight: 0 }}
+              className={`pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words select-none ${textClassName}`}
+            />
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(event) => onChange(event.target.value)}
+              disabled={disabled}
+              placeholder={placeholder}
+              onClick={syncSelection}
+              onKeyUp={syncSelection}
+              onSelect={syncSelection}
+              onScroll={syncHighlightLayer}
+              className="absolute inset-0 h-full w-full resize-none bg-transparent outline-none"
+              style={{ ...textSizeStyle, color: 'transparent', caretColor: 'var(--color-editorial-ink)' }}
+            />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {textarea}
+            <HighlightedText html={highlightHtml} style={textSizeStyle} className={`${minHeightClassName} ${textClassName}`} />
+          </div>
+        )
       ) : null}
       {mode === 'write' && readOnly && highlightHtml ? (
-        <HighlightedText html={highlightHtml} className={fillHeight ? `flex-1 min-h-0 overflow-y-auto ${textClassName}` : `${minHeightClassName} ${textClassName}`} />
+        <HighlightedText html={highlightHtml} style={textSizeStyle} className={fillHeight ? `flex-1 min-h-0 overflow-y-auto ${textClassName}` : `${minHeightClassName} ${textClassName}`} />
       ) : null}
       {mode === 'write' && !highlightHtml ? textarea : null}
       {mode === 'preview' ? preview : null}

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -230,7 +230,7 @@ export function MarkdownEditor({
               title={t('editor.write')}
               ariaLabel={t('editor.write')}
             >
-              <PencilIcon />
+              <Pencil size={15} />
             </ToolbarButton>
             <ToolbarButton
               active={mode === 'preview'}
@@ -362,7 +362,7 @@ export function MarkdownEditor({
               ariaLabel={t('editor.unorderedList')}
               disabled={commandEditingDisabled}
             >
-              <ListIcon />
+              <List size={15} />
             </CommandButton>
             <CommandButton
               active={activeCommands['ordered-list']}
@@ -371,7 +371,7 @@ export function MarkdownEditor({
               ariaLabel={t('editor.orderedList')}
               disabled={commandEditingDisabled}
             >
-              <ListOrderedIcon />
+              <ListOrdered size={15} />
             </CommandButton>
           </div>
         ) : null}
@@ -386,7 +386,7 @@ export function MarkdownEditor({
               ref={highlightLayerRef}
               html={highlightHtml}
               style={{ ...textSizeStyle, minHeight: 0 }}
-              className={`pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words select-none ${textClassName}`}
+              className={`pointer-events-none absolute inset-0 overflow-y-scroll scrollbar-hidden whitespace-pre-wrap break-words select-none ${textClassName}`}
             />
             <textarea
               ref={textareaRef}
@@ -505,14 +505,3 @@ function ToolbarSeparator() {
   return <span className="mx-1 h-5 w-px bg-editorial-border/80" aria-hidden="true" />;
 }
 
-function PencilIcon() {
-  return <Pencil size={15} />;
-}
-
-function ListIcon() {
-  return <List size={15} />;
-}
-
-function ListOrderedIcon() {
-  return <ListOrdered size={15} />;
-}

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -191,16 +191,17 @@ export function MarkdownEditor({
           >
             {toolbarOpen ? <PanelTopClose size={15} /> : <PanelTopOpen size={15} />}
           </button>
-          <div className="flex items-center gap-2 text-editorial-muted">
-            <span className={`rounded-full border p-1.5 ${mode === 'write' ? 'border-editorial-ink bg-editorial-ink text-white' : 'border-editorial-border bg-white/70'}`}>
-              <Pencil size={13} />
+          {/* Mode indicators — non-interactive, show current editor state */}
+          <div className="flex items-center gap-1" aria-hidden="true">
+            <span className={`rounded-full p-1.5 transition-colors ${mode === 'write' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+              <Pencil size={11} />
             </span>
-            <span className={`rounded-full border p-1.5 ${mode === 'preview' ? 'border-editorial-ink bg-editorial-ink text-white' : 'border-editorial-border bg-white/70'}`}>
-              <Eye size={13} />
+            <span className={`rounded-full p-1.5 transition-colors ${mode === 'preview' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+              <Eye size={11} />
             </span>
             {markdownEnabled ? (
-              <span className={`rounded-full border p-1.5 ${mode === 'split' ? 'border-editorial-ink bg-editorial-ink text-white' : 'border-editorial-border bg-white/70'}`}>
-                <Columns2 size={13} />
+              <span className={`rounded-full p-1.5 transition-colors ${mode === 'split' ? 'bg-editorial-ink text-white' : 'text-editorial-border'}`}>
+                <Columns2 size={11} />
               </span>
             ) : null}
           </div>
@@ -242,10 +243,11 @@ export function MarkdownEditor({
             </span>
             <div className="flex items-center gap-1">
               <ToolbarButton
-                active={textSize === 'sm'}
-                onClick={() => setTextSize('sm')}
+                active={false}
+                onClick={() => setTextSize((s) => s === 'lg' ? 'md' : 'sm')}
                 title={t('editor.textSmall')}
                 ariaLabel={t('editor.textSmall')}
+                disabled={textSize === 'sm'}
               >
                 <Minus size={15} />
               </ToolbarButton>
@@ -258,10 +260,11 @@ export function MarkdownEditor({
                 <Type size={15} />
               </ToolbarButton>
               <ToolbarButton
-                active={textSize === 'lg'}
-                onClick={() => setTextSize('lg')}
+                active={false}
+                onClick={() => setTextSize((s) => s === 'sm' ? 'md' : 'lg')}
                 title={t('editor.textLarge')}
                 ariaLabel={t('editor.textLarge')}
+                disabled={textSize === 'lg'}
               >
                 <Plus size={15} />
               </ToolbarButton>
@@ -400,6 +403,7 @@ function ToolbarButton({
   return (
     <button
       type="button"
+      onMouseDown={(event) => event.preventDefault()}
       onClick={onClick}
       title={title}
       aria-label={ariaLabel}

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -38,7 +38,8 @@ import { estimatePipelineCost } from '../../utils/costEstimate';
 import { CopyButton, MarkdownEditor, ProcessingLine } from '../common';
 import { CostBreakdownPanel } from '../pipeline/CostBadge';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
-import { useGlossaryHighlight } from '../../hooks/useGlossaryHighlight';
+import { escapeHtml, useGlossaryHighlight } from '../../hooks/useGlossaryHighlight';
+import { highlightSuperscriptMarkersHtml } from '../../utils/footnoteExtractor';
 
 interface DocumentViewProps {
   onRetranslateChunk: (chunkId: string) => void;
@@ -169,6 +170,14 @@ export function DocumentView({
     showHighlight && paneFocus !== 'source' ? config.glossary : [],
     'translation',
   );
+
+  const sourceHighlightHtml = useMemo(() => {
+    const hasFootnotes = Boolean(currentChunk?.footnotes?.length);
+    const showGlossary = showHighlight && currentChunk?.status !== 'completed' && paneFocus !== 'translation';
+    if (!showGlossary && !hasFootnotes) return null;
+    const base = showGlossary ? sourceHighlight.html : escapeHtml(deferredOriginalText);
+    return hasFootnotes ? highlightSuperscriptMarkersHtml(base) : base;
+  }, [currentChunk?.footnotes?.length, currentChunk?.status, showHighlight, paneFocus, sourceHighlight.html, deferredOriginalText]);
 
   if (!currentChunk) {
     return (
@@ -458,7 +467,7 @@ export function DocumentView({
                 fillHeight
                 textClassName="text-[15px] leading-8 text-editorial-ink"
                 previewClassName="min-h-[280px] text-[15px] leading-8 text-editorial-ink"
-                highlightHtml={showHighlight && currentChunk.status !== 'completed' ? sourceHighlight.html : null}
+                highlightHtml={sourceHighlightHtml}
               />
             </DocumentPage>
           )}

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -172,12 +172,12 @@ export function DocumentView({
   );
 
   const sourceHighlightHtml = useMemo(() => {
-    const hasFootnotes = Boolean(currentChunk?.footnotes?.length);
+    const hasFootnoteMarkers = /\[[⁰¹²³⁴⁵⁶⁷⁸⁹]/.test(deferredOriginalText);
     const showGlossary = showHighlight && currentChunk?.status !== 'completed' && paneFocus !== 'translation';
-    if (!showGlossary && !hasFootnotes) return null;
+    if (!showGlossary && !hasFootnoteMarkers) return null;
     const base = showGlossary ? sourceHighlight.html : escapeHtml(deferredOriginalText);
-    return hasFootnotes ? highlightSuperscriptMarkersHtml(base) : base;
-  }, [currentChunk?.footnotes?.length, currentChunk?.status, showHighlight, paneFocus, sourceHighlight.html, deferredOriginalText]);
+    return hasFootnoteMarkers ? highlightSuperscriptMarkersHtml(base) : base;
+  }, [deferredOriginalText, currentChunk?.status, showHighlight, paneFocus, sourceHighlight.html]);
 
   if (!currentChunk) {
     return (

--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,7 @@ mark.hl-mismatch {
 }
 
 .hl-footnote-marker {
-  color: var(--color-editorial-accent);
+  color: var(--color-editorial-accent) !important;
   font-family: var(--font-mono);
   font-weight: 600;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,14 @@ mark.hl-mismatch {
 }
 
 .hl-footnote-marker {
-  color: var(--color-editorial-accent) !important;
+  color: var(--color-editorial-accent);
   font-family: var(--font-mono);
   font-weight: 600;
+}
+
+.scrollbar-hidden {
+  scrollbar-width: none;
+}
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -60,3 +60,9 @@ mark.hl-mismatch {
   color: inherit;
   cursor: help;
 }
+
+.hl-footnote-marker {
+  color: var(--color-editorial-accent);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
 
 const dbState = vi.hoisted(() => {
   let failRollback = false;
@@ -50,22 +51,22 @@ describe('runInTransaction', () => {
     dbState.setFailRollback(false);
   });
 
-  it('wraps callback statements in BEGIN/COMMIT', async () => {
+  it('executes callback statements through the native transaction command', async () => {
     const { runInTransaction } = await import('./dbService');
 
     await runInTransaction(async (run) => {
       await run('INSERT INTO foo VALUES ($1)', ['bar']);
     });
 
-    const calls = dbState.db.execute.mock.calls.map(([q]: [string]) => q.trim());
-    expect(calls).toContain('INSERT INTO foo VALUES ($1)');
-    expect(calls).toContain('BEGIN');
-    expect(calls).toContain('COMMIT');
-    expect(calls.indexOf('BEGIN')).toBeLessThan(calls.indexOf('INSERT INTO foo VALUES ($1)'));
-    expect(calls.indexOf('INSERT INTO foo VALUES ($1)')).toBeLessThan(calls.indexOf('COMMIT'));
+    expect(invoke).toHaveBeenCalledWith('execute_transaction', {
+      db: 'sqlite:glossa.db',
+      statements: [{ query: 'INSERT INTO foo VALUES ($1)', params: ['bar'] }],
+    });
+    expect(dbState.db.execute).not.toHaveBeenCalledWith('BEGIN');
+    expect(dbState.db.execute).not.toHaveBeenCalledWith('COMMIT');
   });
 
-  it('issues ROLLBACK and re-throws the error when the callback throws', async () => {
+  it('does not execute staged statements when the callback throws', async () => {
     const { runInTransaction } = await import('./dbService');
 
     await expect(
@@ -75,10 +76,10 @@ describe('runInTransaction', () => {
       }),
     ).rejects.toThrow('simulated failure');
 
-    const calls = dbState.db.execute.mock.calls.map(([q]: [string]) => q.trim());
-    expect(calls).toContain('BEGIN');
-    expect(calls).toContain('ROLLBACK');
-    expect(calls).not.toContain('COMMIT');
+    expect(invoke).not.toHaveBeenCalledWith(
+      'execute_transaction',
+      expect.anything(),
+    );
   });
 
   it('returns the value produced by the callback', async () => {

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -1,10 +1,12 @@
 import Database from '@tauri-apps/plugin-sql';
+import { invoke } from '@tauri-apps/api/core';
 
 let db: Database | null = null;
+const DB_URL = 'sqlite:glossa.db';
 
 async function getDb(): Promise<Database> {
   if (!db) {
-    db = await Database.load('sqlite:glossa.db');
+    db = await Database.load(DB_URL);
   }
   return db;
 }
@@ -230,19 +232,23 @@ export async function runInTransaction<T>(
   fn: (run: (query: string, params?: unknown[]) => Promise<void>) => Promise<T>,
 ): Promise<T> {
   return serializeWrite(async () => {
-    const conn = await getDb();
+    await getDb();
+    const statements: Array<{ query: string; params: unknown[] }> = [];
+    // Tauri SQL uses a pool, so BEGIN/COMMIT issued from JS can land on
+    // different SQLite connections and deadlock. Stage writes here; the
+    // native command executes them on one connection inside a real transaction.
     const run = async (query: string, params: unknown[] = []) => {
-      await conn.execute(query, params);
+      statements.push({ query, params });
     };
-    await conn.execute('BEGIN');
-    try {
-      const result = await fn(run);
-      await conn.execute('COMMIT');
-      return result;
-    } catch (error) {
-      try { await conn.execute('ROLLBACK'); } catch { /* ignore rollback error */ }
-      throw error;
+
+    const result = await fn(run);
+    if (statements.length > 0) {
+      await invoke('execute_transaction', {
+        db: DB_URL,
+        statements,
+      });
     }
+    return result;
   });
 }
 

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -161,8 +161,8 @@ function buildPlainText(chunks: TranslationChunk[], separator = '\n\n'): string 
 
 function buildMarkdown(chunks: TranslationChunk[], separator = '\n\n'): string {
   return chunks
-    .map((chunk) => (chunk.currentDraft || chunk.originalText).trim())
-    .filter(Boolean)
+    .map((chunk) => chunk.currentDraft || chunk.originalText)
+    .filter((chunk) => chunk.trim().length > 0)
     .join(separator);
 }
 

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -8,7 +8,15 @@ import type {
 } from '../types';
 import { usePipelineStore } from './pipelineStore';
 import { useUiStore } from './uiStore';
-import { chunkText, findBestSplitIndex, generateId, qualityDefault, resolveSplitIndex } from '../utils';
+import {
+  chunkText,
+  findBestSplitIndex,
+  generateId,
+  qualityDefault,
+  resolveSplitIndex,
+  trimOuterBlankLines,
+  trimSplitFragment,
+} from '../utils';
 import { assignChunkFootnotes, extractFootnotes, replaceMarkersWithSuperscripts, stripFootnoteMarkers } from '../utils/footnoteExtractor';
 
 interface ChunksState {
@@ -376,16 +384,4 @@ function syncSelectedChunk(chunks: TranslationChunk[], preferredId?: string | nu
     return;
   }
   ui.setSelectedChunkId(chunks[0]?.id ?? null);
-}
-
-function trimOuterBlankLines(text: string): string {
-  return text
-    .replace(/^(?:[ \t]*\r?\n)+/, '')
-    .replace(/(?:\r?\n[ \t]*)+$/, '');
-}
-
-function trimSplitFragment(text: string): string {
-  return trimOuterBlankLines(text)
-    .replace(/^[ \t]+/, '')
-    .replace(/[ \t]+$/, '');
 }

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -94,10 +94,12 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
       headingAware: config.headingAware,
     }, footnoteMap);
 
+    const ui = useUiStore.getState();
     usePipelineStore.getState().setInputText(
       footnoteMap ? stripFootnoteMarkers(bodyText) : bodyText,
     );
-    useUiStore.getState().setViewMode(chunks.length > 1 ? 'document' : 'sandbox');
+    ui.setViewMode(chunks.length > 1 ? 'document' : 'sandbox');
+    if (chunks.length > 1) ui.setShowChunkDrawer(true);
     syncSelectedChunk(chunks);
     set({ chunks });
   },
@@ -116,10 +118,12 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
     }
 
     const chunks = buildChunks(bodyText, options, footnoteMap);
+    const ui = useUiStore.getState();
     usePipelineStore.getState().setInputText(
       footnoteMap ? stripFootnoteMarkers(bodyText) : bodyText,
     );
-    useUiStore.getState().setViewMode('document');
+    ui.setViewMode('document');
+    ui.setShowChunkDrawer(true);
     syncSelectedChunk(chunks);
     set({ chunks });
   },

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -76,7 +76,7 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
     const { inputText, config } = usePipelineStore.getState();
     if (!inputText.trim()) return;
 
-    let bodyText = inputText.trim();
+    let bodyText = trimOuterBlankLines(inputText);
     let footnoteMap: Map<string, string> | undefined;
 
     if (config.markdownAware) {
@@ -105,7 +105,7 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
   },
 
   loadDocument: (text, options = {}) => {
-    const trimmed = text.trim();
+    const trimmed = trimOuterBlankLines(text);
     if (!trimmed) return;
 
     let bodyText = trimmed;
@@ -246,7 +246,7 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
 
       const merged = resetChunkForSourceEdit({
         ...current,
-        originalText: `${current.originalText.trim()}\n\n${next.originalText.trim()}`,
+        originalText: `${current.originalText}\n\n${next.originalText}`,
       });
 
       const chunks = [
@@ -347,8 +347,8 @@ function splitChunkState(
     markdownAware: usePipelineStore.getState().config.markdownAware,
   });
   if (boundedSplitAt === null) return null;
-  const firstText = chunk.originalText.slice(0, boundedSplitAt).trim();
-  const secondText = chunk.originalText.slice(boundedSplitAt).trim();
+  const firstText = trimSplitFragment(chunk.originalText.slice(0, boundedSplitAt));
+  const secondText = trimSplitFragment(chunk.originalText.slice(boundedSplitAt));
   if (!firstText || !secondText) return null;
 
   const first = resetChunkForSourceEdit({ ...chunk, originalText: firstText });
@@ -376,4 +376,16 @@ function syncSelectedChunk(chunks: TranslationChunk[], preferredId?: string | nu
     return;
   }
   ui.setSelectedChunkId(chunks[0]?.id ?? null);
+}
+
+function trimOuterBlankLines(text: string): string {
+  return text
+    .replace(/^(?:[ \t]*\r?\n)+/, '')
+    .replace(/(?:\r?\n[ \t]*)+$/, '');
+}
+
+function trimSplitFragment(text: string): string {
+  return trimOuterBlankLines(text)
+    .replace(/^[ \t]+/, '')
+    .replace(/[ \t]+$/, '');
 }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -118,6 +118,7 @@ export const useUiStore = create<UiState>()(
       show
         ? {
             showDocumentDrawer: true,
+            showChunkDrawer: false,
             documentDrawerTab: tab ?? state.documentDrawerTab,
             showConfigDrawer: false,
             showSettings: false,
@@ -131,6 +132,7 @@ export const useUiStore = create<UiState>()(
       show
         ? {
             showChunkDrawer: true,
+            showDocumentDrawer: false,
             chunkDrawerTab: tab ?? state.chunkDrawerTab,
             showConfigDrawer: false,
             showSettings: false,

--- a/src/utils/documentWorkflow.ts
+++ b/src/utils/documentWorkflow.ts
@@ -65,8 +65,8 @@ export function buildSplitPreview(
       adjustedSplitAt: null,
     };
   }
-  const beforeText = text.slice(0, boundedSplitAt).trim();
-  const afterText = text.slice(boundedSplitAt).trim();
+  const beforeText = trimSplitFragment(text.slice(0, boundedSplitAt));
+  const afterText = trimSplitFragment(text.slice(boundedSplitAt));
 
   return {
     beforeText,
@@ -74,6 +74,18 @@ export function buildSplitPreview(
     isValid: beforeText.length > 0 && afterText.length > 0,
     adjustedSplitAt: boundedSplitAt,
   };
+}
+
+function trimOuterBlankLines(text: string): string {
+  return text
+    .replace(/^(?:[ \t]*\r?\n)+/, '')
+    .replace(/(?:\r?\n[ \t]*)+$/, '');
+}
+
+function trimSplitFragment(text: string): string {
+  return trimOuterBlankLines(text)
+    .replace(/^[ \t]+/, '')
+    .replace(/[ \t]+$/, '');
 }
 
 function buildImportWarnings(

--- a/src/utils/documentWorkflow.ts
+++ b/src/utils/documentWorkflow.ts
@@ -1,4 +1,4 @@
-import { chunkText, estimateTextStats, resolveSplitIndex } from './index';
+import { chunkText, estimateTextStats, resolveSplitIndex, trimSplitFragment } from './index';
 
 export interface ImportPreviewChunk {
   index: number;
@@ -75,19 +75,6 @@ export function buildSplitPreview(
     adjustedSplitAt: boundedSplitAt,
   };
 }
-
-function trimOuterBlankLines(text: string): string {
-  return text
-    .replace(/^(?:[ \t]*\r?\n)+/, '')
-    .replace(/(?:\r?\n[ \t]*)+$/, '');
-}
-
-function trimSplitFragment(text: string): string {
-  return trimOuterBlankLines(text)
-    .replace(/^[ \t]+/, '')
-    .replace(/[ \t]+$/, '');
-}
-
 function buildImportWarnings(
   text: string,
   options: {

--- a/src/utils/footnoteExtractor.test.ts
+++ b/src/utils/footnoteExtractor.test.ts
@@ -94,7 +94,7 @@ describe('stripSuperscriptMarkers', () => {
 describe('highlightSuperscriptMarkersHtml', () => {
   it('wraps bracketed superscripts in a span', () => {
     const result = highlightSuperscriptMarkersHtml('Text [¹] end.');
-    expect(result).toContain('<span class="text-editorial-accent font-mono font-semibold">[¹]</span>');
+    expect(result).toContain('<span class="hl-footnote-marker">[¹]</span>');
     expect(result).toContain('Text ');
     expect(result).toContain(' end.');
   });
@@ -109,6 +109,6 @@ describe('highlightSuperscriptMarkersHtml', () => {
     const html = '<mark title="term">text</mark> [¹]';
     const result = highlightSuperscriptMarkersHtml(html);
     expect(result).toContain('<mark title="term">text</mark>');
-    expect(result).toContain('<span class="text-editorial-accent font-mono font-semibold">[¹]</span>');
+    expect(result).toContain('<span class="hl-footnote-marker">[¹]</span>');
   });
 });

--- a/src/utils/footnoteExtractor.ts
+++ b/src/utils/footnoteExtractor.ts
@@ -130,7 +130,7 @@ export function highlightSuperscriptMarkersHtml(html: string): string {
         ? segment
         : segment.replace(
             BRACKETED_SUPERSCRIPT_RE,
-            (match) => `<span class="text-editorial-accent font-mono font-semibold">${match}</span>`,
+            (match) => `<span class="hl-footnote-marker">${match}</span>`,
           ),
     )
     .join('');

--- a/src/utils/footnoteExtractor.ts
+++ b/src/utils/footnoteExtractor.ts
@@ -70,7 +70,7 @@ export function assignChunkFootnotes(
   chunkText: string,
   footnoteMap: Map<string, string>,
 ): Footnote[] {
-  const ids = [...footnoteMap.keys()];
+  const displayNumberById = buildDisplayNumberById(footnoteMap);
   const footnotes: Footnote[] = [];
   const markerRe = /(?<!\\)\[\^([^\]]+)\]/g;
   let match: RegExpExecArray | null;
@@ -80,7 +80,7 @@ export function assignChunkFootnotes(
     const id = match[1];
     if (!seen.has(id) && footnoteMap.has(id)) {
       seen.add(id);
-      const displayNum = ids.indexOf(id) + 1;
+      const displayNum = displayNumberById.get(id)!;
       footnotes.push({ id, marker: `[${toSuperscript(displayNum)}]`, text: footnoteMap.get(id)! });
     }
   }
@@ -94,16 +94,16 @@ export function stripFootnoteMarkers(text: string): string {
 
 /**
  * Replaces [^id] inline markers with bracketed superscript numbers, e.g. [¹].
- * The id is parsed as an integer when possible; otherwise a sequential index is used.
+ * Display numbers are assigned from footnote definition order.
  * Call this instead of stripFootnoteMarkers when you want to keep position info visible.
  */
 export function replaceMarkersWithSuperscripts(
   text: string,
   footnoteMap: Map<string, string>,
 ): string {
-  const ids = [...footnoteMap.keys()];
+  const displayNumberById = buildDisplayNumberById(footnoteMap);
   return text.replace(/(?<!\\)\[\^([^\]]+)\]/g, (_, id) =>
-    footnoteMap.has(id) ? `[${toSuperscript(ids.indexOf(id) + 1)}]` : '',
+    footnoteMap.has(id) ? `[${toSuperscript(displayNumberById.get(id)!)}]` : '',
   );
 }
 
@@ -131,4 +131,8 @@ export function highlightSuperscriptMarkersHtml(html: string): string {
           ),
     )
     .join('');
+}
+
+function buildDisplayNumberById(footnoteMap: Map<string, string>): Map<string, number> {
+  return new Map([...footnoteMap.keys()].map((id, index) => [id, index + 1]));
 }

--- a/src/utils/footnoteExtractor.ts
+++ b/src/utils/footnoteExtractor.ts
@@ -70,6 +70,7 @@ export function assignChunkFootnotes(
   chunkText: string,
   footnoteMap: Map<string, string>,
 ): Footnote[] {
+  const ids = [...footnoteMap.keys()];
   const footnotes: Footnote[] = [];
   const markerRe = /(?<!\\)\[\^([^\]]+)\]/g;
   let match: RegExpExecArray | null;
@@ -79,7 +80,8 @@ export function assignChunkFootnotes(
     const id = match[1];
     if (!seen.has(id) && footnoteMap.has(id)) {
       seen.add(id);
-      footnotes.push({ id, marker: `[^${id}]`, text: footnoteMap.get(id)! });
+      const displayNum = ids.indexOf(id) + 1;
+      footnotes.push({ id, marker: `[${toSuperscript(displayNum)}]`, text: footnoteMap.get(id)! });
     }
   }
 
@@ -100,12 +102,8 @@ export function replaceMarkersWithSuperscripts(
   footnoteMap: Map<string, string>,
 ): string {
   const ids = [...footnoteMap.keys()];
-  const displayNum = (id: string): number => {
-    const n = parseInt(id, 10);
-    return Number.isFinite(n) && n > 0 ? n : ids.indexOf(id) + 1;
-  };
   return text.replace(/(?<!\\)\[\^([^\]]+)\]/g, (_, id) =>
-    footnoteMap.has(id) ? `[${toSuperscript(displayNum(id))}]` : '',
+    footnoteMap.has(id) ? `[${toSuperscript(ids.indexOf(id) + 1)}]` : '',
   );
 }
 

--- a/src/utils/footnoteExtractor.ts
+++ b/src/utils/footnoteExtractor.ts
@@ -44,7 +44,7 @@ export function extractFootnotes(markdown: string): {
 function parseFootnoteDefinitions(lines: string[]): Map<string, string> {
   const map = new Map<string, string>();
   let currentId: string | null = null;
-  const currentTextLines: string[] = [];
+  let currentTextLines: string[] = [];
 
   for (const line of lines) {
     const match = line.match(FOOTNOTE_DEF);
@@ -53,8 +53,7 @@ function parseFootnoteDefinitions(lines: string[]): Map<string, string> {
         map.set(currentId, currentTextLines.join('\n').trim());
       }
       currentId = match[1];
-      currentTextLines.length = 0;
-      currentTextLines.push(match[2]);
+      currentTextLines = [match[2]];
     } else if (currentId !== null) {
       currentTextLines.push(line);
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -329,10 +329,16 @@ type BlockRange = {
   end: number;
 };
 
-function trimOuterBlankLines(text: string): string {
+export function trimOuterBlankLines(text: string): string {
   return text
     .replace(/^(?:[ \t]*\r?\n)+/, '')
     .replace(/(?:\r?\n[ \t]*)+$/, '');
+}
+
+export function trimSplitFragment(text: string): string {
+  return trimOuterBlankLines(text)
+    .replace(/^[ \t]+/, '')
+    .replace(/[ \t]+$/, '');
 }
 
 function getBlockRanges(text: string): BlockRange[] {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -91,9 +91,7 @@ export interface ChunkTextOptions {
 export function estimateTextStats(text: string): TextStats {
   const trimmed = text.trim();
   const words = trimmed ? trimmed.split(/\s+/).filter(Boolean).length : 0;
-  const paragraphs = trimmed
-    ? trimmed.split(/\n{2,}/).map((part) => part.trim()).filter(Boolean).length
-    : 0;
+  const paragraphs = splitParagraphs(trimOuterBlankLines(text)).length;
 
   return {
     characters: text.length,
@@ -109,14 +107,14 @@ export function recommendChunkCount(text: string, targetWordsPerChunk = 700): nu
 }
 
 export function chunkText(text: string, options: ChunkTextOptions = {}): string[] {
-  const trimmed = text.trim();
-  if (!trimmed) return [];
-  if (options.useChunking === false) return [trimmed];
+  const normalized = trimOuterBlankLines(text);
+  if (!normalized.trim()) return [];
+  if (options.useChunking === false) return [normalized];
 
   const target = Math.max(0, Math.floor(options.targetChunkCount ?? 0));
   let chunks = target > 1
-    ? splitIntoTargetChunks(trimmed, target, options)
-    : splitParagraphs(trimmed, options);
+    ? splitIntoTargetChunks(normalized, target, options)
+    : splitParagraphs(normalized, options);
 
   if (options.headingAware) {
     chunks = mergeHeadingChunks(chunks);
@@ -169,30 +167,34 @@ export function resolveSplitIndex(
 }
 
 function splitParagraphs(text: string, options: ChunkTextOptions = {}): string[] {
-  if (options.markdownAware) {
-    return splitMarkdownBlocks(text);
-  }
-  return text.split(/\n{2,}/).map((part) => part.trim()).filter(Boolean);
+  const blocks = options.markdownAware
+    ? mergeMarkdownFootnoteBlocks(text, getBlockRanges(text))
+    : getBlockRanges(text);
+  return blocks.map(({ start, end }) => text.slice(start, end));
 }
 
 function splitIntoTargetChunks(text: string, target: number, options: ChunkTextOptions = {}): string[] {
-  const paragraphs = splitParagraphs(text, options);
-  if (paragraphs.length <= 1) {
+  const blocks = options.markdownAware
+    ? mergeMarkdownFootnoteBlocks(text, getBlockRanges(text))
+    : getBlockRanges(text);
+
+  if (blocks.length <= 1) {
     if (options.markdownAware) {
-      return [text.trim()];
+      return [text];
     }
     return splitWordsIntoTargetChunks(text, target);
   }
 
-  const totalWords = paragraphs.reduce((acc, paragraph) => acc + countWords(paragraph), 0);
+  const totalWords = blocks.reduce((acc, block) => acc + countWords(text.slice(block.start, block.end)), 0);
   const targetWords = Math.max(1, Math.ceil(totalWords / target));
   const chunks: string[] = [];
-  let current: string[] = [];
+  let current: Array<{ start: number; end: number }> = [];
   let currentWords = 0;
 
-  paragraphs.forEach((paragraph, index) => {
-    const paragraphWords = countWords(paragraph);
-    const remainingParagraphs = paragraphs.length - index;
+  blocks.forEach((block, index) => {
+    const blockText = text.slice(block.start, block.end);
+    const paragraphWords = countWords(blockText);
+    const remainingParagraphs = blocks.length - index;
     const remainingSlots = target - chunks.length;
     const shouldClose =
       current.length > 0 &&
@@ -201,16 +203,18 @@ function splitIntoTargetChunks(text: string, target: number, options: ChunkTextO
       (options.markdownAware || remainingParagraphs >= remainingSlots);
 
     if (shouldClose) {
-      chunks.push(current.join('\n\n'));
+      chunks.push(text.slice(current[0].start, current[current.length - 1].end));
       current = [];
       currentWords = 0;
     }
 
-    current.push(paragraph);
+    current.push(block);
     currentWords += paragraphWords;
   });
 
-  if (current.length > 0) chunks.push(current.join('\n\n'));
+  if (current.length > 0) {
+    chunks.push(text.slice(current[0].start, current[current.length - 1].end));
+  }
 
   if (!options.markdownAware && chunks.length < target && chunks.length === 1) {
     return splitWordsIntoTargetChunks(text, target);
@@ -231,11 +235,11 @@ function mergeHeadingChunks(chunks: string[]): string[] {
   for (const chunk of chunks) {
     if (isHeadingChunk(chunk)) {
       headingAccumulator = headingAccumulator
-        ? `${headingAccumulator.trim()}\n\n${chunk.trim()}`
-        : chunk.trim();
+        ? `${headingAccumulator}\n\n${chunk}`
+        : chunk;
     } else {
       const merged = headingAccumulator
-        ? `${headingAccumulator}\n\n${chunk.trim()}`
+        ? `${headingAccumulator}\n\n${chunk}`
         : chunk;
       result.push(merged);
       headingAccumulator = '';
@@ -254,7 +258,7 @@ function mergeSmallChunks(chunks: string[], minWords: number): string[] {
   let pending = chunks[0];
   for (let i = 1; i < chunks.length; i++) {
     if (countWords(pending) < minWords) {
-      pending = `${pending.trim()}\n\n${chunks[i].trim()}`;
+      pending = `${pending}\n\n${chunks[i]}`;
     } else {
       result.push(pending);
       pending = chunks[i];
@@ -287,21 +291,8 @@ function splitLargeChunks(
 }
 
 function splitMarkdownBlocks(text: string): string[] {
-  const rawBlocks = text
-    .split(/\n{2,}/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  const mergedBlocks: string[] = [];
-  for (const block of rawBlocks) {
-    if (block.startsWith('[^') && block.includes(']:') && mergedBlocks.length > 0) {
-      mergedBlocks[mergedBlocks.length - 1] = `${mergedBlocks[mergedBlocks.length - 1]}\n\n${block}`;
-      continue;
-    }
-    mergedBlocks.push(block);
-  }
-
-  return mergedBlocks;
+  const mergedBlocks = mergeMarkdownFootnoteBlocks(text, getBlockRanges(text));
+  return mergedBlocks.map(({ start, end }) => text.slice(start, end));
 }
 
 function findNearestMarkdownBoundary(text: string, pivot: number): number | null {
@@ -317,17 +308,79 @@ function findNearestMarkdownBoundary(text: string, pivot: number): number | null
 }
 
 function splitWordsIntoTargetChunks(text: string, target: number): string[] {
-  const words = text.trim().split(/\s+/).filter(Boolean);
+  const words = Array.from(text.matchAll(/\S+/g))
+    .map((match) => ({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length }));
   if (words.length === 0) return [];
 
   const chunkSize = Math.max(1, Math.ceil(words.length / target));
   const chunks: string[] = [];
 
   for (let i = 0; i < words.length; i += chunkSize) {
-    chunks.push(words.slice(i, i + chunkSize).join(' '));
+    const first = words[i];
+    const last = words[Math.min(i + chunkSize - 1, words.length - 1)];
+    chunks.push(text.slice(first.start, last.end));
   }
 
   return chunks;
+}
+
+type BlockRange = {
+  start: number;
+  end: number;
+};
+
+function trimOuterBlankLines(text: string): string {
+  return text
+    .replace(/^(?:[ \t]*\r?\n)+/, '')
+    .replace(/(?:\r?\n[ \t]*)+$/, '');
+}
+
+function getBlockRanges(text: string): BlockRange[] {
+  const normalized = trimOuterBlankLines(text);
+  if (!normalized.trim()) return [];
+
+  const blocks: BlockRange[] = [];
+  const separator = /\r?\n(?:[ \t]*\r?\n)+/g;
+  let start = 0;
+
+  for (const match of normalized.matchAll(separator)) {
+    const end = match.index ?? 0;
+    if (normalized.slice(start, end).trim()) {
+      blocks.push({ start, end });
+    }
+    start = end + match[0].length;
+  }
+
+  if (normalized.slice(start).trim()) {
+    blocks.push({ start, end: normalized.length });
+  }
+
+  return blocks;
+}
+
+function mergeMarkdownFootnoteBlocks(text: string, blocks: BlockRange[]): BlockRange[] {
+  if (blocks.length <= 1) return blocks;
+
+  const merged: BlockRange[] = [];
+  for (const block of blocks) {
+    const blockText = text.slice(block.start, block.end);
+    if (merged.length > 0 && isFootnoteDefinitionBlock(blockText)) {
+      merged[merged.length - 1] = {
+        start: merged[merged.length - 1].start,
+        end: block.end,
+      };
+      continue;
+    }
+
+    merged.push(block);
+  }
+
+  return merged;
+}
+
+function isFootnoteDefinitionBlock(text: string): boolean {
+  const trimmed = text.trimStart();
+  return /^\[\^[^\]]+\]:/.test(trimmed);
 }
 
 function countWords(text: string): number {


### PR DESCRIPTION
## Summary

- **Indicatori modo editor** non più visivamente simili a bottoni: rimosso il bordo sugli inattivi, icone attenuate, aggiunto `aria-hidden="true"`
- **Bottoni font size** ora fanno uno step incrementale alla volta (sm→md→lg e viceversa) e vengono disabilitati agli estremi; `ToolbarButton` preserva il focus sulla textarea con `onMouseDown preventDefault`
- **Pannello chunk** si apre automaticamente su `loadDocument` e `generateChunks` invece del pannello generale; i due drawer (chunk/document) sono ora mutualmente esclusivi
- **Testo originale in DocumentView** mostra i marker di nota a piè di pagina evidenziati in rosso, con la stessa logica già usata in ProductionStream

## Test plan

- [ ] Aprire l'editor: verificare che gli indicatori write/preview/split non sembrino bottoni cliccabili
- [ ] Aprire la toolbar: premere `-` da 'md' → va a 'sm'; premere ancora `-` → rimane 'sm' (disabilitato); premere `+` → va a 'md', poi 'lg'
- [ ] Importare un file DOCX/PDF: verificare che si apra il pannello chunk (non quello generale)
- [ ] Generare chunk manualmente: verificare che si apra il pannello chunk
- [ ] Aprire un documento con note a piè di pagina in modalità document: verificare che i marker `[¹]` siano rossi nel testo originale
- [ ] Verificare che glossario e note siano entrambi evidenziati correttamente insieme

Closes #98