### PR TITLE
feat: checkpoint & resume interrupted translations

### DIFF
--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -371,7 +371,12 @@ pub async fn preflight_pipeline(
         let (ok, error, available_models, reachable) = if check.provider == "ollama" {
             match run_ollama_preflight_check(&check.model).await {
                 Ok(models) => (true, None, Some(models), Some(true)),
-                Err((is_reachable, e)) => (false, Some(e), None, Some(is_reachable)),
+                Err((is_reachable, e, models)) => (
+                    false,
+                    Some(e),
+                    if models.is_empty() { None } else { Some(models) },
+                    Some(is_reachable),
+                ),
             }
         } else {
             match run_cloud_preflight_check(&app, &check.provider, &check.model).await {
@@ -392,17 +397,18 @@ pub async fn preflight_pipeline(
     Ok(results)
 }
 
-// Returns Err((reachable, error_msg)) so callers can distinguish "offline"
-// from "model not installed" without parsing the error string.
-async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, (bool, String)> {
+// Returns Err((reachable, error_msg, models)) so callers can distinguish "offline"
+// from "model not installed" and always get the installed model list when Ollama
+// is reachable (even on failure), so the UI model picker can refresh.
+async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, (bool, String, Vec<String>)> {
     let status = crate::llm::providers::ollama::check_ollama_preflight(Some(model.to_string()))
         .await
-        .map_err(|e| (false, e))?;
+        .map_err(|e| (false, e, vec![]))?;
     if !status.reachable {
-        return Err((false, "Ollama is not running".into()));
+        return Err((false, "Ollama is not running".into(), vec![]));
     }
     if !status.model_available {
-        return Err((true, format!("Model \"{model}\" is not installed locally")));
+        return Err((true, format!("Model \"{model}\" is not installed locally"), status.models));
     }
     Ok(status.models)
 }

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -379,7 +379,7 @@ pub async fn preflight_pipeline(
                 ),
             }
         } else {
-            match run_cloud_preflight_check(&app, &check.provider, &check.model).await {
+            match run_cloud_preflight_check(&app, &check.provider).await {
                 Ok(()) => (true, None, None, None),
                 Err(e) => (false, Some(e), None, None),
             }
@@ -413,17 +413,10 @@ async fn run_ollama_preflight_check(model: &str) -> Result<Vec<String>, (bool, S
     Ok(status.models)
 }
 
-async fn run_cloud_preflight_check(app: &AppHandle, provider: &str, model: &str) -> Result<(), String> {
-    let api_key = get_api_key(app, provider)?;
-    let prov = get_provider(provider)?;
-    let client = prov.http_client()?;
-    let req = LlmRequest {
-        model,
-        system_prompt: "You are a test assistant.",
-        user_prompt: "Reply with exactly: OK",
-        api_key: &api_key,
-        json_mode: false,
-        provider_options: None,
-    };
-    prov.call(&client, &req).await.map(|_| ())
+/// For cloud providers only the API key presence is verified — no inference call
+/// is made so the check is free and fast. An invalid or expired key will surface
+/// naturally on the first real translation request.
+async fn run_cloud_preflight_check(app: &AppHandle, provider: &str) -> Result<(), String> {
+    get_api_key(app, provider)?;
+    Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect, useRef } from 'react';
 import { initLogger } from './utils/logger';
 import { Header } from './components/layout';
-import { ErrorBoundary, ConfirmDialog, PreflightDialog } from './components/common';
+import { ErrorBoundary, ConfirmDialog, PreflightDialog, RunResumeBanner } from './components/common';
 import { usePipeline } from './hooks/usePipeline';
 import { useProjectAutosave } from './hooks/useProjectAutosave';
 import { useUiStore } from './stores/uiStore';
@@ -133,6 +133,7 @@ export default function App() {
 
         <ConfirmDialog />
         <PreflightDialog />
+        <RunResumeBanner />
       </div>
       <Toaster
         position="bottom-right"

--- a/src/components/common/RunResumeBanner.tsx
+++ b/src/components/common/RunResumeBanner.tsx
@@ -1,0 +1,86 @@
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Play, RotateCcw, X } from 'lucide-react';
+import { useProjectStore } from '../../stores/projectStore';
+import { useChunksStore } from '../../stores/chunksStore';
+import { usePipeline } from '../../hooks/usePipeline';
+import { buildPipelineFingerprint } from '../../utils/pipelineFingerprint';
+import { usePipelineStore } from '../../stores/pipelineStore';
+
+export function RunResumeBanner() {
+  const { t } = useTranslation();
+  const runInterrupted = useProjectStore((s) => s.runInterrupted);
+  const lastRunConfig = useProjectStore((s) => s.lastRunConfig);
+  const clearResumeState = useProjectStore((s) => s.clearResumeState);
+  const chunks = useChunksStore((s) => s.chunks);
+  const config = usePipelineStore((s) => s.config);
+  const { runPipeline } = usePipeline();
+  const resetAllChunks = useChunksStore((s) => s.resetAllChunks);
+
+  if (!runInterrupted) return null;
+
+  const completedCount = chunks.filter((c) => c.status === 'completed').length;
+  const totalCount = chunks.length;
+
+  const currentFingerprint = buildPipelineFingerprint(config);
+  const configChanged = lastRunConfig !== null && lastRunConfig !== currentFingerprint;
+
+  const handleResume = () => {
+    clearResumeState();
+    void runPipeline();
+  };
+
+  const handleRestart = () => {
+    clearResumeState();
+    resetAllChunks();
+    void runPipeline();
+  };
+
+  return (
+    <div
+      role="alert"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-lg px-4"
+    >
+      <div className="bg-editorial-paper border border-editorial-border rounded-lg shadow-lg p-4">
+        <div className="flex items-start gap-3">
+          <AlertTriangle size={18} className="text-amber-500 shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-editorial-ink">
+              {t('resume.title')}
+            </p>
+            <p className="text-xs text-editorial-muted mt-0.5">
+              {t('resume.progress', { completed: completedCount, total: totalCount })}
+            </p>
+            {configChanged && (
+              <p className="text-xs text-amber-600 mt-1">
+                {t('resume.configChanged')}
+              </p>
+            )}
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={handleResume}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-editorial-ink text-editorial-paper rounded hover:opacity-90 transition-opacity"
+              >
+                <Play size={12} />
+                {t('resume.resumeButton')}
+              </button>
+              <button
+                onClick={handleRestart}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-editorial-border text-editorial-ink rounded hover:bg-editorial-muted/10 transition-colors"
+              >
+                <RotateCcw size={12} />
+                {t('resume.restartButton')}
+              </button>
+            </div>
+          </div>
+          <button
+            onClick={() => clearResumeState()}
+            aria-label={t('resume.dismiss')}
+            className="shrink-0 text-editorial-muted hover:text-editorial-ink transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/RunResumeBanner.tsx
+++ b/src/components/common/RunResumeBanner.tsx
@@ -5,12 +5,14 @@ import { useChunksStore } from '../../stores/chunksStore';
 import { usePipeline } from '../../hooks/usePipeline';
 import { buildPipelineFingerprint } from '../../utils/pipelineFingerprint';
 import { usePipelineStore } from '../../stores/pipelineStore';
+import { setRunInProgress } from '../../services/projectService';
 
 export function RunResumeBanner() {
   const { t } = useTranslation();
   const runInterrupted = useProjectStore((s) => s.runInterrupted);
   const lastRunConfig = useProjectStore((s) => s.lastRunConfig);
   const clearResumeState = useProjectStore((s) => s.clearResumeState);
+  const currentProjectId = useProjectStore((s) => s.currentProjectId);
   const chunks = useChunksStore((s) => s.chunks);
   const config = usePipelineStore((s) => s.config);
   const { runPipeline } = usePipeline();
@@ -33,6 +35,13 @@ export function RunResumeBanner() {
     clearResumeState();
     resetAllChunks();
     void runPipeline();
+  };
+
+  const handleDismiss = () => {
+    clearResumeState();
+    if (currentProjectId) {
+      void setRunInProgress(currentProjectId, false).catch(() => {});
+    }
   };
 
   return (
@@ -73,7 +82,7 @@ export function RunResumeBanner() {
             </div>
           </div>
           <button
-            onClick={() => clearResumeState()}
+            onClick={handleDismiss}
             aria-label={t('resume.dismiss')}
             className="shrink-0 text-editorial-muted hover:text-editorial-ink transition-colors"
           >

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -7,3 +7,4 @@ export { PreflightDialog } from './PreflightDialog';
 export { Drawer } from './Drawer';
 export { HighlightedText } from './HighlightedText';
 export { MarkdownEditor } from './MarkdownEditor';
+export { RunResumeBanner } from './RunResumeBanner';

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -10,6 +10,9 @@ import { showPreflightDialog } from '../stores/preflightStore';
 import { withRetry, friendlyError } from '../utils/retry';
 import { qualityDefault, qualityFailure } from '../utils';
 import type { Issue, JudgeResult, PromptInfo, TokenUsage, TranslationChunk } from '../types';
+import { useProjectStore } from '../stores/projectStore';
+import { saveChunkCheckpoint, setRunInProgress } from '../services/projectService';
+import { buildPipelineFingerprint } from '../utils/pipelineFingerprint';
 
 function lastNWords(text: string, n: number): string {
   const words = text.trim().split(/\s+/);
@@ -451,6 +454,11 @@ export function usePipeline() {
     useChunksStore.getState().clearCancelRequest();
     setIsProcessing(true);
 
+    const projectId = useProjectStore.getState().currentProjectId;
+    if (projectId) {
+      void setRunInProgress(projectId, true, buildPipelineFingerprint(config)).catch(() => {});
+    }
+
     let errorCount = 0;
     let cancelled = false;
     let previousTranslation: string | undefined;
@@ -459,6 +467,13 @@ export function usePipeline() {
       const outcome = await executePipelineForChunk(chunk, { skipIfCompleted: true, previousTranslation });
       if (outcome === 'cancelled') { cancelled = true; break; }
       if (outcome === 'failed') errorCount++;
+      if ((outcome === 'completed' || outcome === 'failed') && projectId) {
+        const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
+        const position = liveChunks.indexOf(chunk);
+        if (fresh) {
+          void saveChunkCheckpoint(projectId, fresh, position).catch(() => {});
+        }
+      }
       if (outcome === 'completed' || outcome === 'skipped') {
         const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
         previousTranslation = fresh?.translationProcessingText || undefined;
@@ -467,6 +482,10 @@ export function usePipeline() {
 
     setIsProcessing(false);
     useChunksStore.getState().clearCancelRequest();
+
+    if (projectId) {
+      void setRunInProgress(projectId, false).catch(() => {});
+    }
 
     if (cancelled) {
       logOperation({ level: 'warn', scope: 'pipeline', message: 'Batch pipeline run was cancelled by the user' });

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -463,28 +463,29 @@ export function usePipeline() {
     let cancelled = false;
     let previousTranslation: string | undefined;
 
-    for (const chunk of liveChunks) {
-      const outcome = await executePipelineForChunk(chunk, { skipIfCompleted: true, previousTranslation });
-      if (outcome === 'cancelled') { cancelled = true; break; }
-      if (outcome === 'failed') errorCount++;
-      if ((outcome === 'completed' || outcome === 'failed') && projectId) {
-        const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
-        const position = liveChunks.indexOf(chunk);
-        if (fresh) {
-          void saveChunkCheckpoint(projectId, fresh, position).catch(() => {});
+    try {
+      for (const chunk of liveChunks) {
+        const outcome = await executePipelineForChunk(chunk, { skipIfCompleted: true, previousTranslation });
+        if (outcome === 'cancelled') { cancelled = true; break; }
+        if (outcome === 'failed') errorCount++;
+        if ((outcome === 'completed' || outcome === 'failed') && projectId) {
+          const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
+          const position = liveChunks.indexOf(chunk);
+          if (fresh) {
+            void saveChunkCheckpoint(projectId, fresh, position).catch(() => {});
+          }
+        }
+        if (outcome === 'completed' || outcome === 'skipped') {
+          const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
+          previousTranslation = fresh?.translationProcessingText || undefined;
         }
       }
-      if (outcome === 'completed' || outcome === 'skipped') {
-        const fresh = useChunksStore.getState().chunks.find((c) => c.id === chunk.id);
-        previousTranslation = fresh?.translationProcessingText || undefined;
+    } finally {
+      setIsProcessing(false);
+      useChunksStore.getState().clearCancelRequest();
+      if (projectId) {
+        void setRunInProgress(projectId, false).catch(() => {});
       }
-    }
-
-    setIsProcessing(false);
-    useChunksStore.getState().clearCancelRequest();
-
-    if (projectId) {
-      void setRunInProgress(projectId, false).catch(() => {});
     }
 
     if (cancelled) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -784,5 +784,13 @@
     "levelError": "error",
     "unitLabel": "Unit",
     "showPrompt": "show prompt"
+  },
+  "resume": {
+    "title": "Translation interrupted",
+    "progress": "{{completed}}/{{total}} chunks completed — resume from where it left off?",
+    "configChanged": "Warning: the pipeline configuration has changed since the last run.",
+    "resumeButton": "Resume",
+    "restartButton": "Restart from scratch",
+    "dismiss": "Dismiss"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -784,5 +784,13 @@
     "levelError": "errore",
     "unitLabel": "Unità",
     "showPrompt": "mostra prompt"
+  },
+  "resume": {
+    "title": "Traduzione interrotta",
+    "progress": "{{completed}}/{{total}} chunk completati — vuoi riprendere da dove si era interrotta?",
+    "configChanged": "Attenzione: la configurazione della pipeline è cambiata dall'ultima esecuzione.",
+    "resumeButton": "Riprendi",
+    "restartButton": "Ricomincia da capo",
+    "dismiss": "Ignora"
   }
 }

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -50,6 +50,8 @@ const ALLOWED_MIGRATIONS = new Set([
   'pipeline_configs.persona',
   'pipeline_configs.custom_source_language',
   'pipeline_configs.custom_target_language',
+  'pipeline_configs.run_in_progress',
+  'pipeline_configs.last_run_config',
 ]);
 
 export async function ensureColumn(table: string, column: string, definition: string): Promise<void> {
@@ -244,6 +246,8 @@ export async function initDatabase(): Promise<void> {
   await ensureColumn('translations', 'coherence_result', 'TEXT DEFAULT NULL');
   await ensureColumn('translations', 'footnotes', 'TEXT DEFAULT NULL');
   await ensureColumn('prompt_templates', 'context', "TEXT NOT NULL DEFAULT 'stage'");
+  await ensureColumn('pipeline_configs', 'run_in_progress', 'INTEGER DEFAULT 0');
+  await ensureColumn('pipeline_configs', 'last_run_config', 'TEXT DEFAULT NULL');
   // Migrate unique index from (name) to (name, context) so stage/audit can share names
   await conn.execute('DROP INDEX IF EXISTS idx_prompt_templates_name');
   await conn.execute(`

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -166,6 +166,8 @@ export async function getProjectConfig(projectId: string): Promise<{
   persona: string | undefined;
   customSourceLanguage: string | undefined;
   customTargetLanguage: string | undefined;
+  runInProgress: boolean;
+  lastRunConfig: string | null;
 } | null> {
   const rows = await select<{
     source_language: string;
@@ -188,6 +190,8 @@ export async function getProjectConfig(projectId: string): Promise<{
     persona?: string | null;
     custom_source_language?: string | null;
     custom_target_language?: string | null;
+    run_in_progress?: number | null;
+    last_run_config?: string | null;
   }>(
     `SELECT
        p.source_language,
@@ -209,7 +213,9 @@ export async function getProjectConfig(projectId: string): Promise<{
        pc.review_provider_options,
        pc.persona,
        pc.custom_source_language,
-       pc.custom_target_language
+       pc.custom_target_language,
+       pc.run_in_progress,
+       pc.last_run_config
      FROM pipeline_configs pc
      JOIN projects p ON p.id = pc.project_id
      WHERE pc.project_id = $1`,
@@ -261,6 +267,8 @@ export async function getProjectConfig(projectId: string): Promise<{
       translation: g.translation,
       notes: g.notes,
     })),
+    runInProgress: row.run_in_progress === 1,
+    lastRunConfig: row.last_run_config ?? null,
   };
 }
 
@@ -270,6 +278,70 @@ export async function saveProjectConfig(
   viewMode: ViewMode,
 ): Promise<void> {
   await saveProjectConfigInternal(projectId, undefined, undefined, undefined, config, viewMode, execute);
+}
+
+export async function saveChunkCheckpoint(
+  projectId: string,
+  chunk: TranslationChunk,
+  position: number,
+): Promise<void> {
+  await execute(
+    `INSERT INTO translations (
+       id, project_id, original_text, final_translation, position, chunk_status, stage_results,
+       judge_status, judge_rating, translation_locked, judge_issues, coherence_result, footnotes,
+       source_display_text, source_processing_text, translation_display_text, translation_processing_text
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+     ON CONFLICT(id) DO UPDATE SET
+       chunk_status                 = excluded.chunk_status,
+       stage_results                = excluded.stage_results,
+       final_translation            = excluded.final_translation,
+       judge_status                 = excluded.judge_status,
+       judge_rating                 = excluded.judge_rating,
+       judge_issues                 = excluded.judge_issues,
+       translation_display_text     = excluded.translation_display_text,
+       translation_processing_text  = excluded.translation_processing_text,
+       source_display_text          = excluded.source_display_text,
+       source_processing_text       = excluded.source_processing_text,
+       coherence_result             = excluded.coherence_result,
+       footnotes                    = excluded.footnotes`,
+    [
+      chunk.id,
+      projectId,
+      chunk.sourceDisplayText,
+      chunk.translationDisplayText || chunk.judgeResult.content || '',
+      position,
+      chunk.status,
+      JSON.stringify(chunk.stageResults),
+      chunk.judgeResult.status,
+      chunk.judgeResult.rating,
+      chunk.translationLocked ? 1 : 0,
+      JSON.stringify(chunk.judgeResult.issues),
+      chunk.coherenceResult ? JSON.stringify(chunk.coherenceResult) : null,
+      chunk.footnotes?.length ? JSON.stringify(chunk.footnotes) : null,
+      chunk.sourceDisplayText,
+      chunk.sourceProcessingText,
+      chunk.translationDisplayText,
+      chunk.translationProcessingText,
+    ],
+  );
+}
+
+export async function setRunInProgress(
+  projectId: string,
+  inProgress: boolean,
+  configFingerprint?: string,
+): Promise<void> {
+  if (inProgress) {
+    await execute(
+      'UPDATE pipeline_configs SET run_in_progress = 1, last_run_config = $1 WHERE project_id = $2',
+      [configFingerprint ?? null, projectId],
+    );
+  } else {
+    await execute(
+      'UPDATE pipeline_configs SET run_in_progress = 0 WHERE project_id = $1',
+      [projectId],
+    );
+  }
 }
 
 type ExecuteQuery = (query: string, params?: unknown[]) => Promise<void>;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -292,11 +292,14 @@ export async function saveChunkCheckpoint(
        source_display_text, source_processing_text, translation_display_text, translation_processing_text
      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
      ON CONFLICT(id) DO UPDATE SET
+       original_text                = excluded.original_text,
+       final_translation            = excluded.final_translation,
+       position                     = excluded.position,
        chunk_status                 = excluded.chunk_status,
        stage_results                = excluded.stage_results,
-       final_translation            = excluded.final_translation,
        judge_status                 = excluded.judge_status,
        judge_rating                 = excluded.judge_rating,
+       translation_locked           = excluded.translation_locked,
        judge_issues                 = excluded.judge_issues,
        translation_display_text     = excluded.translation_display_text,
        translation_processing_text  = excluded.translation_processing_text,
@@ -308,7 +311,7 @@ export async function saveChunkCheckpoint(
       chunk.id,
       projectId,
       chunk.sourceDisplayText,
-      chunk.translationDisplayText || chunk.judgeResult.content || '',
+      chunk.translationDisplayText || chunk.judgeResult.content || lastStageContent(chunk.stageResults) || '',
       position,
       chunk.status,
       JSON.stringify(chunk.stageResults),

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -146,6 +146,7 @@ interface ChunksState {
   splitChunkAt: (chunkId: string, splitAt: number) => boolean;
   mergeChunkWithNext: (chunkId: string) => void;
   resetCompletedChunks: () => void;
+  resetAllChunks: () => void;
   unlockChunkForEdit: (chunkId: string) => void;
   clearChunkStages: (chunkId: string) => void;
 }
@@ -373,6 +374,13 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
     set((state) => ({
       chunks: state.chunks.map((chunk) =>
         chunk.status === 'completed' ? resetChunkForSourceEdit(chunk) : chunk,
+      ),
+    })),
+
+  resetAllChunks: () =>
+    set((state) => ({
+      chunks: state.chunks.map((chunk) =>
+        chunk.status !== 'ready' ? resetChunkForSourceEdit(chunk) : chunk,
       ),
     })),
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -26,6 +26,8 @@ interface ProjectState {
   saveState: 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
   lastSaveError: string | null;
   trackedSnapshot: string | null;
+  runInterrupted: boolean;
+  lastRunConfig: string | null;
 
   setShowProjectPanel: (show: boolean) => void;
   loadProjects: () => Promise<void>;
@@ -34,6 +36,7 @@ interface ProjectState {
   removeProject: (id: string) => Promise<void>;
   saveCurrentProject: (name?: string) => Promise<void>;
   closeProject: () => void;
+  clearResumeState: () => void;
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -43,6 +46,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   saveState: 'idle',
   lastSaveError: null,
   trackedSnapshot: null,
+  runInterrupted: false,
+  lastRunConfig: null,
 
   setShowProjectPanel: (show) => {
     set({ showProjectPanel: show });
@@ -117,6 +122,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       saveState: 'saved',
       lastSaveError: null,
       trackedSnapshot: null,
+      runInterrupted: config.runInProgress,
+      lastRunConfig: config.lastRunConfig,
     });
   },
 
@@ -145,8 +152,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       saveState: 'idle',
       lastSaveError: null,
       trackedSnapshot: null,
+      runInterrupted: false,
+      lastRunConfig: null,
     });
   },
+
+  clearResumeState: () => set({ runInterrupted: false, lastRunConfig: null }),
 
   saveCurrentProject: async (name?: string) => {
     if (saveInFlight) {

--- a/src/utils/pipelineFingerprint.ts
+++ b/src/utils/pipelineFingerprint.ts
@@ -1,0 +1,15 @@
+import type { PipelineConfig } from '../types';
+
+/**
+ * Creates a stable JSON fingerprint of the pipeline config fields that, if
+ * changed, would make resuming an interrupted run unsafe or misleading.
+ * Used to warn the user when the config has changed since the interruption.
+ */
+export function buildPipelineFingerprint(config: PipelineConfig): string {
+  return JSON.stringify({
+    stages: config.stages
+      .filter((s) => s.enabled)
+      .map((s) => ({ provider: s.provider, model: s.model })),
+    judge: { provider: config.judgeProvider, model: config.judgeModel },
+  });
+}


### PR DESCRIPTION
Closes #119

## Cosa fa

Salva il progresso chunk per chunk durante l'esecuzione della pipeline, e offre di riprendere alla riapertura del documento se la sessione precedente era stata interrotta (crash, chiusura app, calo di rete).

## Come funziona

### Backend (DB)
- Due nuove colonne in `pipeline_configs`: `run_in_progress` (flag 0/1) e `last_run_config` (fingerprint JSON della configurazione al momento dell'avvio)
- Nuova funzione `saveChunkCheckpoint` — salva un singolo chunk immediatamente nel DB (upsert), senza aspettare l'autosave
- Nuova funzione `setRunInProgress` — accende/spegne il flag in modo fire-and-forget (non blocca la pipeline)

### Pipeline hook
- All'inizio di ogni batch run: imposta `run_in_progress = 1` e salva il fingerprint della configurazione
- Dopo ogni chunk completato o fallito: salva il checkpoint immediatamente
- Al termine della run (successo, cancellazione o errore): imposta `run_in_progress = 0`

### Riapertura progetto
- `openProject` legge `run_in_progress` e lo propaga nello store come `runInterrupted`
- Se `true`, il banner si mostra automaticamente

### Banner di ripresa
- Mostra quanti chunk erano completati su quanti totali
- Avverte se la configurazione della pipeline è cambiata dall'ultima esecuzione
- **Riprendi**: lancia la pipeline (i chunk già completati vengono saltati)
- **Ricomincia da capo**: resetta tutti i chunk a `ready` e rilancia
- **✕**: ignora il banner senza fare nulla
