### PR TITLE
fix: structured file logging with rotation and RUST_LOG override

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,15 +37,22 @@ pub fn run() {
                     tauri_plugin_log::TargetKind::Webview,
                 ));
             }
-            let log_level = if cfg!(debug_assertions) {
+            let default_level = if cfg!(debug_assertions) {
                 log::LevelFilter::Debug
             } else {
                 log::LevelFilter::Info
             };
+            // Allow RUST_LOG to override the compile-time default at runtime.
+            let log_level = std::env::var("RUST_LOG")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default_level);
             app.handle().plugin(
                 tauri_plugin_log::Builder::default()
                     .level(log_level)
                     .targets(log_targets)
+                    .max_file_size(5 * 1024 * 1024)
+                    .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
                     .build(),
             )?;
             Ok(())

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -2403,16 +2403,9 @@ pub async fn judge_translation(
 
     let sanitized = sanitize_llm_json_output(&result_text);
     let parsed: serde_json::Value = serde_json::from_str(sanitized).map_err(|e| {
-        #[cfg(debug_assertions)]
-        {
-            let preview: String = result_text.chars().take(500).collect();
-            let truncated = if result_text.chars().nth(500).is_some() {
-                "…"
-            } else {
-                ""
-            };
-            eprintln!("Failed to parse judge JSON: {e}. Preview: {preview}{truncated}");
-        }
+        let preview: String = result_text.chars().take(500).collect();
+        let truncated = if result_text.chars().nth(500).is_some() { "…" } else { "" };
+        log::warn!("Failed to parse judge JSON: {e}. Preview: {preview}{truncated}");
         format!("Failed to parse judge JSON: {e}")
     })?;
 

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -2403,9 +2403,14 @@ pub async fn judge_translation(
 
     let sanitized = sanitize_llm_json_output(&result_text);
     let parsed: serde_json::Value = serde_json::from_str(sanitized).map_err(|e| {
-        let preview: String = result_text.chars().take(500).collect();
-        let truncated = if result_text.chars().nth(500).is_some() { "…" } else { "" };
-        log::warn!("Failed to parse judge JSON: {e}. Preview: {preview}{truncated}");
+        #[cfg(debug_assertions)]
+        {
+            let preview: String = result_text.chars().take(500).collect();
+            let truncated = if result_text.chars().nth(500).is_some() { "…" } else { "" };
+            log::warn!("Failed to parse judge JSON: {e}. Preview: {preview}{truncated}");
+        }
+        #[cfg(not(debug_assertions))]
+        log::warn!("Failed to parse judge JSON: {e}");
         format!("Failed to parse judge JSON: {e}")
     })?;
 

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   X, ChevronRight,
   FolderOpen, Upload, SlidersHorizontal, Save,
@@ -6,7 +6,9 @@ import {
   LayoutTemplate, PanelRight,
   CheckCheck, PanelTopClose, ScanLine,
   Wand2, BookmarkPlus, BookOpen,
+  Copy, Check,
 } from 'lucide-react';
+import { appLogDir } from '@tauri-apps/api/path';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
@@ -16,7 +18,7 @@ interface HelpGuideProps {
   onClose: () => void;
 }
 
-type Section = 'overview' | 'pipeline' | 'features' | 'streaming' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts';
+type Section = 'overview' | 'pipeline' | 'features' | 'streaming' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts' | 'troubleshooting';
 
 export function HelpGuide({ open, onClose }: HelpGuideProps) {
   const [activeSection, setActiveSection] = useState<Section>('overview');
@@ -32,8 +34,9 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
     { id: 'projects',   label: t('help.sections.projects') },
     { id: 'providers',  label: t('help.sections.providers') },
     { id: 'ollama',     label: t('help.sections.ollama') },
-    { id: 'glossary',   label: t('help.sections.library') },
-    { id: 'shortcuts',  label: t('help.sections.shortcuts') },
+    { id: 'glossary',        label: t('help.sections.library') },
+    { id: 'shortcuts',       label: t('help.sections.shortcuts') },
+    { id: 'troubleshooting', label: t('help.sections.troubleshooting') },
   ];
 
   return (
@@ -106,7 +109,8 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
                 {activeSection === 'providers' && <ProvidersSection />}
                 {activeSection === 'ollama'    && <OllamaSection />}
                 {activeSection === 'glossary'  && <GlossarySection />}
-                {activeSection === 'shortcuts' && <ShortcutsSection />}
+                {activeSection === 'shortcuts'       && <ShortcutsSection />}
+                {activeSection === 'troubleshooting' && <TroubleshootingSection />}
               </div>
             </div>
           </motion.div>
@@ -482,6 +486,52 @@ function ShortcutsSection() {
 
       <SubTitle>{t('help.shortcuts.promptToolsTitle')}</SubTitle>
       <div className="my-4">{promptItems.map(renderRow)}</div>
+    </>
+  );
+}
+
+function TroubleshootingSection() {
+  const { t } = useTranslation();
+  const [logPath, setLogPath] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    appLogDir().then(setLogPath).catch(() => setLogPath(null));
+  }, []);
+
+  const handleCopy = () => {
+    if (!logPath) return;
+    navigator.clipboard.writeText(logPath).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <>
+      <SectionTitle>{t('help.troubleshooting.title')}</SectionTitle>
+      <P>{t('help.troubleshooting.desc')}</P>
+
+      <SubTitle>{t('help.troubleshooting.logFileTitle')}</SubTitle>
+      <P>{t('help.troubleshooting.logFileDesc')}</P>
+      <div className="flex items-center gap-2 rounded-xl border border-editorial-border bg-editorial-textbox/20 px-4 py-3 font-mono text-xs text-editorial-ink/80">
+        <span className="flex-1 break-all">{logPath ?? '…'}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={!logPath}
+          title={t('common.copy')}
+          className="shrink-0 rounded-lg border border-editorial-border p-1.5 text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-30"
+        >
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+
+      <SubTitle>{t('help.troubleshooting.rustLogTitle')}</SubTitle>
+      <P>{t('help.troubleshooting.rustLogDesc')}</P>
+      <div className="rounded-xl border border-editorial-border bg-editorial-textbox/20 px-4 py-3 font-mono text-xs text-editorial-ink/80">
+        RUST_LOG=debug ./glossa
+      </div>
     </>
   );
 }

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -11,6 +11,7 @@ import {
 import { appLogDir } from '@tauri-apps/api/path';
 import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface HelpGuideProps {
@@ -499,12 +500,17 @@ function TroubleshootingSection() {
     appLogDir().then(setLogPath).catch(() => setLogPath(null));
   }, []);
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!logPath) return;
-    navigator.clipboard.writeText(logPath).then(() => {
+    try {
+      await navigator.clipboard.writeText(logPath);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    } catch (err) {
+      toast.error(t('pipeline.copyFailed'), {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
   };
 
   return (
@@ -521,6 +527,8 @@ function TroubleshootingSection() {
           onClick={handleCopy}
           disabled={!logPath}
           title={t('common.copy')}
+          aria-label={copied ? t('pipeline.copied') : t('common.copy')}
+          aria-live="polite"
           className="shrink-0 rounded-lg border border-editorial-border p-1.5 text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-30"
         >
           {copied ? <Check size={13} /> : <Copy size={13} />}
@@ -530,7 +538,7 @@ function TroubleshootingSection() {
       <SubTitle>{t('help.troubleshooting.rustLogTitle')}</SubTitle>
       <P>{t('help.troubleshooting.rustLogDesc')}</P>
       <div className="rounded-xl border border-editorial-border bg-editorial-textbox/20 px-4 py-3 font-mono text-xs text-editorial-ink/80">
-        RUST_LOG=debug ./glossa
+        RUST_LOG=debug
       </div>
     </>
   );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -641,8 +641,8 @@
     "troubleshooting": {
       "title": "Troubleshooting",
       "desc": "This section provides information useful for diagnosing problems and reporting bugs.",
-      "logFileTitle": "Log file location",
-      "logFileDesc": "Glossa writes a structured log to disk. Attach the log file when reporting issues.",
+      "logFileTitle": "Log directory",
+      "logFileDesc": "Glossa writes a structured log named \"glossa\" in this directory. Attach it when reporting issues.",
       "rustLogTitle": "Verbose logging",
       "rustLogDesc": "Set the RUST_LOG environment variable to override the default log level at runtime:"
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -481,7 +481,8 @@
       "ollama": "Ollama",
       "glossary": "Glossary",
       "library": "Library",
-      "shortcuts": "Interface"
+      "shortcuts": "Interface",
+      "troubleshooting": "Troubleshooting"
     },
     "overview": {
       "title": "What is Glossa?",
@@ -636,6 +637,14 @@
       "refineButton": "Wand — AI-rewrites the prompt",
       "saveTemplate": "Bookmark (+) — save prompt as template",
       "loadTemplate": "Open book — load a saved template"
+    },
+    "troubleshooting": {
+      "title": "Troubleshooting",
+      "desc": "This section provides information useful for diagnosing problems and reporting bugs.",
+      "logFileTitle": "Log file location",
+      "logFileDesc": "Glossa writes a structured log to disk. Attach the log file when reporting issues.",
+      "rustLogTitle": "Verbose logging",
+      "rustLogDesc": "Set the RUST_LOG environment variable to override the default log level at runtime:"
     }
   },
   "library": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -481,7 +481,8 @@
       "ollama": "Ollama",
       "glossary": "Glossario",
       "library": "Libreria",
-      "shortcuts": "Interfaccia"
+      "shortcuts": "Interfaccia",
+      "troubleshooting": "Risoluzione problemi"
     },
     "overview": {
       "title": "Cos'è Glossa?",
@@ -636,6 +637,14 @@
       "refineButton": "Bacchetta — rifinisce il prompt con l'IA",
       "saveTemplate": "Segnalibro (+) — salva il prompt come template",
       "loadTemplate": "Libro aperto — carica un template salvato"
+    },
+    "troubleshooting": {
+      "title": "Risoluzione problemi",
+      "desc": "Questa sezione contiene informazioni utili per diagnosticare problemi e inviare segnalazioni di bug.",
+      "logFileTitle": "Posizione del file di log",
+      "logFileDesc": "Glossa scrive un log strutturato su disco. Allega il file di log quando segnali un problema.",
+      "rustLogTitle": "Log dettagliato",
+      "rustLogDesc": "Imposta la variabile d'ambiente RUST_LOG per sovrascrivere il livello di log predefinito a runtime:"
     }
   },
   "library": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -641,8 +641,8 @@
     "troubleshooting": {
       "title": "Risoluzione problemi",
       "desc": "Questa sezione contiene informazioni utili per diagnosticare problemi e inviare segnalazioni di bug.",
-      "logFileTitle": "Posizione del file di log",
-      "logFileDesc": "Glossa scrive un log strutturato su disco. Allega il file di log quando segnali un problema.",
+      "logFileTitle": "Directory dei log",
+      "logFileDesc": "Glossa scrive un log strutturato di nome \"glossa\" in questa directory. Allegalo quando segnali un problema.",
       "rustLogTitle": "Log dettagliato",
       "rustLogDesc": "Imposta la variabile d'ambiente RUST_LOG per sovrascrivere il livello di log predefinito a runtime:"
     }


### PR DESCRIPTION
## Summary

- Add log rotation to `tauri-plugin-log`: `KeepSome(3)` (keep last 3 rotated files) and 5 MB max file size — prevents unbounded disk growth
- Allow `RUST_LOG` environment variable to override the compile-time log level at runtime (useful for diagnosing issues in production builds without a recompile)
- Replace `eprintln!` in `llm.rs` judge JSON parsing with `log::warn!` so the message lands in the structured log file instead of stderr
- New **Troubleshooting** section in the Help Guide: shows the OS-specific log file path (with copy button) and documents how to set `RUST_LOG` for verbose output

## Test plan

- [ ] App starts without errors; log file appears in the OS log directory
- [ ] Setting `RUST_LOG=debug` before launch produces debug-level entries in the log file
- [ ] After 3 rotation cycles the oldest file is pruned (verify with a small `max_file_size` locally)
- [ ] Help Guide → Troubleshooting section renders the correct log path and copy button works
- [ ] Italian locale renders the Troubleshooting section correctly
- [ ] `npm run lint` passes (no TypeScript errors)
- [ ] `cargo check` passes

Closes #65