### PR TITLE
feat: pre-flight validation of all pipeline providers before run

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ pub fn run() {
             llm::pipeline::judge_translation,
             llm::pipeline::refine_prompt,
             llm::pipeline::test_provider_connection,
+            llm::pipeline::preflight_pipeline,
             llm::pipeline::run_coherence_for_chunk,
             keystore::save_api_key,
             keystore::get_api_key_status,

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -368,23 +368,30 @@ pub async fn preflight_pipeline(
 ) -> Result<Vec<PreflightCheckResult>, String> {
     let mut results = Vec::new();
     for check in checks {
-        let outcome = if check.provider == "ollama" {
-            run_ollama_preflight_check(&check.model).await
+        let (ok, error, available_models) = if check.provider == "ollama" {
+            match run_ollama_preflight_check(&check.model).await {
+                Ok(models) => (true, None, Some(models)),
+                Err(e) => (false, Some(e), None),
+            }
         } else {
-            run_cloud_preflight_check(&app, &check.provider).await
+            match run_cloud_preflight_check(&app, &check.provider).await {
+                Ok(()) => (true, None, None),
+                Err(e) => (false, Some(e), None),
+            }
         };
         results.push(PreflightCheckResult {
             provider: check.provider,
             model: check.model,
             label: check.label,
-            ok: outcome.is_ok(),
-            error: outcome.err(),
+            ok,
+            error,
+            available_models,
         });
     }
     Ok(results)
 }
 
-async fn run_ollama_preflight_check(model: &str) -> Result<(), String> {
+async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, String> {
     let status =
         crate::llm::providers::ollama::check_ollama_preflight(Some(model.to_string())).await?;
     if !status.reachable {
@@ -393,7 +400,7 @@ async fn run_ollama_preflight_check(model: &str) -> Result<(), String> {
     if !status.model_available {
         return Err(format!("Model \"{model}\" is not installed locally"));
     }
-    Ok(())
+    Ok(status.models)
 }
 
 async fn run_cloud_preflight_check(app: &AppHandle, provider: &str) -> Result<(), String> {

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -368,15 +368,15 @@ pub async fn preflight_pipeline(
 ) -> Result<Vec<PreflightCheckResult>, String> {
     let mut results = Vec::new();
     for check in checks {
-        let (ok, error, available_models) = if check.provider == "ollama" {
+        let (ok, error, available_models, reachable) = if check.provider == "ollama" {
             match run_ollama_preflight_check(&check.model).await {
-                Ok(models) => (true, None, Some(models)),
-                Err(e) => (false, Some(e), None),
+                Ok(models) => (true, None, Some(models), Some(true)),
+                Err((is_reachable, e)) => (false, Some(e), None, Some(is_reachable)),
             }
         } else {
-            match run_cloud_preflight_check(&app, &check.provider).await {
-                Ok(()) => (true, None, None),
-                Err(e) => (false, Some(e), None),
+            match run_cloud_preflight_check(&app, &check.provider, &check.model).await {
+                Ok(()) => (true, None, None, None),
+                Err(e) => (false, Some(e), None, None),
             }
         };
         results.push(PreflightCheckResult {
@@ -386,29 +386,33 @@ pub async fn preflight_pipeline(
             ok,
             error,
             available_models,
+            reachable,
         });
     }
     Ok(results)
 }
 
-async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, String> {
-    let status =
-        crate::llm::providers::ollama::check_ollama_preflight(Some(model.to_string())).await?;
+// Returns Err((reachable, error_msg)) so callers can distinguish "offline"
+// from "model not installed" without parsing the error string.
+async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, (bool, String)> {
+    let status = crate::llm::providers::ollama::check_ollama_preflight(Some(model.to_string()))
+        .await
+        .map_err(|e| (false, e))?;
     if !status.reachable {
-        return Err("Ollama is not running".into());
+        return Err((false, "Ollama is not running".into()));
     }
     if !status.model_available {
-        return Err(format!("Model \"{model}\" is not installed locally"));
+        return Err((true, format!("Model \"{model}\" is not installed locally")));
     }
     Ok(status.models)
 }
 
-async fn run_cloud_preflight_check(app: &AppHandle, provider: &str) -> Result<(), String> {
+async fn run_cloud_preflight_check(app: &AppHandle, provider: &str, model: &str) -> Result<(), String> {
     let api_key = get_api_key(app, provider)?;
     let prov = get_provider(provider)?;
     let client = prov.http_client()?;
     let req = LlmRequest {
-        model: prov.default_test_model(),
+        model,
         system_prompt: "You are a test assistant.",
         user_prompt: "Reply with exactly: OK",
         api_key: &api_key,

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -11,7 +11,7 @@ use crate::llm::providers::get_provider;
 use crate::llm::stream::{stream_response, StreamGuard, StreamRegistry, STREAM_CANCELLED_ERROR};
 use crate::llm::types::{
     CoherenceChunkInput, CoherenceResponse, JudgeIssue, JudgeResponse, PipelineConfig,
-    ProviderRuntimeConfig, StageConfig,
+    PreflightCheckInput, PreflightCheckResult, ProviderRuntimeConfig, StageConfig,
 };
 
 #[derive(serde::Serialize, Clone)]
@@ -351,4 +351,62 @@ pub async fn test_provider_connection(app: AppHandle, provider: String) -> Resul
         Ok(_) => Ok(true),
         Err(e) => Err(e),
     }
+}
+
+/// Run pre-flight connectivity checks for a set of (provider, model) pairs before
+/// starting a pipeline run. Each entry is checked independently:
+/// - Ollama: verifies reachability and that the specific model is installed.
+/// - Cloud providers: verifies the API key is configured and makes a lightweight
+///   test call to confirm the key is valid and the provider is reachable.
+///
+/// Returns one result per input entry (order preserved). The caller is responsible
+/// for deduplicating entries before calling this command.
+#[tauri::command]
+pub async fn preflight_pipeline(
+    app: AppHandle,
+    checks: Vec<PreflightCheckInput>,
+) -> Result<Vec<PreflightCheckResult>, String> {
+    let mut results = Vec::new();
+    for check in checks {
+        let outcome = if check.provider == "ollama" {
+            run_ollama_preflight_check(&check.model).await
+        } else {
+            run_cloud_preflight_check(&app, &check.provider).await
+        };
+        results.push(PreflightCheckResult {
+            provider: check.provider,
+            model: check.model,
+            label: check.label,
+            ok: outcome.is_ok(),
+            error: outcome.err(),
+        });
+    }
+    Ok(results)
+}
+
+async fn run_ollama_preflight_check(model: &str) -> Result<(), String> {
+    let status =
+        crate::llm::providers::ollama::check_ollama_preflight(Some(model.to_string())).await?;
+    if !status.reachable {
+        return Err("Ollama is not running".into());
+    }
+    if !status.model_available {
+        return Err(format!("Model \"{model}\" is not installed locally"));
+    }
+    Ok(())
+}
+
+async fn run_cloud_preflight_check(app: &AppHandle, provider: &str) -> Result<(), String> {
+    let api_key = get_api_key(app, provider)?;
+    let prov = get_provider(provider)?;
+    let client = prov.http_client()?;
+    let req = LlmRequest {
+        model: prov.default_test_model(),
+        system_prompt: "You are a test assistant.",
+        user_prompt: "Reply with exactly: OK",
+        api_key: &api_key,
+        json_mode: false,
+        provider_options: None,
+    };
+    prov.call(&client, &req).await.map(|_| ())
 }

--- a/src-tauri/src/llm/types.rs
+++ b/src-tauri/src/llm/types.rs
@@ -80,6 +80,10 @@ pub struct PreflightCheckResult {
     /// models returned by Ollama. Used by the frontend to refresh the model
     /// picker without a separate round-trip.
     pub available_models: Option<Vec<String>>,
+    /// True if Ollama responded at all (even if the requested model is missing).
+    /// Absent for cloud providers. Lets the frontend distinguish "offline" from
+    /// "model not installed" without parsing the error string.
+    pub reachable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/llm/types.rs
+++ b/src-tauri/src/llm/types.rs
@@ -76,6 +76,10 @@ pub struct PreflightCheckResult {
     pub label: String,
     pub ok: bool,
     pub error: Option<String>,
+    /// Populated only for Ollama checks — the full list of locally-installed
+    /// models returned by Ollama. Used by the frontend to refresh the model
+    /// picker without a separate round-trip.
+    pub available_models: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/llm/types.rs
+++ b/src-tauri/src/llm/types.rs
@@ -62,6 +62,24 @@ pub struct PipelineConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PreflightCheckInput {
+    pub provider: String,
+    pub model: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreflightCheckResult {
+    pub provider: String,
+    pub model: String,
+    pub label: String,
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OllamaPreflightStatus {
     pub reachable: bool,
     pub models: Vec<String>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect, useRef } from 'react';
 import { initLogger } from './utils/logger';
 import { Header } from './components/layout';
-import { ErrorBoundary, ConfirmDialog } from './components/common';
+import { ErrorBoundary, ConfirmDialog, PreflightDialog } from './components/common';
 import { usePipeline } from './hooks/usePipeline';
 import { useProjectAutosave } from './hooks/useProjectAutosave';
 import { useUiStore } from './stores/uiStore';
@@ -132,6 +132,7 @@ export default function App() {
         )}
 
         <ConfirmDialog />
+        <PreflightDialog />
       </div>
       <Toaster
         position="bottom-right"

--- a/src/components/common/PreflightDialog.tsx
+++ b/src/components/common/PreflightDialog.tsx
@@ -1,0 +1,105 @@
+import { CheckCircle2, XCircle, Settings } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import { usePreflightStore } from '../../stores/preflightStore';
+import { useUiStore } from '../../stores/uiStore';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+export function PreflightDialog() {
+  const { t } = useTranslation();
+  const { open, results, resolve } = usePreflightStore();
+  const setShowSettings = useUiStore((state) => state.setShowSettings);
+  const trapRef = useFocusTrap(open, () => resolve(false));
+
+  const hasFailures = results.some((r) => !r.ok);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center p-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="preflight-title"
+          ref={trapRef}
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-editorial-ink/70 backdrop-blur-sm"
+            onClick={() => resolve(false)}
+          />
+          <motion.div
+            initial={{ scale: 0.96, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.96, opacity: 0 }}
+            className="relative bg-editorial-bg w-full max-w-md p-8 shadow-2xl border border-editorial-border"
+          >
+            <h3
+              id="preflight-title"
+              className="font-display text-lg italic tracking-tight text-editorial-ink mb-1"
+            >
+              {t('preflight.title')}
+            </h3>
+            <p className="text-xs text-editorial-muted mb-6">
+              {hasFailures ? t('preflight.subtitleFailures') : t('preflight.subtitleOk')}
+            </p>
+
+            <ul className="space-y-3 mb-8" aria-label={t('preflight.title')}>
+              {results.map((result, i) => (
+                <li key={i} className="flex items-start gap-3">
+                  {result.ok ? (
+                    <CheckCircle2
+                      size={16}
+                      className="text-green-600 shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <XCircle
+                      size={16}
+                      className="text-editorial-accent shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <span className="text-xs text-editorial-ink">{result.label}</span>
+                    {!result.ok && result.error && (
+                      <p className="text-xs text-editorial-muted mt-0.5 break-words">{result.error}</p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex flex-wrap justify-end gap-3">
+              {hasFailures && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      resolve(false);
+                      setShowSettings(true);
+                    }}
+                    className="flex items-center gap-2 px-5 py-3 border border-editorial-border text-[10px] font-bold uppercase tracking-widest text-editorial-muted hover:text-editorial-ink hover:bg-editorial-textbox/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  >
+                    <Settings size={12} aria-hidden="true" />
+                    {t('preflight.openSettings')}
+                  </button>
+                  <button
+                    type="button"
+                    autoFocus
+                    onClick={() => resolve(true)}
+                    className="px-5 py-3 border border-editorial-accent text-[10px] font-bold uppercase tracking-widest text-editorial-accent hover:bg-editorial-accent/5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  >
+                    {t('preflight.proceedAnyway')}
+                  </button>
+                </>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/common/PreflightDialog.tsx
+++ b/src/components/common/PreflightDialog.tsx
@@ -47,8 +47,8 @@ export function PreflightDialog() {
             </p>
 
             <ul className="space-y-3 mb-8" aria-label={t('preflight.title')}>
-              {results.map((result, i) => (
-                <li key={i} className="flex items-start gap-3">
+              {results.map((result) => (
+                <li key={`${result.provider}:${result.model}`} className="flex items-start gap-3">
                   {result.ok ? (
                     <CheckCircle2
                       size={16}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { StatusIndicator } from './StatusIndicator';
 export { ErrorBoundary } from './ErrorBoundary';
 export { CopyButton } from './CopyButton';
 export { ConfirmDialog } from './ConfirmDialog';
+export { PreflightDialog } from './PreflightDialog';
 export { Drawer } from './Drawer';
 export { HighlightedText } from './HighlightedText';
 export { MarkdownEditor } from './MarkdownEditor';

--- a/src/hooks/usePipeline.test.ts
+++ b/src/hooks/usePipeline.test.ts
@@ -55,12 +55,6 @@ describe('usePipeline', () => {
     (toast.loading as ReturnType<typeof vi.fn>).mockReturnValue('toast-id');
     llmMocks.preflightPipeline.mockResolvedValue([]);
     preflightMocks.showPreflightDialog.mockResolvedValue(true);
-    ollamaMocks.checkPreflight.mockResolvedValue({
-      reachable: true,
-      models: ['llama3.2'],
-      requestedModel: 'llama3.2',
-      modelAvailable: true,
-    });
 
     usePipelineStore.setState((state) => ({
       ...state,
@@ -240,37 +234,6 @@ describe('usePipeline', () => {
     }));
     llmMocks.preflightPipeline.mockResolvedValueOnce([
       { provider: 'ollama', model: 'llama3.2', label: 'Stage 1 — ollama llama3.2', ok: false, error: 'Ollama is not running' },
-    ]);
-    preflightMocks.showPreflightDialog.mockResolvedValueOnce(false);
-
-    const { result } = renderHook(() => usePipeline());
-    await act(async () => {
-      await result.current.runPipeline();
-    });
-
-    expect(llmMocks.runStageStream).not.toHaveBeenCalled();
-    expect(preflightMocks.showPreflightDialog).toHaveBeenCalled();
-  });
-
-  it('blocks the run when Ollama has no installed models', async () => {
-    usePipelineStore.setState((state) => ({
-      ...state,
-      config: {
-        ...state.config,
-        stages: [
-          {
-            id: 'stg-1',
-            name: 'Stage 1',
-            prompt: 'Translate',
-            model: 'llama3.2',
-            provider: 'ollama',
-            enabled: true,
-          },
-        ],
-      },
-    }));
-    llmMocks.preflightPipeline.mockResolvedValueOnce([
-      { provider: 'ollama', model: 'llama3.2', label: 'Stage 1 — ollama llama3.2', ok: false, error: 'Model "llama3.2" is not installed locally' },
     ]);
     preflightMocks.showPreflightDialog.mockResolvedValueOnce(false);
 

--- a/src/hooks/usePipeline.test.ts
+++ b/src/hooks/usePipeline.test.ts
@@ -10,10 +10,15 @@ const llmMocks = vi.hoisted(() => ({
   runStageStream: vi.fn(),
   judgeTranslation: vi.fn(),
   cancelStream: vi.fn(),
+  preflightPipeline: vi.fn(),
 }));
 
 const ollamaMocks = vi.hoisted(() => ({
   checkPreflight: vi.fn(),
+}));
+
+const preflightMocks = vi.hoisted(() => ({
+  showPreflightDialog: vi.fn(),
 }));
 
 vi.mock('../services/llmService', async () => {
@@ -28,18 +33,28 @@ vi.mock('../services/llmService', async () => {
   };
 });
 
+vi.mock('../stores/preflightStore', () => ({
+  showPreflightDialog: preflightMocks.showPreflightDialog,
+  usePreflightStore: vi.fn(),
+}));
+
 vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
     warning: vi.fn(),
     error: vi.fn(),
     message: vi.fn(),
+    loading: vi.fn().mockReturnValue('toast-id'),
+    dismiss: vi.fn(),
   },
 }));
 
 describe('usePipeline', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    (toast.loading as ReturnType<typeof vi.fn>).mockReturnValue('toast-id');
+    llmMocks.preflightPipeline.mockResolvedValue([]);
+    preflightMocks.showPreflightDialog.mockResolvedValue(true);
     ollamaMocks.checkPreflight.mockResolvedValue({
       reachable: true,
       models: ['llama3.2'],
@@ -223,12 +238,10 @@ describe('usePipeline', () => {
         ],
       },
     }));
-    ollamaMocks.checkPreflight.mockResolvedValueOnce({
-      reachable: false,
-      models: [],
-      requestedModel: 'llama3.2',
-      modelAvailable: false,
-    });
+    llmMocks.preflightPipeline.mockResolvedValueOnce([
+      { provider: 'ollama', model: 'llama3.2', label: 'Stage 1 — ollama llama3.2', ok: false, error: 'Ollama is not running' },
+    ]);
+    preflightMocks.showPreflightDialog.mockResolvedValueOnce(false);
 
     const { result } = renderHook(() => usePipeline());
     await act(async () => {
@@ -236,7 +249,7 @@ describe('usePipeline', () => {
     });
 
     expect(llmMocks.runStageStream).not.toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalled();
+    expect(preflightMocks.showPreflightDialog).toHaveBeenCalled();
   });
 
   it('blocks the run when Ollama has no installed models', async () => {
@@ -256,12 +269,10 @@ describe('usePipeline', () => {
         ],
       },
     }));
-    ollamaMocks.checkPreflight.mockResolvedValueOnce({
-      reachable: true,
-      models: [],
-      requestedModel: 'llama3.2',
-      modelAvailable: false,
-    });
+    llmMocks.preflightPipeline.mockResolvedValueOnce([
+      { provider: 'ollama', model: 'llama3.2', label: 'Stage 1 — ollama llama3.2', ok: false, error: 'Model "llama3.2" is not installed locally' },
+    ]);
+    preflightMocks.showPreflightDialog.mockResolvedValueOnce(false);
 
     const { result } = renderHook(() => usePipeline());
     await act(async () => {
@@ -269,7 +280,7 @@ describe('usePipeline', () => {
     });
 
     expect(llmMocks.runStageStream).not.toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalled();
+    expect(preflightMocks.showPreflightDialog).toHaveBeenCalled();
   });
 
   it('blocks the run when the configured Ollama model is missing', async () => {
@@ -289,12 +300,10 @@ describe('usePipeline', () => {
         ],
       },
     }));
-    ollamaMocks.checkPreflight.mockResolvedValueOnce({
-      reachable: true,
-      models: ['mistral:latest'],
-      requestedModel: 'llama3.2',
-      modelAvailable: false,
-    });
+    llmMocks.preflightPipeline.mockResolvedValueOnce([
+      { provider: 'ollama', model: 'llama3.2', label: 'Stage 1 — ollama llama3.2', ok: false, error: 'Model "llama3.2" is not installed locally' },
+    ]);
+    preflightMocks.showPreflightDialog.mockResolvedValueOnce(false);
 
     const { result } = renderHook(() => usePipeline());
     await act(async () => {
@@ -302,10 +311,10 @@ describe('usePipeline', () => {
     });
 
     expect(llmMocks.runStageStream).not.toHaveBeenCalled();
-    expect(toast.error).toHaveBeenCalled();
+    expect(preflightMocks.showPreflightDialog).toHaveBeenCalled();
   });
 
-  it('shows a friendly toast when Ollama preflight throws', async () => {
+  it('shows a friendly toast when preflight pipeline call throws', async () => {
     usePipelineStore.setState((state) => ({
       ...state,
       config: {
@@ -322,7 +331,7 @@ describe('usePipeline', () => {
         ],
       },
     }));
-    ollamaMocks.checkPreflight.mockRejectedValueOnce(new Error('invoke failed'));
+    llmMocks.preflightPipeline.mockRejectedValueOnce(new Error('invoke failed'));
 
     const { result } = renderHook(() => usePipeline());
     await act(async () => {

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -84,7 +84,7 @@ export function usePipeline() {
 
     const toastId = toast.loading(t('preflight.checking'));
 
-    let results;
+    let results: Awaited<ReturnType<typeof llmService.preflightPipeline>>;
     try {
       results = await llmService.preflightPipeline(dedupedChecks);
     } catch (error: unknown) {
@@ -103,14 +103,17 @@ export function usePipeline() {
     toast.dismiss(toastId);
 
     // Keep Ollama status indicator and model list in sync.
+    // Use `reachable` (not `ok`) so a missing-model failure doesn't incorrectly
+    // mark Ollama as disconnected when it is actually running.
     const ollamaResults = results.filter((r) => r.provider === 'ollama');
     if (ollamaResults.length > 0) {
+      const ollamaReachable = ollamaResults.some((r) => r.reachable === true);
       const allOllamaOk = ollamaResults.every((r) => r.ok);
-      useUiStore.getState().setOllamaStatus(allOllamaOk ? 'connected' : 'disconnected');
+      useUiStore.getState().setOllamaStatus(ollamaReachable || allOllamaOk ? 'connected' : 'disconnected');
       const allModels = [...new Set(ollamaResults.flatMap((r) => r.availableModels ?? []))];
       if (allModels.length > 0) {
         useUiStore.getState().setOllamaModels(allModels);
-      } else if (!allOllamaOk) {
+      } else if (!ollamaReachable) {
         useUiStore.getState().setOllamaModels([]);
       }
     }

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -6,6 +6,7 @@ import { useChunksStore } from '../stores/chunksStore';
 import { llmService, ollamaService, isStreamCancelledError } from '../services/llmService';
 import { useUiStore } from '../stores/uiStore';
 import { logOperation } from '../stores/operationLogStore';
+import { showPreflightDialog } from '../stores/preflightStore';
 import { withRetry, friendlyError } from '../utils/retry';
 import { qualityDefault, qualityFailure } from '../utils';
 import type { Issue, JudgeResult, PromptInfo, TokenUsage, TranslationChunk } from '../types';
@@ -129,6 +130,84 @@ export function usePipeline() {
       toast.error(t('ollama.notRunning'), { description: msg });
       return false;
     }
+  }, [t]);
+
+  type ProviderCheck = { provider: string; model: string; label: string };
+
+  /**
+   * Run pre-flight checks for all providers referenced by the given list of
+   * (provider, model, label) entries. Deduplicates by (provider, model).
+   *
+   * - Shows a loading toast while checks are in flight.
+   * - Updates Ollama UI state from the check results.
+   * - Opens the PreflightDialog when any check fails, letting the user decide
+   *   whether to abort (fix config) or proceed anyway.
+   *
+   * Returns true if the pipeline can proceed, false if it should be aborted.
+   */
+  const ensureProvidersReady = useCallback(async (checks: ProviderCheck[]) => {
+    if (checks.length === 0) return true;
+
+    // Deduplicate by (provider, model) — preserves first occurrence's label.
+    const seen = new Set<string>();
+    const dedupedChecks = checks.filter((c) => {
+      const key = `${c.provider}:${c.model}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    logOperation({
+      level: 'info',
+      scope: 'preflight',
+      message: 'Running pre-flight provider checks',
+      meta: { checks: dedupedChecks.map((c) => `${c.provider}/${c.model}`) },
+    });
+
+    const toastId = toast.loading(t('preflight.checking'));
+
+    let results;
+    try {
+      results = await llmService.preflightPipeline(dedupedChecks);
+    } catch (error: unknown) {
+      toast.dismiss(toastId);
+      const msg = friendlyError(error instanceof Error ? error.message : String(error));
+      logOperation({
+        level: 'error',
+        scope: 'preflight',
+        message: 'Pre-flight check itself failed to run',
+        meta: { error: msg },
+      });
+      toast.error(t('preflight.checkFailed'), { description: msg });
+      return false;
+    }
+
+    toast.dismiss(toastId);
+
+    // Keep Ollama status indicator in sync.
+    const ollamaResult = results.find((r) => r.provider === 'ollama');
+    if (ollamaResult) {
+      useUiStore.getState().setOllamaStatus(ollamaResult.ok ? 'connected' : 'disconnected');
+    }
+
+    const hasFailures = results.some((r) => !r.ok);
+
+    if (hasFailures) {
+      logOperation({
+        level: 'warn',
+        scope: 'preflight',
+        message: 'Pre-flight check found provider configuration issues',
+        meta: { failures: results.filter((r) => !r.ok).map((r) => `${r.provider}/${r.model}: ${r.error}`) },
+      });
+      return showPreflightDialog(results);
+    }
+
+    logOperation({
+      level: 'success',
+      scope: 'preflight',
+      message: 'Pre-flight check passed — all providers ready',
+    });
+    return true;
   }, [t]);
 
   // ── Internal helpers ────────────────────────────────────────────────
@@ -433,9 +512,13 @@ export function usePipeline() {
       message: 'Batch pipeline run started',
       meta: { chunks: liveChunks.length, stages: config.stages.filter((stage) => stage.enabled).length },
     });
-    if (!(await ensureOllamaReady([
-      ...config.stages.filter((stage) => stage.enabled).map((stage) => ({ provider: stage.provider, model: stage.model })),
-      { provider: config.judgeProvider, model: config.judgeModel },
+    if (!(await ensureProvidersReady([
+      ...config.stages.filter((stage) => stage.enabled).map((stage, i) => ({
+        provider: stage.provider,
+        model: stage.model,
+        label: `${stage.name || `Stage ${i + 1}`} — ${stage.provider} ${stage.model}`,
+      })),
+      { provider: config.judgeProvider, model: config.judgeModel, label: `Judge — ${config.judgeProvider} ${config.judgeModel}` },
     ]))) return;
     useChunksStore.getState().clearCancelRequest();
     setIsProcessing(true);
@@ -472,16 +555,20 @@ export function usePipeline() {
       });
       toast.warning(t('errors.pipelineCompletedWithErrors', { count: errorCount }));
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, setChunkStagePromptInfo, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, ensureOllamaReady]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, setChunkStagePromptInfo, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, ensureProvidersReady]);
 
   const runSingleChunk = useCallback(async (chunkId: string) => {
     if (useChunksStore.getState().isProcessing) return;
     const chunk = useChunksStore.getState().chunks.find((c) => c.id === chunkId);
     if (!chunk) return;
     logOperation({ level: 'info', scope: 'pipeline', message: 'Single chunk pipeline run started', chunkId });
-    if (!(await ensureOllamaReady([
-      ...config.stages.filter((stage) => stage.enabled).map((stage) => ({ provider: stage.provider, model: stage.model })),
-      { provider: config.judgeProvider, model: config.judgeModel },
+    if (!(await ensureProvidersReady([
+      ...config.stages.filter((stage) => stage.enabled).map((stage, i) => ({
+        provider: stage.provider,
+        model: stage.model,
+        label: `${stage.name || `Stage ${i + 1}`} — ${stage.provider} ${stage.model}`,
+      })),
+      { provider: config.judgeProvider, model: config.judgeModel, label: `Judge — ${config.judgeProvider} ${config.judgeModel}` },
     ]))) return;
     useChunksStore.getState().clearCancelRequest();
     setIsProcessing(true);
@@ -503,14 +590,16 @@ export function usePipeline() {
       // Per-chunk failure already raised a toast inside the helper; no
       // extra summary toast is needed.
     }
-  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, setChunkStagePromptInfo, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, ensureOllamaReady]);
+  }, [config, t, setIsProcessing, updateChunkStage, appendChunkStageContent, setChunkStagePromptInfo, updateChunkJudge, updateChunkDraft, updateChunkStatus, clearChunkStages, ensureProvidersReady]);
 
   const runAuditOnly = useCallback(async () => {
     if (useChunksStore.getState().isProcessing) return;
     const liveChunks = useChunksStore.getState().chunks;
     if (liveChunks.length === 0) return;
     logOperation({ level: 'info', scope: 'audit', message: 'Batch audit run started', meta: { chunks: liveChunks.length } });
-    if (!(await ensureOllamaReady([{ provider: config.judgeProvider, model: config.judgeModel }]))) return;
+    if (!(await ensureProvidersReady([
+      { provider: config.judgeProvider, model: config.judgeModel, label: `Judge — ${config.judgeProvider} ${config.judgeModel}` },
+    ]))) return;
     useChunksStore.getState().clearCancelRequest();
     setIsProcessing(true);
 
@@ -543,7 +632,7 @@ export function usePipeline() {
       logOperation({ level: 'success', scope: 'audit', message: 'Batch audit run completed successfully' });
       toast.success(t('errors.reEvalCompleted'));
     }
-  }, [config, t, setIsProcessing, updateChunkJudge, updateChunkStatus, ensureOllamaReady]);
+  }, [config, t, setIsProcessing, updateChunkJudge, updateChunkStatus, ensureProvidersReady]);
 
   const auditSingleChunk = useCallback(async (chunkId: string) => {
     if (useChunksStore.getState().isProcessing) return;
@@ -553,7 +642,9 @@ export function usePipeline() {
       toast.message(t('pipeline.auditSkippedNoDraft'));
       return;
     }
-    if (!(await ensureOllamaReady([{ provider: config.judgeProvider, model: config.judgeModel }]))) return;
+    if (!(await ensureProvidersReady([
+      { provider: config.judgeProvider, model: config.judgeModel, label: `Judge — ${config.judgeProvider} ${config.judgeModel}` },
+    ]))) return;
     logOperation({ level: 'info', scope: 'audit', message: 'Single chunk audit started', chunkId });
     useChunksStore.getState().clearCancelRequest();
     setIsProcessing(true);
@@ -570,7 +661,7 @@ export function usePipeline() {
       logOperation({ level: 'success', scope: 'audit', message: 'Single chunk audit completed', chunkId });
       toast.success(t('pipeline.singleChunkAudited'));
     }
-  }, [config, t, setIsProcessing, updateChunkJudge, updateChunkStatus, ensureOllamaReady]);
+  }, [config, t, setIsProcessing, updateChunkJudge, updateChunkStatus, ensureProvidersReady]);
 
   const runCoherenceAudit = useCallback(async () => {
     if (useChunksStore.getState().isProcessing) return;

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { usePipelineStore } from '../stores/pipelineStore';
 import { useChunksStore } from '../stores/chunksStore';
-import { llmService, ollamaService, isStreamCancelledError } from '../services/llmService';
+import { llmService, isStreamCancelledError } from '../services/llmService';
 import { useUiStore } from '../stores/uiStore';
 import { logOperation } from '../stores/operationLogStore';
 import { showPreflightDialog } from '../stores/preflightStore';
@@ -22,7 +22,6 @@ function firstNWords(text: string, n: number): string {
 }
 
 type ChunkOutcome = 'completed' | 'failed' | 'cancelled' | 'skipped';
-type OllamaRunRequirement = { provider: string; model?: string | null };
 
 /**
  * Hook that encapsulates pipeline execution logic.
@@ -50,87 +49,6 @@ export function usePipeline() {
   const { config } = usePipelineStore();
   const isProcessing = useChunksStore((state) => state.isProcessing);
   const { t } = useTranslation();
-
-  const ensureOllamaReady = useCallback(async (requirements: OllamaRunRequirement[]) => {
-    const ollamaModels = new Set(
-      requirements
-        .filter((item) => item.provider === 'ollama')
-        .map((item) => item.model?.trim())
-        .filter((model): model is string => Boolean(model)),
-    );
-
-    if (ollamaModels.size === 0) return true;
-
-    const requestedModels = [...ollamaModels];
-    logOperation({
-      level: 'info',
-      scope: 'preflight',
-      message: 'Checking whether Ollama is reachable and whether the requested local models are installed',
-      meta: { requestedModels },
-    });
-
-    try {
-      const preflight = await ollamaService.checkPreflight(requestedModels[0]);
-      useUiStore.getState().setOllamaStatus(preflight.reachable ? 'connected' : 'disconnected');
-      useUiStore.getState().setOllamaModels(preflight.models);
-
-      if (!preflight.reachable) {
-        logOperation({
-          level: 'error',
-          scope: 'preflight',
-          message: 'Ollama is offline, so the run is blocked before any chunk work starts',
-        });
-        toast.error(t('ollama.notRunning'));
-        return false;
-      }
-      if (preflight.models.length === 0) {
-        logOperation({
-          level: 'warn',
-          scope: 'preflight',
-          message: 'Ollama responded, but there are no installed local models to run',
-        });
-        toast.error(t('ollama.noModels'));
-        return false;
-      }
-
-      const available = new Set(preflight.models);
-      const missing = requestedModels.filter((model) =>
-        !available.has(model) &&
-        !available.has(`${model}:latest`) &&
-        !(model.endsWith(':latest') && available.has(model.slice(0, -7))),
-      );
-
-      if (missing.length > 0) {
-        logOperation({
-          level: 'error',
-          scope: 'preflight',
-          message: `The configured Ollama model "${missing[0]}" is missing locally`,
-        });
-        toast.error(t('ollama.modelMissing', { model: missing[0] }));
-        return false;
-      }
-
-      logOperation({
-        level: 'success',
-        scope: 'preflight',
-        message: 'Ollama preflight passed and the run can proceed',
-        meta: { models: preflight.models.length, availableModels: preflight.models },
-      });
-      return true;
-    } catch (error: unknown) {
-      useUiStore.getState().setOllamaStatus('disconnected');
-      useUiStore.getState().setOllamaModels([]);
-      const msg = friendlyError(error instanceof Error ? error.message : String(error));
-      logOperation({
-        level: 'error',
-        scope: 'preflight',
-        message: 'The preflight request itself failed before the pipeline could start',
-        meta: { error: msg },
-      });
-      toast.error(t('ollama.notRunning'), { description: msg });
-      return false;
-    }
-  }, [t]);
 
   type ProviderCheck = { provider: string; model: string; label: string };
 
@@ -184,10 +102,17 @@ export function usePipeline() {
 
     toast.dismiss(toastId);
 
-    // Keep Ollama status indicator in sync.
-    const ollamaResult = results.find((r) => r.provider === 'ollama');
-    if (ollamaResult) {
-      useUiStore.getState().setOllamaStatus(ollamaResult.ok ? 'connected' : 'disconnected');
+    // Keep Ollama status indicator and model list in sync.
+    const ollamaResults = results.filter((r) => r.provider === 'ollama');
+    if (ollamaResults.length > 0) {
+      const allOllamaOk = ollamaResults.every((r) => r.ok);
+      useUiStore.getState().setOllamaStatus(allOllamaOk ? 'connected' : 'disconnected');
+      const allModels = [...new Set(ollamaResults.flatMap((r) => r.availableModels ?? []))];
+      if (allModels.length > 0) {
+        useUiStore.getState().setOllamaModels(allModels);
+      } else if (!allOllamaOk) {
+        useUiStore.getState().setOllamaModels([]);
+      }
     }
 
     const hasFailures = results.some((r) => !r.ok);
@@ -675,7 +600,7 @@ export function usePipeline() {
       toast.message(t('coherence.translationsRequired'));
       return;
     }
-    if (!(await ensureOllamaReady([{ provider: config.judgeProvider, model: config.judgeModel }]))) return;
+    if (!(await ensureProvidersReady([{ provider: config.judgeProvider, model: config.judgeModel, label: `Judge — ${config.judgeProvider} ${config.judgeModel}` }]))) return;
     logOperation({ level: 'info', scope: 'coherence', message: 'Cross-chunk coherence audit started', meta: { chunks: liveChunks.length } });
 
     useChunksStore.getState().clearCancelRequest();
@@ -777,7 +702,7 @@ export function usePipeline() {
       });
       toast.warning(t('coherence.auditCompletedWithErrors', { count: errorCount }));
     }
-  }, [config, t, setIsProcessing, updateChunkCoherence, ensureOllamaReady]);
+  }, [config, t, setIsProcessing, updateChunkCoherence, ensureProvidersReady]);
 
   const cancelPipeline = useCallback(() => {
     requestCancel();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -244,6 +244,15 @@
     "unchecked": "Ollama status not checked",
     "uncheckedHint": "Status unchecked. Click \"Refresh\" to verify the connection and load local models."
   },
+  "preflight": {
+    "title": "Pre-flight check",
+    "subtitleFailures": "One or more providers have configuration issues. Fix the settings or proceed anyway.",
+    "subtitleOk": "All providers are reachable and correctly configured.",
+    "checking": "Checking providers…",
+    "checkFailed": "Pre-flight check failed",
+    "openSettings": "Open Settings",
+    "proceedAnyway": "Proceed anyway"
+  },
   "errors": {
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -244,6 +244,15 @@
     "unchecked": "Stato Ollama non verificato",
     "uncheckedHint": "Stato non verificato. Clicca «Aggiorna» per controllare la connessione e caricare i modelli locali."
   },
+  "preflight": {
+    "title": "Controllo pre-avvio",
+    "subtitleFailures": "Uno o più provider hanno problemi di configurazione. Correggi le impostazioni o avvia comunque.",
+    "subtitleOk": "Tutti i provider sono raggiungibili e configurati correttamente.",
+    "checking": "Controllo provider in corso…",
+    "checkFailed": "Controllo pre-avvio non riuscito",
+    "openSettings": "Apri Impostazioni",
+    "proceedAnyway": "Avvia comunque"
+  },
   "errors": {
     "somethingWentWrong": "Qualcosa è andato storto",
     "unexpectedError": "Si è verificato un errore imprevisto.",

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -57,9 +57,11 @@ export interface PreflightCheckResult {
   model: string;
   label: string;
   ok: boolean;
-  error?: string;
+  error: string | null;
   /** Populated for Ollama only — the full list of locally-installed models. */
-  availableModels?: string[];
+  availableModels: string[] | null;
+  /** True if Ollama responded (even if the model is missing). Null for cloud. */
+  reachable: boolean | null;
 }
 
 /**

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -52,6 +52,14 @@ export interface OllamaPreflightStatus {
   modelAvailable: boolean;
 }
 
+export interface PreflightCheckResult {
+  provider: string;
+  model: string;
+  label: string;
+  ok: boolean;
+  error?: string;
+}
+
 /**
  * LLM Service — delegates all AI calls to the Tauri Rust backend.
  * API keys are stored securely in the OS-level store, never in the browser.
@@ -252,6 +260,13 @@ export const llmService = {
 
   async testConnection(provider: string): Promise<boolean> {
     return invoke<boolean>('test_provider_connection', { provider });
+  },
+
+  /** Run pre-flight checks for the given (provider, model, label) entries. */
+  async preflightPipeline(
+    checks: Array<{ provider: string; model: string; label: string }>,
+  ): Promise<PreflightCheckResult[]> {
+    return invoke<PreflightCheckResult[]>('preflight_pipeline', { checks });
   },
 };
 

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -58,6 +58,8 @@ export interface PreflightCheckResult {
   label: string;
   ok: boolean;
   error?: string;
+  /** Populated for Ollama only — the full list of locally-installed models. */
+  availableModels?: string[];
 }
 
 /**

--- a/src/stores/preflightStore.ts
+++ b/src/stores/preflightStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import type { PreflightCheckResult } from '../services/llmService';
+
+interface PreflightState {
+  open: boolean;
+  results: PreflightCheckResult[];
+  resolver: ((proceed: boolean) => void) | null;
+  /** Open the dialog with given results. Resolves with true if the user proceeds, false if they cancel. */
+  show: (results: PreflightCheckResult[]) => Promise<boolean>;
+  resolve: (proceed: boolean) => void;
+}
+
+export const usePreflightStore = create<PreflightState>((set, get) => ({
+  open: false,
+  results: [],
+  resolver: null,
+
+  show: (results) =>
+    new Promise<boolean>((resolve) => {
+      const previous = get().resolver;
+      if (previous) previous(false);
+      set({ open: true, results, resolver: resolve });
+    }),
+
+  resolve: (proceed) => {
+    const { resolver } = get();
+    set({ open: false, results: [], resolver: null });
+    resolver?.(proceed);
+  },
+}));
+
+export function showPreflightDialog(results: PreflightCheckResult[]): Promise<boolean> {
+  return usePreflightStore.getState().show(results);
+}


### PR DESCRIPTION
Closes #120

## Summary

Before starting any pipeline or audit run, Glossa now checks that every configured provider (cloud + Ollama) is reachable and correctly set up — instead of discovering a bad API key or offline model only when the first chunk fails.

## Changes

### Backend (Rust)
- New `preflight_pipeline` Tauri command that accepts a deduplicated list of `{ provider, model, label }` entries:
  - **Ollama**: checks reachability + that the specific model is installed
  - **Cloud providers**: validates API key is configured, then makes a lightweight test call (same logic as `test_provider_connection`)
- New `PreflightCheckInput` / `PreflightCheckResult` types in `llm/types.rs`

### Frontend
- `preflightStore` — Zustand store with `show(results) → Promise<boolean>` API (mirrors `confirmStore` pattern)
- `PreflightDialog` — modal component showing ✓/✗ per provider with error details; on failure offers **Open Settings** and **Proceed anyway**
- `usePipeline`: new `ensureProvidersReady` replaces the Ollama-only `ensureOllamaReady` in all four entry points (`runPipeline`, `runAuditOnly`, `runSingleChunk`, `auditSingleChunk`):
  - Shows a loading toast during checks
  - Keeps the Ollama status indicator in sync
  - On failure: opens the dialog and waits for user decision
  - On success: proceeds silently
- i18n keys added to `it.json` and `en.json` (`preflight.*`)
- Tests updated: Ollama-specific tests migrated to the new mock surface (`preflightPipeline` + `showPreflightDialog`)