### PR TITLE
feat: FASE 3 — pipeline mode router (standard / editorial) (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,45 @@ Prima di ogni commit verifica:
 - [ ] Le query SQL usano parametri bind (mai concatenazione di stringhe)
 - [ ] I path sui file sono sanitizzati
 
+## UI — Stile dei componenti
+
+Queste regole si applicano a tutti i componenti del pannello di configurazione e in generale all'intera UI.
+
+### Label di sezione
+
+Ogni sezione ha un'intestazione icona + etichetta:
+
+```tsx
+<div className="flex items-center gap-1.5">
+  <IconName size={11} className="text-editorial-accent shrink-0" />
+  <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+    {t('chiave.etichetta')}
+  </p>
+</div>
+```
+
+### Pulsanti pill (selezione tra opzioni)
+
+```tsx
+className={`rounded-full border px-4 py-1.5 text-xs font-bold uppercase tracking-widest transition-colors
+  focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent
+  disabled:cursor-not-allowed disabled:opacity-40 ${
+    isActive
+      ? 'border-editorial-accent bg-editorial-accent text-white'
+      : 'border-editorial-border text-editorial-muted hover:border-editorial-accent/60 hover:text-editorial-accent'
+  }`}
+```
+
+Non usare `editorial-ink` per i pulsanti di selezione: usare sempre `editorial-accent` (rosso).
+
+### Ordine degli elementi nel tab Impostazioni
+
+Disporre dall'alto verso il basso per importanza percepita dall'utente:
+
+1. Modalità di traduzione (scelta che cambia la struttura della pipeline)
+2. Coppia linguistica
+3. Persona
+
 ## Contributing
 
 1. Apri un issue prima di iniziare lavori grandi

--- a/src-tauri/src/llm/mod.rs
+++ b/src-tauri/src/llm/mod.rs
@@ -188,6 +188,7 @@ mod tests {
         StageConfig {
             id: "stg-1".into(),
             name: "Translation".into(),
+            role: None,
             prompt: "Translate accurately.".into(),
             model: "test-model".into(),
             provider: provider.into(),

--- a/src-tauri/src/llm/prompts.rs
+++ b/src-tauri/src/llm/prompts.rs
@@ -141,16 +141,24 @@ pub(crate) fn build_stage_prompts(
         .map(|id| format!("Current chunk id: {id}\n\n"))
         .unwrap_or_default();
 
-    let user = match previous_result {
-        Some(prev) if !prev.is_empty() => format!(
-            "{current_chunk_line}Original text for the current chunk:\n{text}\n\n\
-             Previous Iteration for the current chunk:\n{prev}\n\n\
-             Refine only the current chunk according to your instructions. Output only the refined translation."
-        ),
-        _ => format!(
-            "{current_chunk_line}Text to translate from the current chunk:\n{text}\n\n\
-             Translate only the current chunk. Output only its translation."
-        ),
+    let is_format = stage.role.as_deref() == Some("format");
+    let user = if is_format {
+        format!(
+            "{current_chunk_line}Text to format from the current chunk:\n{text}\n\n\
+             Apply your formatting instructions to the current chunk. Output only the formatted text."
+        )
+    } else {
+        match previous_result {
+            Some(prev) if !prev.is_empty() => format!(
+                "{current_chunk_line}Original text for the current chunk:\n{text}\n\n\
+                 Previous Iteration for the current chunk:\n{prev}\n\n\
+                 Refine only the current chunk according to your instructions. Output only the refined translation."
+            ),
+            _ => format!(
+                "{current_chunk_line}Text to translate from the current chunk:\n{text}\n\n\
+                 Translate only the current chunk. Output only its translation."
+            ),
+        }
     };
 
     StructuredPrompt { system, user }

--- a/src-tauri/src/llm/types.rs
+++ b/src-tauri/src/llm/types.rs
@@ -79,6 +79,8 @@ pub struct ProviderRuntimeConfig {
 pub struct StageConfig {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub role: Option<String>,
     pub prompt: String,
     pub model: String,
     pub provider: String,

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -308,21 +308,27 @@ export function DocumentView({
               <div className="flex items-center gap-2">
                 {config.stages
                   .filter((stage) => stage.enabled)
-                  .map((stage, stageIndex) => (
-                    <button
-                      key={stage.id}
-                      type="button"
-                      onClick={() => setTraceStageId(stage.id)}
-                      className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                      title={stage.name}
-                      aria-label={stage.name}
-                    >
-                      <CompactStatusIndicator
-                        status={currentChunk.stageResults[stage.id]?.status || 'idle'}
-                        icon={Languages}
-                      />
-                    </button>
-                  ))}
+                  .map((stage) => {
+                    const stageIcon: LucideIcon =
+                      stage.role === 'refine' ? Pencil
+                      : stage.role === 'format' ? FileText
+                      : Languages;
+                    return (
+                      <button
+                        key={stage.id}
+                        type="button"
+                        onClick={() => setTraceStageId(stage.id)}
+                        className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                        title={stage.name}
+                        aria-label={stage.name}
+                      >
+                        <CompactStatusIndicator
+                          status={currentChunk.stageResults[stage.id]?.status || 'idle'}
+                          icon={stageIcon}
+                        />
+                      </button>
+                    );
+                  })}
                 <button
                   type="button"
                   className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -1,11 +1,12 @@
-import { ArrowRightLeft, Play, Languages, Cpu, FileText, Pencil, Scale, RefreshCw, Loader2, X, ShieldCheck, AlertTriangle, RotateCcw, Wand2, BookmarkPlus, BookOpen, Check, Trash2, Bot, Settings, Globe, WifiOff } from 'lucide-react';
+import { ArrowRightLeft, Play, Languages, FileText, Pencil, Scale, RefreshCw, Loader2, X, RotateCcw, Wand2, BookmarkPlus, BookOpen, Check, Trash2, Bot, Settings, Globe, ShieldCheck, Cpu, AlertTriangle } from 'lucide-react';
 import { useMemo, useState, useEffect, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import type { ModelProvider, PromptTemplate } from '../../types';
+import type { ModelProvider, PipelineMode, PromptTemplate } from '../../types';
 import { MODEL_OPTIONS, LANGUAGES, defaultPersonaText } from '../../constants';
 import { getModelStatus, calculateBlobBudget, getContextWindow } from '../../models/catalog';
 import { usePipelineStore } from '../../stores/pipelineStore';
+import { StageCard } from './StageCard';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
@@ -494,16 +495,17 @@ export function PipelineConfig({
   const {
     config,
     setConfig,
-    removeStage,
+    setMode,
     updateStage,
   } = usePipelineStore();
   const { chunks, isProcessing, cancelRequested, resetCompletedChunks } = useChunksStore();
   const ollamaStatus = useUiStore((s) => s.ollamaStatus);
+  const ollamaModels = useUiStore((s) => s.ollamaModels);
   const { t } = useTranslation();
   const judgeModels = useJudgeModelOptions(config.judgeProvider);
   const [isRefreshingOllama, setIsRefreshingOllama] = useState(false);
   const [isRefiningPersona, setIsRefiningPersona] = useState(false);
-  const [isRefiningStage, setIsRefiningStage] = useState(false);
+  const [refiningStageId, setRefiningStageId] = useState<string | null>(null);
   const [isRefiningJudge, setIsRefiningJudge] = useState(false);
   const [isRefiningCoherence, setIsRefiningCoherence] = useState(false);
   const [activeTab, setActiveTab] = useState<ConfigSection>(visibleSection ?? 'translation');
@@ -550,8 +552,6 @@ export function PipelineConfig({
   );
 
   const stage0 = config.stages[0];
-  const stageModels = useJudgeModelOptions(stage0?.provider ?? 'openai');
-  const stageOllamaOffline = stage0?.provider === 'ollama' && ollamaStatus === 'disconnected';
 
   const currentContextWindow = stage0
     ? getContextWindow(stage0.provider, stage0.model)
@@ -562,17 +562,6 @@ export function PipelineConfig({
     config.chunkedWithContextWindow !== undefined &&
     currentContextWindow !== undefined &&
     currentContextWindow !== config.chunkedWithContextWindow;
-
-  const handleStageProviderChange = (newProvider: ModelProvider) => {
-    if (!stage0) return;
-    const models = newProvider === 'ollama' ? useUiStore.getState().ollamaModels : MODEL_OPTIONS[newProvider];
-    updateStage(stage0.id, { provider: newProvider, model: models[0] || '' });
-    if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'unknown') {
-      toast.message(t('ollama.uncheckedHint'));
-    } else if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'disconnected') {
-      toast.warning(t('ollama.selectedButOffline'));
-    }
-  };
 
   const handleRefreshOllama = async () => {
     setIsRefreshingOllama(true);
@@ -590,17 +579,18 @@ export function PipelineConfig({
     }
   };
 
-  const handleRefineStagePrompt = async () => {
-    if (!stage0?.prompt.trim() || !stage0?.model.trim()) return;
-    setIsRefiningStage(true);
+  const handleRefineStagePrompt = async (stageId: string) => {
+    const stage = config.stages.find((s) => s.id === stageId);
+    if (!stage?.prompt.trim() || !stage?.model.trim()) return;
+    setRefiningStageId(stageId);
     try {
-      const refined = await llmService.refinePrompt(stage0.prompt, stage0.provider, stage0.model, 'stage');
-      updateStage(stage0.id, { prompt: refined });
+      const refined = await llmService.refinePrompt(stage.prompt, stage.provider, stage.model, 'stage');
+      updateStage(stageId, { prompt: refined });
       toast.success(t('pipeline.refined'));
     } catch (err: unknown) {
       toast.error(t('pipeline.refineFailed'), { description: err instanceof Error ? err.message : String(err) });
     } finally {
-      setIsRefiningStage(false);
+      setRefiningStageId(null);
     }
   };
 
@@ -909,109 +899,80 @@ export function PipelineConfig({
         )}
 
         {/* ── TRADUZIONE ── */}
-        {activeTab === 'translation' && stage0 && (
+        {activeTab === 'translation' && (
           <div
             id="pconfig-panel-translation"
             role="tabpanel"
             aria-labelledby="pconfig-tab-translation"
             className="space-y-6"
           >
-            {/* Model + options card */}
-            <div className="space-y-3 rounded-[20px] border border-editorial-border bg-editorial-bg/70 px-5 py-4">
-              <div className="flex items-center gap-1.5">
-                <Cpu size={11} className="text-editorial-accent shrink-0" />
-                <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
-                  {t('pipeline.stageModelLabel')}
-                </p>
-              </div>
+            {/* Mode selector */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                {t('pipeline.modeLabel')}
+              </p>
               <div className="flex gap-2">
-                <select
-                  value={stage0.provider}
-                  onChange={(e) => handleStageProviderChange(e.target.value as ModelProvider)}
-                  disabled={translationsExist || isProcessing}
-                  className="rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                  aria-label={t('models.provider')}
-                >
-                  {Object.keys(MODEL_OPTIONS).map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-                {stageModels.length > 0 ? (
-                  <select
-                    value={stage0.model}
-                    onChange={(e) => updateStage(stage0.id, { model: e.target.value })}
-                    disabled={translationsExist || isProcessing}
-                    className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label={t('pipeline.stageModelLabel')}
-                  >
-                    {stageModels.map((m) => (
-                      <option key={m} value={m}>
-                        {m}{getModelStatus(stage0.provider, m) === 'preview' ? ' (preview)' : ''}
-                      </option>
-                    ))}
-                  </select>
-                ) : stage0.provider === 'ollama' ? (
-                  <input
-                    value={stage0.model}
-                    onChange={(e) => updateStage(stage0.id, { model: e.target.value })}
-                    disabled={translationsExist || isProcessing}
-                    placeholder={t('ollama.modelPlaceholder')}
-                    className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label={t('pipeline.stageModelLabel')}
-                  />
-                ) : (
-                  <select
-                    value={stage0.model}
-                    onChange={(e) => updateStage(stage0.id, { model: e.target.value })}
-                    disabled={translationsExist || isProcessing}
-                    className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label={t('pipeline.stageModelLabel')}
-                  >
-                    {MODEL_OPTIONS[stage0.provider]?.map((m) => (
-                      <option key={m} value={m}>
-                        {m}{getModelStatus(stage0.provider, m) === 'preview' ? ' (preview)' : ''}
-                      </option>
-                    ))}
-                  </select>
-                )}
-              </div>
-              {translationsExist && (
-                <div className="flex items-center gap-2 text-xs text-editorial-muted">
-                  <AlertTriangle size={12} className="shrink-0" />
-                  <span>{t('pipeline.modelLockedHint')}</span>
-                </div>
-              )}
-              {contextWindowChanged && (
-                <div className="flex items-center gap-2 text-xs text-editorial-warning">
-                  <AlertTriangle size={12} className="shrink-0 text-editorial-warning" />
-                  <span>{t('pipeline.modelContextWindowChangedHint')}</span>
-                </div>
-              )}
-              {stageOllamaOffline && !translationsExist && (
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 text-xs text-editorial-accent">
-                    <WifiOff size={13} />
-                    <span>{t('ollama.selectedButOffline')}</span>
-                  </div>
+                {(['standard', 'editorial'] as PipelineMode[]).map((m) => (
                   <button
+                    key={m}
                     type="button"
-                    onClick={handleRefreshOllama}
-                    disabled={isRefreshingOllama}
-                    className="flex items-center gap-1.5 rounded-full border border-editorial-accent/60 px-3 py-1 text-xs text-editorial-accent transition-colors hover:bg-editorial-accent hover:text-white disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    onClick={() => setMode(m)}
+                    disabled={translationsExist || isProcessing}
+                    className={`rounded-full border px-4 py-1.5 text-xs font-bold uppercase tracking-widest transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${
+                      (config.mode ?? 'standard') === m
+                        ? 'border-editorial-ink bg-editorial-ink text-white'
+                        : 'border-editorial-border text-editorial-muted hover:border-editorial-accent/60 hover:text-editorial-accent'
+                    }`}
                   >
-                    {isRefreshingOllama ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-                    {t('ollama.loadModels')}
+                    {t(`pipeline.mode.${m}`)}
                   </button>
-                </div>
-              )}
-              <ProviderRuntimeEditor
-                provider={stage0.provider}
-                value={stage0.providerOptions}
-                onChange={(providerOptions) => updateStage(stage0.id, { providerOptions })}
-                title={t('pipeline.providerOptions.stageTitle')}
-                hint={t('pipeline.providerOptions.stageHint')}
-              />
+                ))}
+              </div>
+              <p className="text-[10px] text-editorial-muted/70">
+                {t(`pipeline.modeDesc.${config.mode ?? 'standard'}`)}
+              </p>
             </div>
+
+            {/* Context window warning */}
+            {contextWindowChanged && (
+              <div className="flex items-center gap-2 text-xs text-editorial-warning">
+                <ShieldCheck size={12} className="shrink-0 text-editorial-warning" />
+                <span>{t('pipeline.modelContextWindowChangedHint')}</span>
+              </div>
+            )}
+
+            {/* Stage cards — one per stage in the current mode */}
+            {config.stages.map((stage) => {
+              const stageModelOptions =
+                stage.provider === 'ollama'
+                  ? ollamaModels
+                  : (MODEL_OPTIONS[stage.provider] ?? []);
+              return (
+                <div key={stage.id} className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-ink font-bold">
+                      {t(`pipeline.stageRole.${stage.role ?? 'translation'}`)}
+                    </span>
+                    <span className="h-px flex-1 bg-editorial-border/60" aria-hidden="true" />
+                  </div>
+                  <StageCard
+                    stage={stage}
+                    templates={templates.filter((tmpl) => tmpl.context === 'stage')}
+                    isRefining={refiningStageId === stage.id}
+                    translationsExist={translationsExist}
+                    isProcessing={isProcessing}
+                    ollamaStatus={ollamaStatus}
+                    isRefreshingOllama={isRefreshingOllama}
+                    modelOptions={stageModelOptions}
+                    onUpdate={(updates) => updateStage(stage.id, updates)}
+                    onRefinePrompt={() => handleRefineStagePrompt(stage.id)}
+                    onRefreshOllama={handleRefreshOllama}
+                    saveTemplate={saveTemplate}
+                    deleteTemplate={deleteTemplate}
+                  />
+                </div>
+              );
+            })}
 
             {/* Context memory card */}
             {(() => {
@@ -1033,7 +994,7 @@ export function PipelineConfig({
                   >
                     <span className="space-y-0.5">
                       <span className="flex items-center gap-1.5">
-                        <Cpu size={11} className="text-editorial-accent shrink-0" />
+                        <FileText size={11} className="text-editorial-accent shrink-0" />
                         <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
                           {t('pipeline.blobContext')}
                         </span>
@@ -1107,29 +1068,6 @@ export function PipelineConfig({
                 </div>
               );
             })()}
-
-            {/* Translation instructions card */}
-            <AuditPromptEditor
-              label={t('pipeline.prompt')}
-              hint=""
-              value={stage0.prompt}
-              placeholder={t('pipeline.stagePromptPlaceholder')}
-              templates={templates.filter((tmpl) => tmpl.context === 'stage')}
-              isRefining={isRefiningStage}
-              onRefine={handleRefineStagePrompt}
-              onChange={(value) => updateStage(stage0.id, { prompt: value })}
-              onApplyTemplate={(tmpl) => updateStage(stage0.id, {
-                prompt: tmpl.prompt,
-                ...(tmpl.defaultModel ? { model: tmpl.defaultModel } : {}),
-                ...(tmpl.defaultProvider ? { provider: tmpl.defaultProvider as ModelProvider } : {}),
-              })}
-              saveTemplate={saveTemplate}
-              deleteTemplate={deleteTemplate}
-              defaultModel={stage0.model}
-              defaultProvider={stage0.provider}
-              icon={<FileText size={11} />}
-              context="stage"
-            />
           </div>
         )}
 

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, Play, Languages, FileText, Pencil, Scale, RefreshCw, Loader2, X, RotateCcw, Wand2, BookmarkPlus, BookOpen, Check, Trash2, Bot, Settings, Globe, ShieldCheck, Cpu, AlertTriangle } from 'lucide-react';
+import { ArrowRightLeft, Play, Languages, FileText, Layers, Pencil, Scale, RefreshCw, Loader2, X, RotateCcw, Wand2, BookmarkPlus, BookOpen, Check, Trash2, Bot, Settings, Globe, ShieldCheck, Cpu, AlertTriangle } from 'lucide-react';
 import { useMemo, useState, useEffect, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -237,7 +237,7 @@ function PersonaEditor({
         value={isCustom ? persona : defaultText}
         disabled={!isCustom}
         onChange={(e) => onChange(e.target.value.trim() ? e.target.value : undefined)}
-        rows={isCustom ? 4 : 2}
+        rows={isCustom ? 8 : 2}
         className={`w-full rounded-[14px] border px-3 py-2 text-xs font-mono outline-none leading-relaxed resize-y ${
           isCustom
             ? 'bg-editorial-textbox/40 border-editorial-border/60 focus-visible:ring-2 focus-visible:ring-editorial-accent'
@@ -553,15 +553,20 @@ export function PipelineConfig({
 
   const stage0 = config.stages[0];
 
-  const currentContextWindow = stage0
-    ? getContextWindow(stage0.provider, stage0.model)
-    : undefined;
+  // Min context window across all source-aware stages (translation + refine receive source text)
+  const minSourceAwareContextWindow = config.stages
+    .filter((s) => s.enabled && s.role !== 'format')
+    .reduce<number | undefined>((min, s) => {
+      const cw = getContextWindow(s.provider, s.model);
+      if (cw === undefined) return min;
+      return min === undefined ? cw : Math.min(min, cw);
+    }, undefined);
   const contextWindowChanged =
     !translationsExist &&
     chunks.length > 0 &&
     config.chunkedWithContextWindow !== undefined &&
-    currentContextWindow !== undefined &&
-    currentContextWindow !== config.chunkedWithContextWindow;
+    minSourceAwareContextWindow !== undefined &&
+    minSourceAwareContextWindow !== config.chunkedWithContextWindow;
 
   const handleRefreshOllama = async () => {
     setIsRefreshingOllama(true);
@@ -831,6 +836,85 @@ export function PipelineConfig({
         {/* ── SETTINGS ── */}
         {activeTab === 'settings' && (
           <div id="pconfig-panel-settings" role="tabpanel" aria-labelledby="pconfig-tab-settings" className="space-y-6">
+            {/* Mode selector */}
+            <div className="space-y-2">
+              <div className="flex items-center gap-1.5">
+                <Layers size={11} className="text-editorial-accent shrink-0" />
+                <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                  {t('pipeline.modeLabel')}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {([
+                  { mode: 'standard' as PipelineMode, Icon: Languages },
+                  { mode: 'editorial' as PipelineMode, Icon: Layers },
+                ]).map(({ mode: m, Icon }) => {
+                  const isActive = (config.mode ?? 'standard') === m;
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setMode(m)}
+                      disabled={translationsExist || isProcessing}
+                      title={t(`pipeline.mode.${m}`)}
+                      aria-label={t(`pipeline.mode.${m}`)}
+                      aria-pressed={isActive}
+                      className={`rounded-full border p-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${
+                        isActive
+                          ? 'border-editorial-accent bg-editorial-accent text-white'
+                          : 'border-editorial-border text-editorial-muted hover:border-editorial-accent/40 hover:text-editorial-accent'
+                      }`}
+                    >
+                      <Icon size={16} />
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="rounded-[14px] border border-editorial-border/40 bg-editorial-textbox/20 px-3 py-3 space-y-2.5">
+                {([
+                  {
+                    mode: 'standard' as PipelineMode,
+                    stages: [
+                      { role: 'translation', Icon: Languages, labelKey: 'pipeline.stageRole.translation' },
+                      { role: 'audit', Icon: ShieldCheck, labelKey: 'pipeline.tabAudit' },
+                    ],
+                  },
+                  {
+                    mode: 'editorial' as PipelineMode,
+                    stages: [
+                      { role: 'translation', Icon: Languages, labelKey: 'pipeline.stageRole.translation' },
+                      { role: 'refine', Icon: Wand2, labelKey: 'pipeline.stageRole.refine' },
+                      { role: 'format', Icon: FileText, labelKey: 'pipeline.stageRole.format' },
+                      { role: 'audit', Icon: ShieldCheck, labelKey: 'pipeline.tabAudit' },
+                    ],
+                  },
+                ]).map(({ mode: m, stages }) => {
+                  const isActive = (config.mode ?? 'standard') === m;
+                  return (
+                    <div key={m} className={`flex items-center gap-2.5 transition-opacity ${isActive ? '' : 'opacity-25'}`}>
+                      <span className={`shrink-0 w-[68px] text-[10px] font-bold uppercase tracking-widest ${isActive ? 'text-editorial-accent' : 'text-editorial-muted'}`}>
+                        {t(`pipeline.mode.${m}`)}
+                      </span>
+                      <div className="flex items-center gap-1.5">
+                        {stages.map(({ role, Icon, labelKey }, i) => (
+                          <span key={role} className="flex items-center gap-1.5">
+                            {i > 0 && <span className="text-editorial-muted/40 text-xs">›</span>}
+                            <span
+                              title={t(labelKey)}
+                              aria-label={t(labelKey)}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border transition-colors border-editorial-border bg-editorial-bg text-editorial-muted"
+                            >
+                              <Icon size={14} strokeWidth={1.9} />
+                            </span>
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
             <div className="space-y-2">
               <div className="flex items-center gap-1.5">
                 <Globe size={11} className="text-editorial-accent shrink-0" />
@@ -895,6 +979,7 @@ export function PipelineConfig({
               onSaveTemplate={(name, prompt) => saveTemplate(name, prompt, 'persona')}
               deleteTemplate={deleteTemplate}
             />
+
           </div>
         )}
 
@@ -906,74 +991,6 @@ export function PipelineConfig({
             aria-labelledby="pconfig-tab-translation"
             className="space-y-6"
           >
-            {/* Mode selector */}
-            <div className="space-y-2">
-              <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
-                {t('pipeline.modeLabel')}
-              </p>
-              <div className="flex gap-2">
-                {(['standard', 'editorial'] as PipelineMode[]).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => setMode(m)}
-                    disabled={translationsExist || isProcessing}
-                    className={`rounded-full border px-4 py-1.5 text-xs font-bold uppercase tracking-widest transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${
-                      (config.mode ?? 'standard') === m
-                        ? 'border-editorial-ink bg-editorial-ink text-white'
-                        : 'border-editorial-border text-editorial-muted hover:border-editorial-accent/60 hover:text-editorial-accent'
-                    }`}
-                  >
-                    {t(`pipeline.mode.${m}`)}
-                  </button>
-                ))}
-              </div>
-              <p className="text-[10px] text-editorial-muted/70">
-                {t(`pipeline.modeDesc.${config.mode ?? 'standard'}`)}
-              </p>
-            </div>
-
-            {/* Context window warning */}
-            {contextWindowChanged && (
-              <div className="flex items-center gap-2 text-xs text-editorial-warning">
-                <ShieldCheck size={12} className="shrink-0 text-editorial-warning" />
-                <span>{t('pipeline.modelContextWindowChangedHint')}</span>
-              </div>
-            )}
-
-            {/* Stage cards — one per stage in the current mode */}
-            {config.stages.map((stage) => {
-              const stageModelOptions =
-                stage.provider === 'ollama'
-                  ? ollamaModels
-                  : (MODEL_OPTIONS[stage.provider] ?? []);
-              return (
-                <div key={stage.id} className="space-y-3">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-ink font-bold">
-                      {t(`pipeline.stageRole.${stage.role ?? 'translation'}`)}
-                    </span>
-                    <span className="h-px flex-1 bg-editorial-border/60" aria-hidden="true" />
-                  </div>
-                  <StageCard
-                    stage={stage}
-                    templates={templates.filter((tmpl) => tmpl.context === 'stage')}
-                    isRefining={refiningStageId === stage.id}
-                    translationsExist={translationsExist}
-                    isProcessing={isProcessing}
-                    ollamaStatus={ollamaStatus}
-                    isRefreshingOllama={isRefreshingOllama}
-                    modelOptions={stageModelOptions}
-                    onUpdate={(updates) => updateStage(stage.id, updates)}
-                    onRefinePrompt={() => handleRefineStagePrompt(stage.id)}
-                    onRefreshOllama={handleRefreshOllama}
-                    saveTemplate={saveTemplate}
-                    deleteTemplate={deleteTemplate}
-                  />
-                </div>
-              );
-            })}
-
             {/* Context memory card */}
             {(() => {
               const isOverride = (config.blobBudgetTokens ?? 0) > 0;
@@ -984,11 +1001,12 @@ export function PipelineConfig({
                     type="button"
                     role="switch"
                     aria-checked={isOverride}
+                    disabled={translationsExist}
                     onClick={() => setConfig((prev) => ({
                       ...prev,
                       blobBudgetTokens: isOverride ? 0 : auto.budget,
                     }))}
-                    className={`flex w-full items-center justify-between text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+                    className={`flex w-full items-center justify-between text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed ${
                       isOverride ? '' : 'opacity-80 hover:opacity-100'
                     }`}
                   >
@@ -1068,6 +1086,47 @@ export function PipelineConfig({
                 </div>
               );
             })()}
+
+            {/* Context window warning */}
+            {contextWindowChanged && (
+              <div className="flex items-center gap-2 text-xs text-editorial-warning">
+                <ShieldCheck size={12} className="shrink-0 text-editorial-warning" />
+                <span>{t('pipeline.modelContextWindowChangedHint')}</span>
+              </div>
+            )}
+
+            {/* Stage cards — one per stage in the current mode */}
+            {config.stages.map((stage) => {
+              const stageModelOptions =
+                stage.provider === 'ollama'
+                  ? ollamaModels
+                  : (MODEL_OPTIONS[stage.provider] ?? []);
+              return (
+                <div key={stage.id} className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-ink font-bold">
+                      {t(`pipeline.stageRole.${stage.role ?? 'translation'}`)}
+                    </span>
+                    <span className="h-px flex-1 bg-editorial-border/60" aria-hidden="true" />
+                  </div>
+                  <StageCard
+                    stage={stage}
+                    templates={templates.filter((tmpl) => tmpl.context === 'stage')}
+                    isRefining={refiningStageId === stage.id}
+                    translationsExist={translationsExist}
+                    isProcessing={isProcessing}
+                    ollamaStatus={ollamaStatus}
+                    isRefreshingOllama={isRefreshingOllama}
+                    modelOptions={stageModelOptions}
+                    onUpdate={(updates) => updateStage(stage.id, updates)}
+                    onRefinePrompt={() => handleRefineStagePrompt(stage.id)}
+                    onRefreshOllama={handleRefreshOllama}
+                    saveTemplate={saveTemplate}
+                    deleteTemplate={deleteTemplate}
+                  />
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/src/components/pipeline/ProductionStream.tsx
+++ b/src/components/pipeline/ProductionStream.tsx
@@ -144,15 +144,15 @@ const ChunkRow = memo(function ChunkRow({
           </span>
         </div>
         <div className="flex gap-4">
-          {enabledStages.map((s, si) => (
+          {enabledStages.map((s) => (
             <StatusIndicator
               key={s.id}
               status={chunk.stageResults[s.id]?.status || 'idle'}
-              label={indexPad(si + 1)}
+              label={t(`pipeline.stageRole.${s.role ?? 'translation'}`)}
               retryInfo={chunk.stageResults[s.id]?.retryInfo}
             />
           ))}
-          <StatusIndicator status={chunk.judgeResult.status} label="Audit" />
+          <StatusIndicator status={chunk.judgeResult.status} label={t('pipeline.tabAudit')} />
         </div>
       </div>
 

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -1,105 +1,89 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import {
   BookmarkPlus,
   BookOpen,
-  ChevronUp,
-  ChevronDown,
-  Loader2,
-  Trash2,
-  ShieldCheck,
-  AlertTriangle,
   Check,
-  X,
+  Cpu,
+  Loader2,
+  RefreshCw,
+  Trash2,
   Wand2,
+  WifiOff,
+  X,
+  AlertTriangle,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { PipelineStageConfig, ModelProvider } from '../../types';
+import type { ModelProvider, OllamaStatus, PipelineStageConfig, PromptTemplate } from '../../types';
 import { MODEL_OPTIONS } from '../../constants';
 import { getModelStatus } from '../../models/catalog';
-import { useUiStore } from '../../stores/uiStore';
-import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
-import { confirm } from '../../stores/confirmStore';
-import { llmService } from '../../services/llmService';
 import { ProviderRuntimeEditor } from './ProviderRuntimeEditor';
 
 interface StageCardProps {
   stage: PipelineStageConfig;
-  /** Reserved for future multi-stage UI — not rendered in MVP (single-stage). */
-  index: number;
+  templates: PromptTemplate[];
+  isRefining: boolean;
+  translationsExist: boolean;
+  isProcessing: boolean;
+  ollamaStatus: OllamaStatus;
+  isRefreshingOllama: boolean;
+  modelOptions: string[];
   onUpdate: (updates: Partial<PipelineStageConfig>) => void;
-  onRemove: () => void;
+  onRefinePrompt: () => void;
+  onRefreshOllama: () => void;
+  saveTemplate: (
+    name: string,
+    prompt: string,
+    context: 'stage' | 'audit',
+    defaultModel?: string,
+    defaultProvider?: string,
+  ) => Promise<void>;
+  deleteTemplate: (id: string) => Promise<void>;
 }
 
-function useModelOptions(provider: ModelProvider): string[] {
-  const ollamaModels = useUiStore((s) => s.ollamaModels);
-  if (provider === 'ollama') return ollamaModels;
-  return MODEL_OPTIONS[provider] || [];
-}
-
-export function StageCard({ stage, index: _index, onUpdate, onRemove }: StageCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+export function StageCard({
+  stage,
+  templates,
+  isRefining,
+  translationsExist,
+  isProcessing,
+  ollamaStatus,
+  isRefreshingOllama,
+  modelOptions,
+  onUpdate,
+  onRefinePrompt,
+  onRefreshOllama,
+  saveTemplate,
+  deleteTemplate,
+}: StageCardProps) {
+  const { t } = useTranslation();
   const [showSaveName, setShowSaveName] = useState(false);
   const [templateName, setTemplateName] = useState('');
   const [showTemplateList, setShowTemplateList] = useState(false);
   const [templateSearch, setTemplateSearch] = useState('');
-  const [isRefining, setIsRefining] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { t } = useTranslation();
-  const modelOptions = useModelOptions(stage.provider);
-  const ollamaStatus = useUiStore((s) => s.ollamaStatus);
-  const showOllamaOfflineWarning =
-    stage.provider === 'ollama' && ollamaStatus === 'disconnected';
 
-  const { templates, loadTemplates, saveTemplate, deleteTemplate } = usePromptTemplateStore();
+  const ollamaOffline = stage.provider === 'ollama' && ollamaStatus === 'disconnected';
 
-  useEffect(() => {
-    if (isExpanded) loadTemplates();
-  }, [isExpanded]);
-
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
-  }, [stage.prompt]);
+  const filteredTemplates = templates.filter((tmpl) =>
+    tmpl.name.toLowerCase().includes(templateSearch.toLowerCase()),
+  );
 
   const handleProviderChange = (newProvider: ModelProvider) => {
     const models =
-      newProvider === 'ollama'
-        ? useUiStore.getState().ollamaModels
-        : MODEL_OPTIONS[newProvider];
-    onUpdate({
-      provider: newProvider,
-      model: models[0] || '',
-    });
-    if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'unknown') {
-      toast.message(t('ollama.uncheckedHint'));
-    } else if (newProvider === 'ollama' && useUiStore.getState().ollamaStatus === 'disconnected') {
-      toast.warning(t('ollama.selectedButOffline'));
-    }
-  };
-
-  const handleRemove = async () => {
-    const ok = await confirm({
-      title: t('pipeline.confirmRemoveStageTitle'),
-      message: t('pipeline.confirmRemoveStageMessage', { name: stage.name }),
-      confirmLabel: t('common.delete'),
-      danger: true,
-    });
-    if (ok) onRemove();
+      newProvider === 'ollama' ? [] : (MODEL_OPTIONS[newProvider] ?? []);
+    onUpdate({ provider: newProvider, model: models[0] || '' });
   };
 
   const handleSaveTemplate = async () => {
     const name = templateName.trim();
     if (!name) return;
     try {
-      await saveTemplate(name, stage.prompt, 'stage');
+      await saveTemplate(name, stage.prompt, 'stage', stage.model, stage.provider);
       toast.success(t('pipeline.templates.saved'));
       setTemplateName('');
       setShowSaveName(false);
     } catch (err: unknown) {
-      toast.error(t('pipeline.templates.saved'), {
+      toast.error(t('errors.somethingWentWrong'), {
         description: err instanceof Error ? err.message : String(err),
       });
     }
@@ -116,267 +100,213 @@ export function StageCard({ stage, index: _index, onUpdate, onRemove }: StageCar
     }
   };
 
-  const handleRefinePrompt = async () => {
-    if (!stage.prompt.trim() || !stage.model.trim()) return;
-    setIsRefining(true);
-    try {
-      const refined = await llmService.refinePrompt(stage.prompt, stage.provider, stage.model, 'stage');
-      onUpdate({ prompt: refined });
-      toast.success(t('pipeline.refined'));
-    } catch (err: unknown) {
-      toast.error(t('pipeline.refineFailed'), {
-        description: err instanceof Error ? err.message : String(err),
-      });
-    } finally {
-      setIsRefining(false);
-    }
-  };
-
-  const stageTemplates = templates.filter((tmpl) => tmpl.context === 'stage');
-  const filteredTemplates = stageTemplates.filter((tmpl) =>
-    tmpl.name.toLowerCase().includes(templateSearch.toLowerCase()),
-  );
-
   return (
-    <div
-      className={`relative rounded-[20px] border border-editorial-border bg-editorial-bg p-7 transition-all ${
-        !stage.enabled ? 'grayscale opacity-40' : 'shadow-sm'
-      }`}
-    >
-      <div className="flex items-center justify-between mb-5">
-        <div className="flex items-center gap-3">
-          <input
-            value={stage.name}
-            onChange={(e) => onUpdate({ name: e.target.value })}
-            className="bg-transparent border-none p-0 font-display text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent w-36 border-b border-transparent focus:border-editorial-ink/20"
-            aria-label={t('pipeline.stageName')}
-          />
-        </div>
-        <div className="flex items-center gap-3">
-          <button
-            onClick={() => onUpdate({ enabled: !stage.enabled })}
-            title={stage.enabled ? t('pipeline.disableStage') : t('pipeline.enableStage')}
-            className="text-editorial-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            aria-label={stage.enabled ? t('pipeline.disableStage') : t('pipeline.enableStage')}
-            aria-pressed={stage.enabled}
-          >
-            {stage.enabled ? (
-              <ShieldCheck size={17} className="text-editorial-ink" />
-            ) : (
-              <div className="w-4 h-4 border-2 border-editorial-muted rounded-sm" />
-            )}
-          </button>
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            title={isExpanded ? t('pipeline.collapseStage') : t('pipeline.expandStage')}
-            className="text-editorial-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            aria-expanded={isExpanded}
-            aria-label={isExpanded ? t('pipeline.collapseStage') : t('pipeline.expandStage')}
-          >
-            {isExpanded ? <ChevronUp size={19} /> : <ChevronDown size={19} />}
-          </button>
-          <button
-            onClick={handleRemove}
-            title={t('pipeline.removeStage')}
-            className="text-editorial-muted hover:text-editorial-accent overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            aria-label={t('pipeline.removeStage')}
-          >
-            <Trash2 size={17} />
-          </button>
-        </div>
-      </div>
+    <div className="space-y-4">
+      {/* Role hint for non-translation stages */}
+      {(stage.role ?? 'translation') !== 'translation' && (
+        <p className="text-[10px] leading-relaxed text-editorial-muted/70">
+          {t(`pipeline.stageRoleHint.${stage.role ?? 'translation'}`)}
+        </p>
+      )}
 
-      {isExpanded && (
-        <div className="space-y-4 animate-in slide-in-from-top-1 duration-200">
-
-          <div className="flex gap-2">
+      {/* Model + provider card */}
+      <div className="space-y-3 rounded-[20px] border border-editorial-border bg-editorial-bg/70 px-5 py-4">
+        <div className="flex items-center gap-1.5">
+          <Cpu size={11} className="text-editorial-accent shrink-0" />
+          <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+            {t('pipeline.stageModelLabel')}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <select
+            value={stage.provider}
+            onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
+            disabled={translationsExist || isProcessing}
+            className="rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label={t('models.provider')}
+          >
+            {Object.keys(MODEL_OPTIONS).map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+          {modelOptions.length > 0 ? (
             <select
-              value={stage.provider}
-              onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
-              className="bg-editorial-textbox/60 rounded-[12px] border border-editorial-border/60 px-2 py-1 text-xs font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              value={stage.model}
+              onChange={(e) => onUpdate({ model: e.target.value })}
+              disabled={translationsExist || isProcessing}
+              className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label={t('pipeline.stageModelLabel')}
             >
-              {Object.keys(MODEL_OPTIONS).map((p) => (
-                <option key={p} value={p}>{p}</option>
+              {modelOptions.map((m) => (
+                <option key={m} value={m}>
+                  {m}{getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
+                </option>
               ))}
             </select>
-            {modelOptions.length > 0 ? (
-              <select
-                value={stage.model}
-                onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox/60 rounded-[12px] border border-editorial-border/60 px-2 py-1 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              >
-                {modelOptions.map((m) => (
-                  <option key={m} value={m}>
-                    {m}{getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
-                  </option>
-                ))}
-              </select>
-            ) : stage.provider === 'ollama' ? (
-              <input
-                value={stage.model}
-                onChange={(e) => onUpdate({ model: e.target.value })}
-                placeholder={t('ollama.modelPlaceholder')}
-                className="flex-1 bg-editorial-textbox/60 rounded-[12px] border border-editorial-border/60 px-2 py-1 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              />
-            ) : (
-              <select
-                value={stage.model}
-                onChange={(e) => onUpdate({ model: e.target.value })}
-                className="flex-1 bg-editorial-textbox/60 rounded-[12px] border border-editorial-border/60 px-2 py-1 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              >
-                {MODEL_OPTIONS[stage.provider]?.map((m) => (
-                  <option key={m} value={m}>
-                    {m}{getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
-                  </option>
-                ))}
-              </select>
-            )}
+          ) : (
+            <input
+              value={stage.model}
+              onChange={(e) => onUpdate({ model: e.target.value })}
+              disabled={translationsExist || isProcessing}
+              placeholder={t('ollama.modelPlaceholder')}
+              className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label={t('pipeline.stageModelLabel')}
+            />
+          )}
+        </div>
+        {translationsExist && (
+          <div className="flex items-center gap-2 text-xs text-editorial-muted">
+            <AlertTriangle size={12} className="shrink-0" />
+            <span>{t('pipeline.modelLockedHint')}</span>
           </div>
-
-          {showOllamaOfflineWarning && (
+        )}
+        {ollamaOffline && !translationsExist && (
+          <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 text-xs text-editorial-accent">
-              <AlertTriangle size={14} />
+              <WifiOff size={13} />
               <span>{t('ollama.selectedButOffline')}</span>
             </div>
-          )}
+            <button
+              type="button"
+              onClick={onRefreshOllama}
+              disabled={isRefreshingOllama}
+              className="flex items-center gap-1.5 rounded-full border border-editorial-accent/60 px-3 py-1 text-xs text-editorial-accent transition-colors hover:bg-editorial-accent hover:text-white disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            >
+              {isRefreshingOllama ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+              {t('ollama.loadModels')}
+            </button>
+          </div>
+        )}
+        <ProviderRuntimeEditor
+          provider={stage.provider}
+          value={stage.providerOptions}
+          onChange={(providerOptions) => onUpdate({ providerOptions })}
+          title={t('pipeline.providerOptions.stageTitle')}
+          hint={t('pipeline.providerOptions.stageHint')}
+        />
+      </div>
 
-          <ProviderRuntimeEditor
-            provider={stage.provider}
-            value={stage.providerOptions}
-            onChange={(providerOptions) => onUpdate({ providerOptions })}
-            title={t('pipeline.providerOptions.stageTitle')}
-            hint={t('pipeline.providerOptions.stageHint')}
-          />
-
-          {/* Prompt textarea with template controls */}
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
-                {t('pipeline.prompt')}
-              </span>
-              <div className="flex items-center gap-1.5">
-                {/* Refine prompt */}
-                <button
-                  type="button"
-                  onClick={handleRefinePrompt}
-                  disabled={isRefining || !stage.prompt.trim() || !stage.model.trim()}
-                  title={t('pipeline.refinePrompt')}
-                  aria-label={t('pipeline.refinePrompt')}
-                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
-                >
-                  {isRefining ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={16} />}
-                </button>
-                {/* Save as template */}
-                <button
-                  type="button"
-                  onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
-                  title={t('pipeline.templates.save')}
-                  aria-label={t('pipeline.templates.save')}
-                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                >
-                  <BookmarkPlus size={16} />
-                </button>
-                {/* Load template */}
-                <button
-                  type="button"
-                  onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
-                  title={t('pipeline.templates.load')}
-                  aria-label={t('pipeline.templates.load')}
-                  className="text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                >
-                  <BookOpen size={16} />
-                </button>
-              </div>
-            </div>
-
-            {/* Inline save name input */}
-            {showSaveName && (
-              <div className="flex items-center gap-1.5">
-                <input
-                  value={templateName}
-                  onChange={(e) => setTemplateName(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') handleSaveTemplate(); if (e.key === 'Escape') setShowSaveName(false); }}
-                  placeholder={t('pipeline.templates.namePlaceholder')}
-                  autoFocus
-                  className="flex-1 rounded bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                />
-                <button
-                  type="button"
-                  onClick={handleSaveTemplate}
-                  disabled={!templateName.trim()}
-                  className="text-editorial-ink hover:text-editorial-accent transition-colors disabled:opacity-40 focus:outline-none"
-                  aria-label={t('common.confirm')}
-                >
-                  <Check size={16} />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { setShowSaveName(false); setTemplateName(''); }}
-                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
-                  aria-label={t('common.cancel')}
-                >
-                  <X size={16} />
-                </button>
-              </div>
-            )}
-
-            {/* Template list popover */}
-            {showTemplateList && (
-              <div className="rounded-lg border border-editorial-border bg-editorial-bg shadow-lg overflow-hidden">
-                <div className="p-2 border-b border-editorial-border/60">
-                  <input
-                    value={templateSearch}
-                    onChange={(e) => setTemplateSearch(e.target.value)}
-                    placeholder={t('pipeline.templates.searchPlaceholder')}
-                    autoFocus
-                    className="w-full rounded bg-editorial-textbox/60 border border-editorial-border/40 px-2 py-1 text-sm font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                  />
-                </div>
-                <ul className="max-h-48 overflow-y-auto custom-scrollbar">
-                  {filteredTemplates.length === 0 ? (
-                    <li className="px-3 py-4 text-xs text-editorial-muted text-center">
-                      {t('pipeline.templates.empty')}
-                    </li>
-                  ) : (
-                    filteredTemplates.map((tmpl) => (
-                      <li
-                        key={tmpl.id}
-                        className="flex items-start gap-2 px-3 py-2 hover:bg-editorial-textbox/40 group"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => { onUpdate({ prompt: tmpl.prompt }); setShowTemplateList(false); setTemplateSearch(''); }}
-                          className="flex-1 text-left min-w-0 focus:outline-none"
-                        >
-                          <div className="text-sm font-bold text-editorial-ink truncate">{tmpl.name}</div>
-                          <div className="text-xs text-editorial-muted truncate mt-0.5 font-mono">{tmpl.prompt}</div>
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDeleteTemplate(tmpl.id)}
-                          className="shrink-0 text-editorial-muted/40 hover:text-editorial-accent transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none mt-0.5"
-                          aria-label={t('common.delete')}
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </li>
-                    ))
-                  )}
-                </ul>
-              </div>
-            )}
-
-            <textarea
-              ref={textareaRef}
-              value={stage.prompt}
-              onChange={(e) => onUpdate({ prompt: e.target.value })}
-              placeholder={t('pipeline.stagePromptPlaceholder')}
-              rows={8}
-              className="w-full rounded-[16px] bg-editorial-textbox/40 border border-editorial-border/60 p-4 text-sm font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            />
+      {/* Prompt editor */}
+      <div className="rounded-[20px] border border-editorial-border bg-editorial-bg/70 px-5 py-4 space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+            {t('pipeline.prompt')}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={onRefinePrompt}
+              disabled={isRefining || !stage.prompt.trim()}
+              title={t('pipeline.refinePrompt')}
+              aria-label={t('pipeline.refinePrompt')}
+              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
+            >
+              {isRefining ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
+              title={t('pipeline.templates.save')}
+              aria-label={t('pipeline.templates.save')}
+              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+            >
+              <BookmarkPlus size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
+              title={t('pipeline.templates.load')}
+              aria-label={t('pipeline.templates.load')}
+              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+            >
+              <BookOpen size={16} />
+            </button>
           </div>
         </div>
-      )}
+
+        {showSaveName && (
+          <div className="flex items-center gap-1.5">
+            <input
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSaveTemplate();
+                if (e.key === 'Escape') { setShowSaveName(false); setTemplateName(''); }
+              }}
+              placeholder={t('pipeline.templates.namePlaceholder')}
+              autoFocus
+              className="flex-1 rounded bg-editorial-textbox/60 border border-editorial-border/60 px-2 py-1 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            />
+            <button
+              type="button"
+              onClick={handleSaveTemplate}
+              disabled={!templateName.trim()}
+              className="text-editorial-ink hover:text-editorial-accent transition-colors disabled:opacity-40 focus:outline-none"
+              aria-label={t('common.confirm')}
+            >
+              <Check size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowSaveName(false); setTemplateName(''); }}
+              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
+              aria-label={t('common.cancel')}
+            >
+              <X size={16} />
+            </button>
+          </div>
+        )}
+
+        {showTemplateList && (
+          <div className="rounded-lg border border-editorial-border bg-editorial-bg shadow-lg overflow-hidden">
+            <div className="p-2 border-b border-editorial-border/60">
+              <input
+                value={templateSearch}
+                onChange={(e) => setTemplateSearch(e.target.value)}
+                placeholder={t('pipeline.templates.searchPlaceholder')}
+                autoFocus
+                className="w-full rounded bg-editorial-textbox/60 border border-editorial-border/40 px-2 py-1 text-sm font-mono outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+              />
+            </div>
+            <ul className="max-h-48 overflow-y-auto custom-scrollbar">
+              {filteredTemplates.length === 0 ? (
+                <li className="px-3 py-4 text-xs text-editorial-muted text-center">
+                  {t('pipeline.templates.empty')}
+                </li>
+              ) : (
+                filteredTemplates.map((tmpl) => (
+                  <li key={tmpl.id} className="flex items-start gap-2 px-3 py-2 hover:bg-editorial-textbox/40 group">
+                    <button
+                      type="button"
+                      onClick={() => { onUpdate({ prompt: tmpl.prompt }); setShowTemplateList(false); setTemplateSearch(''); }}
+                      className="flex-1 text-left min-w-0 focus:outline-none"
+                    >
+                      <div className="text-sm font-bold text-editorial-ink truncate">{tmpl.name}</div>
+                      <div className="text-xs text-editorial-muted truncate mt-0.5 font-mono">{tmpl.prompt}</div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTemplate(tmpl.id)}
+                      className="shrink-0 text-editorial-muted/40 hover:text-editorial-accent transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none mt-0.5"
+                      aria-label={t('common.delete')}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        )}
+
+        <textarea
+          value={stage.prompt}
+          onChange={(e) => onUpdate({ prompt: e.target.value })}
+          placeholder={t('pipeline.stagePromptPlaceholder')}
+          rows={8}
+          className="w-full rounded-[16px] bg-editorial-textbox/40 border border-editorial-border/60 p-4 text-sm font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Cpu,
   Loader2,
+  Pencil,
   RefreshCw,
   Trash2,
   Wand2,
@@ -57,10 +58,13 @@ export function StageCard({
   deleteTemplate,
 }: StageCardProps) {
   const { t } = useTranslation();
+  const [isEditingPrompt, setIsEditingPrompt] = useState(false);
   const [showSaveName, setShowSaveName] = useState(false);
   const [templateName, setTemplateName] = useState('');
   const [showTemplateList, setShowTemplateList] = useState(false);
   const [templateSearch, setTemplateSearch] = useState('');
+
+  const promptEditable = isEditingPrompt && !translationsExist && !isProcessing;
 
   const ollamaOffline = stage.provider === 'ollama' && ollamaStatus === 'disconnected';
 
@@ -70,7 +74,7 @@ export function StageCard({
 
   const handleProviderChange = (newProvider: ModelProvider) => {
     const models =
-      newProvider === 'ollama' ? [] : (MODEL_OPTIONS[newProvider] ?? []);
+      newProvider === 'ollama' ? modelOptions : (MODEL_OPTIONS[newProvider] ?? []);
     onUpdate({ provider: newProvider, model: models[0] || '' });
   };
 
@@ -193,38 +197,62 @@ export function StageCard({
             {t('pipeline.prompt')}
           </span>
           <div className="flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={onRefinePrompt}
-              disabled={isRefining || !stage.prompt.trim()}
-              title={t('pipeline.refinePrompt')}
-              aria-label={t('pipeline.refinePrompt')}
-              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
-            >
-              {isRefining ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
-            </button>
-            <button
-              type="button"
-              onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
-              title={t('pipeline.templates.save')}
-              aria-label={t('pipeline.templates.save')}
-              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-            >
-              <BookmarkPlus size={16} />
-            </button>
-            <button
-              type="button"
-              onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
-              title={t('pipeline.templates.load')}
-              aria-label={t('pipeline.templates.load')}
-              className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-            >
-              <BookOpen size={16} />
-            </button>
+            {isEditingPrompt ? (
+              <>
+                <button
+                  type="button"
+                  onClick={onRefinePrompt}
+                  disabled={isRefining || !stage.prompt.trim()}
+                  title={t('pipeline.refinePrompt')}
+                  aria-label={t('pipeline.refinePrompt')}
+                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
+                >
+                  {isRefining ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
+                  title={t('pipeline.templates.save')}
+                  aria-label={t('pipeline.templates.save')}
+                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                >
+                  <BookmarkPlus size={16} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
+                  title={t('pipeline.templates.load')}
+                  aria-label={t('pipeline.templates.load')}
+                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                >
+                  <BookOpen size={16} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setIsEditingPrompt(false); setShowSaveName(false); setShowTemplateList(false); }}
+                  title={t('common.close')}
+                  aria-label={t('common.close')}
+                  className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                >
+                  <X size={16} />
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsEditingPrompt(true)}
+                disabled={translationsExist || isProcessing}
+                title={t('pipeline.editPrompt')}
+                aria-label={t('pipeline.editPrompt')}
+                className="text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Pencil size={16} />
+              </button>
+            )}
           </div>
         </div>
 
-        {showSaveName && (
+        {isEditingPrompt && showSaveName && (
           <div className="flex items-center gap-1.5">
             <input
               value={templateName}
@@ -257,7 +285,7 @@ export function StageCard({
           </div>
         )}
 
-        {showTemplateList && (
+        {isEditingPrompt && showTemplateList && (
           <div className="rounded-lg border border-editorial-border bg-editorial-bg shadow-lg overflow-hidden">
             <div className="p-2 border-b border-editorial-border/60">
               <input
@@ -278,7 +306,15 @@ export function StageCard({
                   <li key={tmpl.id} className="flex items-start gap-2 px-3 py-2 hover:bg-editorial-textbox/40 group">
                     <button
                       type="button"
-                      onClick={() => { onUpdate({ prompt: tmpl.prompt }); setShowTemplateList(false); setTemplateSearch(''); }}
+                      onClick={() => {
+                          onUpdate({
+                            prompt: tmpl.prompt,
+                            ...(tmpl.defaultModel ? { model: tmpl.defaultModel } : {}),
+                            ...(tmpl.defaultProvider ? { provider: tmpl.defaultProvider as ModelProvider } : {}),
+                          });
+                          setShowTemplateList(false);
+                          setTemplateSearch('');
+                        }}
                       className="flex-1 text-left min-w-0 focus:outline-none"
                     >
                       <div className="text-sm font-bold text-editorial-ink truncate">{tmpl.name}</div>
@@ -303,8 +339,13 @@ export function StageCard({
           value={stage.prompt}
           onChange={(e) => onUpdate({ prompt: e.target.value })}
           placeholder={t('pipeline.stagePromptPlaceholder')}
+          disabled={!promptEditable}
           rows={8}
-          className="w-full rounded-[16px] bg-editorial-textbox/40 border border-editorial-border/60 p-4 text-sm font-mono outline-none leading-relaxed resize-y focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          className={`w-full rounded-[16px] border p-4 text-sm font-mono outline-none leading-relaxed resize-y ${
+            promptEditable
+              ? 'bg-editorial-textbox/40 border-editorial-border/60 focus-visible:ring-2 focus-visible:ring-editorial-accent'
+              : 'bg-editorial-textbox/10 border-editorial-border/30 text-editorial-muted/60 cursor-default'
+          }`}
         />
       </div>
     </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,9 @@ import { MODEL_CATALOG } from './models/catalog';
 
 export const DEFAULT_STAGES: PipelineStageConfig[] = [
   {
-    id: 'stg-draft',
+    id: 'stg-translation',
     name: 'Translation',
+    role: 'translation',
     prompt: 'Translate the text accurately.',
     model: 'gpt-4o-mini',
     provider: 'openai',

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -215,9 +215,12 @@ export function usePipeline() {
       if (!stage.enabled) continue;
 
       // Override global language pair with stage-specific one if set, but not when persona is active.
-      // Also inject blob context (original texts of sibling chunks in the same blob).
+      // Format stage is blind: no source blob context (it must not see the original text).
+      // Other stages use source blob context for translation continuity.
       const liveChunks = useChunksStore.getState().chunks;
-      const blobContext = assembleBlobContext(liveChunks, chunk.id);
+      const stageRole = stage.role ?? 'translation';
+      const isFormatStage = stageRole === 'format';
+      const blobContext = isFormatStage ? undefined : assembleBlobContext(liveChunks, chunk.id);
       const effectiveConfig = {
         ...config,
         ...(!config.persona && stage.sourceLanguage ? { sourceLanguage: stage.sourceLanguage } : {}),
@@ -255,6 +258,12 @@ export function usePipeline() {
         stageId: stage.id,
       });
 
+      // Format stage is blind: receives the previous stage output as primary text,
+      // with no access to the source. Translation and refine stages receive the source
+      // text plus the previous stage output for comparison.
+      const stageText = isFormatStage ? lastResult : chunk.sourceProcessingText;
+      const stagePrevious = isFormatStage ? undefined : (lastResult || undefined);
+
       try {
         let capturedUsage: TokenUsage | undefined;
         const stageResult = await withRetry(
@@ -263,7 +272,7 @@ export function usePipeline() {
             updateChunkStage(chunk.id, stage.id, { content: '', status: 'processing' });
             if (stage.provider === 'ollama') {
               const text = await llmService.runStageStream(
-                chunk.sourceProcessingText, stage, effectiveConfig, lastResult || undefined,
+                stageText, stage, effectiveConfig, stagePrevious,
                 (token) => appendChunkStageContent(chunk.id, stage.id, token),
                 (usage) => { capturedUsage = usage; },
                 onPrompt,
@@ -272,7 +281,7 @@ export function usePipeline() {
               return { content: text };
             }
             return llmService.runStage(
-              chunk.sourceProcessingText, stage, effectiveConfig, lastResult || undefined,
+              stageText, stage, effectiveConfig, stagePrevious,
               onPrompt,
               onIdleGrace,
             );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -211,6 +211,7 @@
       "saved": "Template saved",
       "deleted": "Template deleted"
     },
+    "editPrompt": "Edit prompt",
     "refinePrompt": "Refine prompt",
     "refining": "Refining...",
     "refined": "Prompt refined",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,6 +34,24 @@
     "swapLanguages": "Swap Languages",
     "autoSegment": "Auto-segment",
     "headingAware": "Heading-aware (Markdown)",
+    "modeLabel": "Translation mode",
+    "mode": {
+      "standard": "Standard",
+      "editorial": "Editorial"
+    },
+    "modeDesc": {
+      "standard": "One translation stage + quality audit.",
+      "editorial": "Three stages: translation → refine → format, then quality audit."
+    },
+    "stageRole": {
+      "translation": "Translation",
+      "refine": "Refine",
+      "format": "Format"
+    },
+    "stageRoleHint": {
+      "refine": "Reviews and improves the translation by comparing it against the original source.",
+      "format": "Applies formatting corrections without seeing the source text (blind stage). Cannot retranslate."
+    },
     "blobContext": "Context memory",
     "blobContextAutoDesc": "Automatic — ~{{tokens}} tokens based on {{model}}",
     "blobBudgetTokens": "Token budget",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -34,6 +34,24 @@
     "swapLanguages": "Inverti Lingue",
     "autoSegment": "Auto-segmentazione",
     "headingAware": "Titoli nel chunk successivo (Markdown)",
+    "modeLabel": "Modalità di traduzione",
+    "mode": {
+      "standard": "Standard",
+      "editorial": "Editoriale"
+    },
+    "modeDesc": {
+      "standard": "Uno stage di traduzione + audit qualità.",
+      "editorial": "Tre stage: traduzione → refine → format, poi audit qualità."
+    },
+    "stageRole": {
+      "translation": "Traduzione",
+      "refine": "Refine",
+      "format": "Format"
+    },
+    "stageRoleHint": {
+      "refine": "Rivede e migliora la traduzione confrontandola con il testo originale.",
+      "format": "Applica correzioni di formattazione senza vedere il testo sorgente (stage cieco). Non può ritradurre."
+    },
     "blobContext": "Memoria di contesto",
     "blobContextAutoDesc": "Automatica — ~{{tokens}} token basati su {{model}}",
     "blobBudgetTokens": "Budget token",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -211,6 +211,7 @@
       "saved": "Template salvato",
       "deleted": "Template eliminato"
     },
+    "editPrompt": "Modifica prompt",
     "refinePrompt": "Rifinisci prompt",
     "refining": "Rifinendo...",
     "refined": "Prompt rifinito",

--- a/src/pipeline/pipelineModes.ts
+++ b/src/pipeline/pipelineModes.ts
@@ -1,0 +1,61 @@
+import type { PipelineMode, PipelineStageConfig, StageRole } from '../types';
+
+interface StageTemplate {
+  id: string;
+  role: StageRole;
+  name: string;
+  defaultPrompt: string;
+}
+
+const STAGE_TEMPLATES: Record<StageRole, StageTemplate> = {
+  translation: {
+    id: 'stg-translation',
+    role: 'translation',
+    name: 'Translation',
+    defaultPrompt: 'Translate the text accurately.',
+  },
+  refine: {
+    id: 'stg-refine',
+    role: 'refine',
+    name: 'Refine',
+    defaultPrompt:
+      'Review the translation against the original. Correct inaccuracies, improve fluency, and ensure the tone matches the original intent.',
+  },
+  format: {
+    id: 'stg-format',
+    role: 'format',
+    name: 'Format',
+    defaultPrompt:
+      'Fix markdown structure, footnotes, and formatting. Do not alter the meaning or wording of the translation. Output only the formatted text.',
+  },
+};
+
+const MODE_SEQUENCES: Record<PipelineMode, StageRole[]> = {
+  standard: ['translation'],
+  editorial: ['translation', 'refine', 'format'],
+};
+
+function buildStage(template: StageTemplate, existing?: PipelineStageConfig): PipelineStageConfig {
+  return {
+    id: template.id,
+    name: template.name,
+    role: template.role,
+    prompt: existing?.prompt ?? template.defaultPrompt,
+    model: existing?.model ?? 'gpt-4o-mini',
+    provider: existing?.provider ?? 'openai',
+    enabled: existing?.enabled ?? true,
+    providerOptions: existing?.providerOptions,
+  };
+}
+
+/**
+ * Build the stages array for a given mode, preserving existing stage config
+ * (prompt, model, provider, options) where the role matches.
+ */
+export function buildStagesForMode(
+  mode: PipelineMode,
+  currentStages: PipelineStageConfig[],
+): PipelineStageConfig[] {
+  const byRole = new Map(currentStages.map((s) => [s.role ?? 'translation', s]));
+  return MODE_SEQUENCES[mode].map((role) => buildStage(STAGE_TEMPLATES[role], byRole.get(role)));
+}

--- a/src/pipeline/pipelineModes.ts
+++ b/src/pipeline/pipelineModes.ts
@@ -43,7 +43,7 @@ function buildStage(template: StageTemplate, existing?: PipelineStageConfig): Pi
     prompt: existing?.prompt ?? template.defaultPrompt,
     model: existing?.model ?? 'gpt-4o-mini',
     provider: existing?.provider ?? 'openai',
-    enabled: existing?.enabled ?? true,
+    enabled: true,
     providerOptions: existing?.providerOptions,
   };
 }
@@ -56,6 +56,10 @@ export function buildStagesForMode(
   mode: PipelineMode,
   currentStages: PipelineStageConfig[],
 ): PipelineStageConfig[] {
-  const byRole = new Map(currentStages.map((s) => [s.role ?? 'translation', s]));
+  const byRole = new Map<string, PipelineStageConfig>();
+  for (const s of currentStages) {
+    const role = s.role ?? 'translation';
+    if (!byRole.has(role)) byRole.set(role, s);
+  }
   return MODE_SEQUENCES[mode].map((role) => buildStage(STAGE_TEMPLATES[role], byRole.get(role)));
 }

--- a/src/stores/pipelineStore.ts
+++ b/src/stores/pipelineStore.ts
@@ -1,10 +1,12 @@
 import { create } from 'zustand';
 import type {
   PipelineConfig,
+  PipelineMode,
   PipelineStageConfig,
   ModelProvider,
 } from '../types';
 import { DEFAULT_STAGES, DEFAULT_JUDGE_PROMPT, DEFAULT_COHERENCE_PROMPT } from '../constants';
+import { buildStagesForMode } from '../pipeline/pipelineModes';
 import { getGlossaryEntries } from '../services/glossaryService';
 import type { FootnoteDefinition } from '../types';
 import { deriveSourceDocumentState } from '../utils/documentState';
@@ -23,6 +25,7 @@ interface PipelineState {
     renderProfile?: PipelineConfig['renderProfile'];
   }) => void;
   setConfig: (updater: PipelineConfig | ((prev: PipelineConfig) => PipelineConfig)) => void;
+  setMode: (mode: PipelineMode) => void;
   assignGlossary: (glossaryId: string | null) => Promise<void>;
   resetToDefaults: () => void;
 
@@ -34,6 +37,7 @@ interface PipelineState {
 const DEFAULT_PIPELINE_CONFIG: PipelineConfig = {
   sourceLanguage: 'English',
   targetLanguage: 'Italian',
+  mode: 'standard',
   stages: DEFAULT_STAGES,
   judgePrompt: DEFAULT_JUDGE_PROMPT,
   judgeModel: 'gpt-4o-mini',
@@ -95,6 +99,15 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       };
     }),
 
+  setMode: (mode) =>
+    set((state) => ({
+      config: {
+        ...state.config,
+        mode,
+        stages: buildStagesForMode(mode, state.config.stages),
+      },
+    })),
+
   resetToDefaults: () =>
     set({
       inputText: '',
@@ -125,6 +138,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
           {
             id: `stg-${Date.now()}`,
             name: 'New Stage',
+            role: 'translation' as const,
             prompt: '',
             model: 'gpt-4o-mini',
             provider: 'openai' as ModelProvider,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type DocumentFormat = 'plain' | 'markdown';
 export type DocumentRenderProfile = 'plain-text' | 'markdown';
 export type ExperimentalImportMode = 'docx-markdown';
 export type OllamaThinkLevel = boolean | 'low' | 'medium' | 'high';
+export type StageRole = 'translation' | 'refine' | 'format';
+export type PipelineMode = 'standard' | 'editorial';
 
 export interface OllamaConfig {
   temperature?: number;
@@ -57,6 +59,7 @@ export interface Glossary {
 export interface PipelineStageConfig {
   id: string;
   name: string;
+  role?: StageRole;
   prompt: string;
   model: string;
   provider: ModelProvider;
@@ -151,6 +154,7 @@ export interface CoherenceResult {
 export interface PipelineConfig {
   sourceLanguage: string;
   targetLanguage: string;
+  mode?: PipelineMode;
   stages: PipelineStageConfig[];
   judgePrompt: string;
   judgeModel: string;


### PR DESCRIPTION
## Summary

- Introduces fixed **pipeline modes** replacing the free-form stage list
- **Standard**: `[translation]` + audit
- **Editorial**: `[translation → refine → format]` + audit
- Each stage role has strict input semantics enforced by the executor:
  - `translation`: source text only
  - `refine`: source text + previous output (comparison against original)
  - `format`: **blind** — previous output only, no source text, no source blob context
- Rust prompt builder uses role-aware user message framing for format stages
- Mode switch preserves existing stage config (prompt, model, provider) where role matches
- Stage outputs saved per-stable-ID → future translation↔refine diff requires no further store changes

## New file

`src/pipeline/pipelineModes.ts` — pure router, defines role sequences per mode

## Test plan

- [ ] All 263 existing tests pass (`npm test`)
- [ ] TypeScript clean (`npm run lint`)
- [ ] Rust compiles (`cargo check`)
- [ ] Standard mode shows 1 stage card (Translation) in UI
- [ ] Switching to Editorial adds Refine and Format cards, preserving Translation config
- [ ] Switching back to Standard drops Refine/Format, keeps Translation config
- [ ] Format stage card shows blind-stage hint text
- [ ] Running pipeline in editorial mode: translation output feeds refine, refine output feeds format
- [ ] Format stage log shows "Text to format" framing in prompt debug

Closes #148