### PR TITLE
feat: token context overflow detection (#121)

### DIFF
--- a/src-tauri/src/llm/providers/mod.rs
+++ b/src-tauri/src/llm/providers/mod.rs
@@ -28,12 +28,20 @@ pub(crate) fn format_api_error(
     body: &str,
 ) -> String {
     log_response_body(provider_label, status, body);
+    let body_lower = body.to_lowercase();
     let user_message = match status.as_u16() {
+        400 if body_lower.contains("context")
+            || body_lower.contains("too long")
+            || body_lower.contains("maximum context")
+            || body_lower.contains("context_length_exceeded") =>
+        {
+            "context window exceeded — reduce chunk size or use a model with a larger context window"
+        }
         400 => "bad request — check the model name or prompt",
         401 | 403 => "API key not authorized",
         404 => "model or endpoint not found",
         408 => "the provider timed out",
-        413 => "input too large for the model",
+        413 => "context window exceeded — reduce chunk size or use a model with a larger context window",
         429 => "rate limited — retry shortly",
         500..=599 => "provider unavailable",
         _ => "unexpected response",

--- a/src-tauri/src/llm/providers/ollama.rs
+++ b/src-tauri/src/llm/providers/ollama.rs
@@ -342,12 +342,19 @@ pub(crate) fn parse_ollama_usage(json: &Value) -> Option<(u32, u32)> {
 fn format_ollama_api_error(status: reqwest::StatusCode, body: &str) -> String {
     #[cfg(debug_assertions)]
     log::debug!("Ollama API error body ({status}): {body}");
-    #[cfg(not(debug_assertions))]
-    let _ = body;
 
+    let body_lower = body.to_lowercase();
     match status.as_u16() {
+        400 if body_lower.contains("context")
+            || body_lower.contains("too long")
+            || body_lower.contains("maximum context")
+            || body_lower.contains("context_length_exceeded") =>
+        {
+            "Ollama context window exceeded — reduce chunk size or lower numCtx in Settings.".to_string()
+        }
         404 => "Ollama model or endpoint not found. Verify that the configured model is installed locally.".to_string(),
         408 => "Ollama timed out while preparing the response. The model may be too large for the available VRAM/CPU budget.".to_string(),
+        413 => "Ollama context window exceeded — reduce chunk size or lower numCtx in Settings.".to_string(),
         503 => "Ollama is overloaded and rejected the request. The server queue may be full or the machine may not have enough free memory.".to_string(),
         500..=599 => "Ollama failed while loading or running the model. This usually means insufficient VRAM, a model crash, or a local server fault.".to_string(),
         _ => format!("Ollama API error ({status}): unexpected response"),

--- a/src-tauri/src/llm/providers/ollama.rs
+++ b/src-tauri/src/llm/providers/ollama.rs
@@ -350,11 +350,11 @@ fn format_ollama_api_error(status: reqwest::StatusCode, body: &str) -> String {
             || body_lower.contains("maximum context")
             || body_lower.contains("context_length_exceeded") =>
         {
-            "Ollama context window exceeded — reduce chunk size or lower numCtx in Settings.".to_string()
+            "Ollama context window exceeded — reduce chunk size or increase numCtx in Ollama provider settings.".to_string()
         }
         404 => "Ollama model or endpoint not found. Verify that the configured model is installed locally.".to_string(),
         408 => "Ollama timed out while preparing the response. The model may be too large for the available VRAM/CPU budget.".to_string(),
-        413 => "Ollama context window exceeded — reduce chunk size or lower numCtx in Settings.".to_string(),
+        413 => "Ollama context window exceeded — reduce chunk size or increase numCtx in Ollama provider settings.".to_string(),
         503 => "Ollama is overloaded and rejected the request. The server queue may be full or the machine may not have enough free memory.".to_string(),
         500..=599 => "Ollama failed while loading or running the model. This usually means insufficient VRAM, a model crash, or a local server fault.".to_string(),
         _ => format!("Ollama API error ({status}): unexpected response"),

--- a/src/components/document/ImportPreviewDialog.tsx
+++ b/src/components/document/ImportPreviewDialog.tsx
@@ -18,7 +18,7 @@ import { buildImportPreview } from '../../utils/documentWorkflow';
 import { findBestSplitIndex, recommendChunkCount, trimSplitFragment } from '../../utils';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { usePipelineStore } from '../../stores/pipelineStore';
-import { checkContextOverflow } from '../../utils/tokenEstimate';
+import { checkContextOverflow, estimateCharTokens } from '../../utils/tokenEstimate';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -486,19 +486,28 @@ export function ImportPreviewDialog({
   const contextWarning = useMemo(() => {
     if (!useChunking) return null;
     const longestChunk = preview.chunks.reduce(
-      (a, b) => (a.text.length > b.text.length ? a : b),
+      (a, b) => (estimateCharTokens(a.text) >= estimateCharTokens(b.text) ? a : b),
       { text: '' },
     );
     const activeModels = [
       ...config.stages
         .filter((s) => s.enabled)
         .map((s) => ({ provider: s.provider, model: s.model, numCtx: s.providerOptions?.ollama?.numCtx })),
-      { provider: config.judgeProvider, model: config.judgeModel, numCtx: undefined },
+      {
+        provider: config.judgeProvider,
+        model: config.judgeModel,
+        numCtx: config.reviewProviderOptions?.ollama?.numCtx,
+      },
     ];
-    const longestPrompt = config.stages
-      .filter((s) => s.enabled)
-      .reduce((a, b) => (a.prompt.length > b.prompt.length ? a : b), { prompt: '' }).prompt;
-    return checkContextOverflow(longestChunk.text, longestPrompt, activeModels);
+    const allPrompts = [
+      ...config.stages.filter((s) => s.enabled).map((s) => s.prompt),
+      config.judgePrompt,
+      ...(config.coherencePrompt ? [config.coherencePrompt] : []),
+    ];
+    const maxPrompt = allPrompts.reduce((a, b) =>
+      estimateCharTokens(a) >= estimateCharTokens(b) ? a : b, '',
+    );
+    return checkContextOverflow(longestChunk.text, maxPrompt, activeModels);
   }, [preview.chunks, useChunking, config]);
 
   // ── Manual boundary editing state ─────────────────────────────────────────

--- a/src/components/document/ImportPreviewDialog.tsx
+++ b/src/components/document/ImportPreviewDialog.tsx
@@ -17,6 +17,8 @@ import {
 import { buildImportPreview } from '../../utils/documentWorkflow';
 import { findBestSplitIndex, recommendChunkCount, trimSplitFragment } from '../../utils';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { usePipelineStore } from '../../stores/pipelineStore';
+import { checkContextOverflow } from '../../utils/tokenEstimate';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -412,6 +414,7 @@ export function ImportPreviewDialog({
   const { t } = useTranslation();
   const trapRef = useFocusTrap(true, onCancel);
   const [editorMode, setEditorMode] = useState<EditorMode>('cards');
+  const config = usePipelineStore((s) => s.config);
 
   // ── Settings: words-per-chunk ↔ targetChunkCount sync ─────────────────────
   const totalWords = useMemo(() => {
@@ -479,6 +482,24 @@ export function ImportPreviewDialog({
     () => toParagraphChunks(preview.chunks.map((c) => c.text)),
     [preview.chunks],
   );
+
+  const contextWarning = useMemo(() => {
+    if (!useChunking) return null;
+    const longestChunk = preview.chunks.reduce(
+      (a, b) => (a.text.length > b.text.length ? a : b),
+      { text: '' },
+    );
+    const activeModels = [
+      ...config.stages
+        .filter((s) => s.enabled)
+        .map((s) => ({ provider: s.provider, model: s.model, numCtx: s.providerOptions?.ollama?.numCtx })),
+      { provider: config.judgeProvider, model: config.judgeModel, numCtx: undefined },
+    ];
+    const longestPrompt = config.stages
+      .filter((s) => s.enabled)
+      .reduce((a, b) => (a.prompt.length > b.prompt.length ? a : b), { prompt: '' }).prompt;
+    return checkContextOverflow(longestChunk.text, longestPrompt, activeModels);
+  }, [preview.chunks, useChunking, config]);
 
   // ── Manual boundary editing state ─────────────────────────────────────────
   const [manualParaChunks, setManualParaChunks] = useState<ParagraphChunks | null>(null);
@@ -798,6 +819,22 @@ export function ImportPreviewDialog({
             </button>
           </div>
         </div>
+
+        {/* ── Context overflow warning ──────────────────────────────────────── */}
+        {contextWarning && (
+          <div className="shrink-0 px-6 pb-2">
+            <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+              <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-500" />
+              <span>
+                {t('pipeline.contextOverflowWarning', {
+                  tokens: contextWarning.estimatedTokens.toLocaleString(),
+                  model: contextWarning.modelId,
+                  window: contextWarning.contextWindow.toLocaleString(),
+                })}
+              </span>
+            </div>
+          </div>
+        )}
 
         {/* ── Content area ─────────────────────────────────────────────────── */}
         <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5 custom-scrollbar">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -182,7 +182,8 @@
     "refinePrompt": "Refine prompt",
     "refining": "Refining...",
     "refined": "Prompt refined",
-    "refineFailed": "Refinement failed"
+    "refineFailed": "Refinement failed",
+    "contextOverflowWarning": "The longest chunk (~{{tokens}} tokens) may exceed {{model}}'s context window ({{window}} tokens). Consider reducing chunk size or using a model with a larger context window."
   },
   "audit": {
     "title": "Audit Logs",
@@ -266,7 +267,8 @@
     "pipelineCompleted": "Pipeline completed successfully",
     "pipelineCompletedWithErrors": "Pipeline completed with {{count}} error(s)",
     "reEvalCompleted": "Re-evaluation completed",
-    "coherenceFailed": "Coherence audit failed"
+    "coherenceFailed": "Coherence audit failed",
+    "contextOverflow": "Context window exceeded. Reduce chunk size or use a model with a larger context window."
   },
   "coherence": {
     "title": "Document Coherence",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -182,7 +182,8 @@
     "refinePrompt": "Rifinisci prompt",
     "refining": "Rifinendo...",
     "refined": "Prompt rifinito",
-    "refineFailed": "Rifinizione fallita"
+    "refineFailed": "Rifinizione fallita",
+    "contextOverflowWarning": "Il chunk più lungo (~{{tokens}} token) potrebbe superare la finestra di contesto di {{model}} ({{window}} token). Riduci la dimensione dei chunk o usa un modello con contesto più grande."
   },
   "audit": {
     "title": "Log Audit",
@@ -266,7 +267,8 @@
     "pipelineCompleted": "Pipeline completata con successo",
     "pipelineCompletedWithErrors": "Pipeline completata con {{count}} errore/i",
     "reEvalCompleted": "Rivalutazione completata",
-    "coherenceFailed": "Audit di coerenza fallito"
+    "coherenceFailed": "Audit di coerenza fallito",
+    "contextOverflow": "Finestra di contesto superata. Riduci la dimensione dei chunk o usa un modello con una finestra di contesto più grande."
   },
   "coherence": {
     "title": "Coerenza Documento",

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -6,6 +6,7 @@ export interface ModelEntry {
   id: string;
   provider: ModelProvider;
   status: ModelStatus;
+  contextWindow: number; // tokens
   pricing?: { input: number; output: number }; // USD per 1M tokens; undefined = free/local
 }
 
@@ -13,19 +14,19 @@ export interface ModelEntry {
 // Source: official provider pricing pages
 export const MODEL_CATALOG: ModelEntry[] = [
   // Gemini
-  { id: 'gemini-3-flash-preview',        provider: 'gemini',    status: 'preview', pricing: { input: 0.075, output: 0.30  } },
-  { id: 'gemini-3.1-pro-preview',        provider: 'gemini',    status: 'preview', pricing: { input: 1.25,  output: 5.00  } },
-  { id: 'gemini-2.5-flash-lite-preview', provider: 'gemini',    status: 'preview', pricing: { input: 0.10,  output: 0.40  } },
+  { id: 'gemini-3-flash-preview',        provider: 'gemini',    status: 'preview', contextWindow: 1_048_576, pricing: { input: 0.075, output: 0.30  } },
+  { id: 'gemini-3.1-pro-preview',        provider: 'gemini',    status: 'preview', contextWindow: 1_048_576, pricing: { input: 1.25,  output: 5.00  } },
+  { id: 'gemini-2.5-flash-lite-preview', provider: 'gemini',    status: 'preview', contextWindow: 1_048_576, pricing: { input: 0.10,  output: 0.40  } },
   // OpenAI
-  { id: 'gpt-4o',                        provider: 'openai',    status: 'stable',  pricing: { input: 2.50,  output: 10.00 } },
-  { id: 'gpt-4o-mini',                   provider: 'openai',    status: 'stable',  pricing: { input: 0.15,  output: 0.60  } },
-  { id: 'o1-preview',                    provider: 'openai',    status: 'preview', pricing: { input: 15.00, output: 60.00 } },
+  { id: 'gpt-4o',                        provider: 'openai',    status: 'stable',  contextWindow: 128_000,   pricing: { input: 2.50,  output: 10.00 } },
+  { id: 'gpt-4o-mini',                   provider: 'openai',    status: 'stable',  contextWindow: 128_000,   pricing: { input: 0.15,  output: 0.60  } },
+  { id: 'o1-preview',                    provider: 'openai',    status: 'preview', contextWindow: 128_000,   pricing: { input: 15.00, output: 60.00 } },
   // Anthropic
-  { id: 'claude-3-5-sonnet-latest',      provider: 'anthropic', status: 'stable',  pricing: { input: 3.00,  output: 15.00 } },
-  { id: 'claude-3-haiku-latest',         provider: 'anthropic', status: 'stable',  pricing: { input: 0.25,  output: 1.25  } },
+  { id: 'claude-3-5-sonnet-latest',      provider: 'anthropic', status: 'stable',  contextWindow: 200_000,   pricing: { input: 3.00,  output: 15.00 } },
+  { id: 'claude-3-haiku-latest',         provider: 'anthropic', status: 'stable',  contextWindow: 200_000,   pricing: { input: 0.25,  output: 1.25  } },
   // DeepSeek
-  { id: 'deepseek-chat',                 provider: 'deepseek',  status: 'stable',  pricing: { input: 0.27,  output: 1.10  } },
-  { id: 'deepseek-reasoner',             provider: 'deepseek',  status: 'stable',  pricing: { input: 0.55,  output: 2.19  } },
+  { id: 'deepseek-chat',                 provider: 'deepseek',  status: 'stable',  contextWindow: 64_000,    pricing: { input: 0.27,  output: 1.10  } },
+  { id: 'deepseek-reasoner',             provider: 'deepseek',  status: 'stable',  contextWindow: 64_000,    pricing: { input: 0.55,  output: 2.19  } },
 ];
 
 export function getModelEntry(provider: ModelProvider, modelId: string): ModelEntry | undefined {

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -14,6 +14,14 @@ describe('classifyError', () => {
     expect(classifyError('quota exceeded')).toBe('rate_limit');
   });
 
+  it('detects context overflow errors', () => {
+    expect(classifyError('context window exceeded')).toBe('context_overflow');
+    expect(classifyError('context_length_exceeded')).toBe('context_overflow');
+    expect(classifyError('maximum context reached')).toBe('context_overflow');
+    expect(classifyError('input too large for model')).toBe('context_overflow');
+    expect(classifyError('HTTP status 413')).toBe('context_overflow');
+  });
+
   it('detects network errors', () => {
     expect(classifyError('network error')).toBe('network');
     expect(classifyError('fetch failed')).toBe('network');
@@ -61,6 +69,15 @@ describe('friendlyError', () => {
     const longMsg = 'x'.repeat(200);
     const result = friendlyError(longMsg);
     expect(result.length).toBeLessThanOrEqual(121);
+  });
+
+  it('returns friendly message for context overflow (413 in message)', () => {
+    expect(friendlyError('context window exceeded, 413')).toContain('Context window exceeded');
+  });
+
+  it('returns Ollama message as-is for context overflow', () => {
+    const msg = 'Ollama context window exceeded — reduce chunk size or increase numCtx in Ollama provider settings.';
+    expect(friendlyError(msg)).toBe(msg);
   });
 });
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -66,11 +66,12 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** Classify an error string into a user-friendly category */
-export type ErrorCategory = 'config' | 'network' | 'rate_limit' | 'api' | 'parse' | 'unknown';
+export type ErrorCategory = 'config' | 'network' | 'rate_limit' | 'context_overflow' | 'api' | 'parse' | 'unknown';
 
 export function classifyError(message: string): ErrorCategory {
   if (isConfigError(message)) return 'config';
   if (/rate.?limit|429|quota/i.test(message)) return 'rate_limit';
+  if (/context.window.exceeded|context_length_exceeded|maximum context|input too large|413/i.test(message)) return 'context_overflow';
   if (/network|fetch|timeout|ECONNREFUSED|ENOTFOUND/i.test(message)) return 'network';
   if (/parse|JSON|unexpected token/i.test(message)) return 'parse';
   if (/API error|request failed|status/i.test(message)) return 'api';
@@ -86,6 +87,8 @@ export function friendlyError(message: string): string {
       return message; // Already user-friendly from backend
     case 'rate_limit':
       return 'Rate limit reached. The request will be retried automatically.';
+    case 'context_overflow':
+      return 'Context window exceeded. Reduce the chunk size in Settings or switch to a model with a larger context window.';
     case 'network':
       return 'Network error. Please check your internet connection.';
     case 'parse':

--- a/src/utils/tokenEstimate.test.ts
+++ b/src/utils/tokenEstimate.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { estimateCharTokens, getContextWindow, checkContextOverflow } from './tokenEstimate';
+
+describe('estimateCharTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateCharTokens('')).toBe(0);
+  });
+
+  it('estimates western text at ~1 token per 4 chars', () => {
+    const result = estimateCharTokens('abcdefgh'); // 8 chars → ceil(8/4) = 2
+    expect(result).toBe(2);
+  });
+
+  it('estimates CJK text at ~1 token per 2 chars', () => {
+    const result = estimateCharTokens('你好世界'); // 4 CJK chars → ceil(4/2) = 2
+    expect(result).toBe(2);
+  });
+
+  it('estimates mixed text correctly', () => {
+    // '你好 hi': 2 CJK + 3 western (' ', 'h', 'i') → ceil(2/2 + 3/4) = ceil(1 + 0.75) = 2
+    const result = estimateCharTokens('你好 hi');
+    expect(result).toBe(2);
+  });
+
+  it('is higher for CJK than western for same char count', () => {
+    const cjk = estimateCharTokens('你好世界世界世界世界'); // 9 CJK
+    const western = estimateCharTokens('hello world!'); // 12 western chars
+    expect(cjk).toBeGreaterThan(western);
+  });
+});
+
+describe('getContextWindow', () => {
+  it('returns numCtx for ollama provider', () => {
+    expect(getContextWindow('ollama', 'llama3', 4096)).toBe(4096);
+  });
+
+  it('returns 8192 as default for ollama when numCtx is null', () => {
+    expect(getContextWindow('ollama', 'llama3', null)).toBe(8192);
+  });
+
+  it('returns context window from catalog for known models', () => {
+    const result = getContextWindow('anthropic', 'claude-3-5-sonnet-latest');
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('returns undefined for unknown models', () => {
+    expect(getContextWindow('unknown_provider', 'nonexistent-model')).toBeUndefined();
+  });
+});
+
+describe('checkContextOverflow', () => {
+  it('returns null when all models have sufficient context', () => {
+    const models = [{ provider: 'ollama', model: 'llama3', numCtx: 128000 }];
+    const result = checkContextOverflow('short chunk', 'short prompt', models);
+    expect(result).toBeNull();
+  });
+
+  it('returns warning when estimated tokens exceed 80% of context window', () => {
+    // Small numCtx to force overflow: 10 tokens context, chunk + prompt > 8 tokens
+    const longText = 'a'.repeat(200); // ~50 tokens
+    const models = [{ provider: 'ollama', model: 'llama3', numCtx: 10 }];
+    const result = checkContextOverflow(longText, '', models);
+    expect(result).not.toBeNull();
+    expect(result?.provider).toBe('ollama');
+    expect(result?.modelId).toBe('llama3');
+    expect(result?.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it('returns the most restrictive model (smallest context window)', () => {
+    const longText = 'a'.repeat(200); // ~50 tokens
+    const models = [
+      { provider: 'ollama', model: 'big-model', numCtx: 20 },  // 80% = 16 tokens — overflows
+      { provider: 'ollama', model: 'small-model', numCtx: 10 }, // 80% = 8 tokens — overflows, smaller
+    ];
+    const result = checkContextOverflow(longText, '', models);
+    expect(result?.modelId).toBe('small-model');
+    expect(result?.contextWindow).toBe(10);
+  });
+
+  it('returns null when no models are provided', () => {
+    expect(checkContextOverflow('text', 'prompt', [])).toBeNull();
+  });
+
+  it('accounts for both chunk and prompt tokens separately', () => {
+    const chunk = 'a'.repeat(100); // ~25 tokens
+    const prompt = 'b'.repeat(100); // ~25 tokens, total ~50
+    const models = [{ provider: 'ollama', model: 'm', numCtx: 30 }]; // 80% = 24 < 50 → overflow
+    const result = checkContextOverflow(chunk, prompt, models);
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/utils/tokenEstimate.ts
+++ b/src/utils/tokenEstimate.ts
@@ -1,16 +1,5 @@
 import { MODEL_CATALOG } from '../models/catalog';
 
-const CJK_REGEX = /[\u3000-\u9fff\ua000-\uffef]/g;
-
-/** Estimate token count for a string using char-based heuristics.
- *  ~2 chars/token for CJK, ~4 chars/token for western text. */
-export function estimateTokens(text: string): number {
-  if (!text) return 0;
-  const cjkCount = (text.match(CJK_REGEX) ?? []).length;
-  const westernCount = text.length - cjkCount;
-  return Math.ceil(cjkCount / 2 + westernCount / 4);
-}
-
 /** Safety margin: warn if chunk exceeds this fraction of context window */
 export const CONTEXT_OVERFLOW_THRESHOLD = 0.8;
 
@@ -21,6 +10,20 @@ export interface ContextOverflowWarning {
   provider: string;
 }
 
+/** Estimate token count for a string using char-based heuristics.
+ *  ~2 chars/token for CJK, ~4 chars/token for western text.
+ *  Named distinctly from costEstimate.ts::estimateTokens (word-based). */
+export function estimateCharTokens(text: string): number {
+  if (!text) return 0;
+  let cjkCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    const cp = text.charCodeAt(i);
+    if ((cp >= 0x3000 && cp <= 0x9fff) || (cp >= 0xa000 && cp <= 0xffef)) cjkCount++;
+  }
+  const westernCount = text.length - cjkCount;
+  return Math.ceil(cjkCount / 2 + westernCount / 4);
+}
+
 /** Get context window for a model. Falls back to numCtx for Ollama, undefined for unknown. */
 export function getContextWindow(provider: string, modelId: string, numCtx?: number | null): number | undefined {
   if (provider === 'ollama') return numCtx ?? 8192;
@@ -28,19 +31,23 @@ export function getContextWindow(provider: string, modelId: string, numCtx?: num
   return entry?.contextWindow;
 }
 
-/** Returns a warning if the estimated tokens exceed 80% of any pipeline model's context window.
- *  Returns null if all models have sufficient context. */
+/** Returns a warning for the most restrictive model that exceeds 80% of its context window,
+ *  or null if all models have sufficient context. Chunk and prompt are estimated separately
+ *  to avoid creating large intermediate strings. */
 export function checkContextOverflow(
   longestChunkText: string,
-  systemPromptText: string,
+  maxPromptText: string,
   activeModels: Array<{ provider: string; model: string; numCtx?: number | null }>,
 ): ContextOverflowWarning | null {
-  const estimated = estimateTokens(longestChunkText + '\n' + systemPromptText);
+  const estimated = estimateCharTokens(longestChunkText) + estimateCharTokens(maxPromptText);
+  let worst: ContextOverflowWarning | null = null;
   for (const m of activeModels) {
     const contextWindow = getContextWindow(m.provider, m.model, m.numCtx);
     if (contextWindow && estimated > contextWindow * CONTEXT_OVERFLOW_THRESHOLD) {
-      return { estimatedTokens: estimated, contextWindow, modelId: m.model, provider: m.provider };
+      if (!worst || contextWindow < worst.contextWindow) {
+        worst = { estimatedTokens: estimated, contextWindow, modelId: m.model, provider: m.provider };
+      }
     }
   }
-  return null;
+  return worst;
 }

--- a/src/utils/tokenEstimate.ts
+++ b/src/utils/tokenEstimate.ts
@@ -1,0 +1,46 @@
+import { MODEL_CATALOG } from '../models/catalog';
+
+const CJK_REGEX = /[\u3000-\u9fff\ua000-\uffef]/g;
+
+/** Estimate token count for a string using char-based heuristics.
+ *  ~2 chars/token for CJK, ~4 chars/token for western text. */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  const cjkCount = (text.match(CJK_REGEX) ?? []).length;
+  const westernCount = text.length - cjkCount;
+  return Math.ceil(cjkCount / 2 + westernCount / 4);
+}
+
+/** Safety margin: warn if chunk exceeds this fraction of context window */
+export const CONTEXT_OVERFLOW_THRESHOLD = 0.8;
+
+export interface ContextOverflowWarning {
+  estimatedTokens: number;
+  contextWindow: number;
+  modelId: string;
+  provider: string;
+}
+
+/** Get context window for a model. Falls back to numCtx for Ollama, undefined for unknown. */
+export function getContextWindow(provider: string, modelId: string, numCtx?: number | null): number | undefined {
+  if (provider === 'ollama') return numCtx ?? 8192;
+  const entry = MODEL_CATALOG.find((e) => e.provider === provider && e.id === modelId);
+  return entry?.contextWindow;
+}
+
+/** Returns a warning if the estimated tokens exceed 80% of any pipeline model's context window.
+ *  Returns null if all models have sufficient context. */
+export function checkContextOverflow(
+  longestChunkText: string,
+  systemPromptText: string,
+  activeModels: Array<{ provider: string; model: string; numCtx?: number | null }>,
+): ContextOverflowWarning | null {
+  const estimated = estimateTokens(longestChunkText + '\n' + systemPromptText);
+  for (const m of activeModels) {
+    const contextWindow = getContextWindow(m.provider, m.model, m.numCtx);
+    if (contextWindow && estimated > contextWindow * CONTEXT_OVERFLOW_THRESHOLD) {
+      return { estimatedTokens: estimated, contextWindow, modelId: m.model, provider: m.provider };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Changes

Implements both aspects of #121.

### Pre-send estimation

Adds a `contextWindow` field to the model catalog and a CJK-aware token estimation utility. The ImportPreviewDialog now shows a warning banner when the longest chunk + system prompt is estimated to exceed 80% of any active pipeline model's context window. Ollama uses the configured `numCtx` value.

### Runtime error recognition

HTTP 413 and HTTP 400 responses with context-length body text are now mapped to a specific, actionable error message instead of the generic 'API error'. The TypeScript error classifier gains a `context_overflow` category with a clear user-facing message.

Closes #121