### PR TITLE
chore: shared HTTP client pools + tracing (#107, closes #106)

### DIFF
--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -91,6 +91,7 @@ pub async fn run_stage(
         return Err(STREAM_CANCELLED_ERROR.to_string());
     }
 
+    log::info!("LLM call starting provider={} model={}", stage.provider, stage.model);
     // Non-streaming providers still run over HTTP. Race the request against
     // the shared cancel token so "Stop" drops the in-flight request here too.
     let response = tokio::select! {
@@ -164,6 +165,7 @@ pub async fn run_stage_stream(
         return Err(STREAM_CANCELLED_ERROR.to_string());
     }
 
+    log::info!("LLM stream starting provider={} model={}", stage.provider, stage.model);
     let resp = provider.build_streaming_request(&client, &req).await?;
     let status = resp.status();
     if !status.is_success() {

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -91,7 +91,10 @@ pub async fn run_stage(
         return Err(STREAM_CANCELLED_ERROR.to_string());
     }
 
-    log::info!("LLM call starting provider={} model={}", stage.provider, stage.model);
+    log::info!(
+        "LLM call starting provider={} model={} stage={} stream_id={}",
+        stage.provider, stage.model, stage.name, stream_id
+    );
     // Non-streaming providers still run over HTTP. Race the request against
     // the shared cancel token so "Stop" drops the in-flight request here too.
     let response = tokio::select! {
@@ -101,16 +104,18 @@ pub async fn run_stage(
         }
         result = provider.call(&client, &req) => result?,
     };
-    if let Some(usage) = response.usage.as_ref() {
-        log::info!(
-            "LLM call completed provider={} model={} input_tokens={} output_tokens={} cached_input_tokens={} cache_miss_input_tokens={}",
-            stage.provider,
-            stage.model,
-            usage.input,
-            usage.output,
+    match response.usage.as_ref() {
+        Some(usage) => log::info!(
+            "LLM call completed provider={} model={} stage={} stream_id={} input_tokens={} output_tokens={} cached_input_tokens={} cache_miss_input_tokens={}",
+            stage.provider, stage.model, stage.name, stream_id,
+            usage.input, usage.output,
             usage.cached_input.unwrap_or(0),
             usage.cache_miss_input.unwrap_or(0),
-        );
+        ),
+        None => log::info!(
+            "LLM call completed provider={} model={} stage={} stream_id={} (no usage data)",
+            stage.provider, stage.model, stage.name, stream_id
+        ),
     }
     Ok(StageResult {
         content: response.content,
@@ -165,7 +170,10 @@ pub async fn run_stage_stream(
         return Err(STREAM_CANCELLED_ERROR.to_string());
     }
 
-    log::info!("LLM stream starting provider={} model={}", stage.provider, stage.model);
+    log::info!(
+        "LLM stream starting provider={} model={} stage={} stream_id={}",
+        stage.provider, stage.model, stage.name, stream_id
+    );
     let resp = provider.build_streaming_request(&client, &req).await?;
     let status = resp.status();
     if !status.is_success() {

--- a/src-tauri/src/llm/provider.rs
+++ b/src-tauri/src/llm/provider.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use reqwest::Client;
-use std::time::Duration;
 
-use crate::llm::stream::{StreamTimeouts, HTTP_CONNECT_TIMEOUT_SECS};
+use crate::llm::stream::{build_default_streaming_http_client, StreamTimeouts};
 use crate::llm::types::{ProviderRuntimeConfig, StructuredPrompt};
 
 #[derive(Debug, Clone)]
@@ -84,14 +83,11 @@ pub trait LlmProvider: Send + Sync {
 
     /// Build the HTTP client for streaming requests.
     ///
-    /// Default omits the global request timeout — streaming sessions are long-lived
-    /// and rely on `StreamTimeouts` (idle + total) instead. Providers that use a
-    /// shared static client (Ollama) override this.
+    /// Default returns the shared cloud streaming pool (connect-timeout only;
+    /// per-stream idle/total timeouts are enforced in `stream_response`).
+    /// Ollama overrides this with its own shared pool and wider timeouts.
     fn streaming_client(&self) -> Result<Client, String> {
-        Client::builder()
-            .connect_timeout(Duration::from_secs(HTTP_CONNECT_TIMEOUT_SECS))
-            .build()
-            .map_err(|e| format!("Failed to build streaming HTTP client: {e}"))
+        build_default_streaming_http_client()
     }
 
     /// Format a non-2xx HTTP response into a user-facing error message.

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -65,7 +65,11 @@ pub(crate) fn build_http_client_with_timeout(timeout_secs: u64) -> Result<Client
 }
 
 pub(crate) fn build_default_http_client() -> Result<Client, String> {
-    build_http_client_with_timeout(HTTP_REQUEST_TIMEOUT_SECS)
+    shared_cloud_http_client()
+}
+
+pub(crate) fn build_default_streaming_http_client() -> Result<Client, String> {
+    shared_cloud_streaming_client()
 }
 
 // ── Stream cancellation registry ─────────────────────────────────────
@@ -571,6 +575,43 @@ pub(crate) fn provider_label(provider: &str) -> &'static str {
 }
 
 // ── Lazy HTTP client singletons (shared with providers) ───────────────
+//
+// One connection pool per (timeout profile, streaming/non-streaming) pair.
+// reqwest::Client is Arc-backed: cloning is cheap and all clones share the
+// same underlying pool, so TLS sessions are reused across pipeline commands.
 
+pub(crate) static CLOUD_HTTP_CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
+pub(crate) static CLOUD_STREAMING_HTTP_CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
 pub(crate) static OLLAMA_HTTP_CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
 pub(crate) static OLLAMA_STREAMING_HTTP_CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
+
+/// Returns the shared cloud HTTP client (120 s request timeout).
+/// Initialises the pool on first call; subsequent calls are a cheap clone.
+pub(crate) fn shared_cloud_http_client() -> Result<Client, String> {
+    CLOUD_HTTP_CLIENT
+        .get_or_init(|| {
+            let result = build_http_client_with_timeout(HTTP_REQUEST_TIMEOUT_SECS);
+            if result.is_ok() {
+                log::info!("Shared cloud HTTP client pool initialised");
+            }
+            result
+        })
+        .clone()
+}
+
+/// Returns the shared cloud streaming client (connect-timeout only;
+/// per-stream idle/total timeouts are handled separately in `stream_response`).
+pub(crate) fn shared_cloud_streaming_client() -> Result<Client, String> {
+    CLOUD_STREAMING_HTTP_CLIENT
+        .get_or_init(|| {
+            let result = Client::builder()
+                .connect_timeout(Duration::from_secs(HTTP_CONNECT_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| format!("Failed to build cloud streaming HTTP client: {e}"));
+            if result.is_ok() {
+                log::info!("Shared cloud streaming HTTP client pool initialised");
+            }
+            result
+        })
+        .clone()
+}


### PR DESCRIPTION
## Summary

- **Client pool condiviso per provider cloud**: ogni chiamata LLM creava un `reqwest::Client` fresco, bypassando il connection pool e forzando un nuovo handshake TLS per ogni chunk su run lunghe. Ora `CLOUD_HTTP_CLIENT` e `CLOUD_STREAMING_HTTP_CLIENT` sono `OnceLock` inizializzati al primo uso e condivisi tra tutte le invocazioni. Ollama aveva già i suoi (invariati).
- **Tracing strutturato sulle hot path**: aggiunto `log::info!` all'avvio di ogni chiamata LLM (non-streaming e streaming), complementare al log di completamento già esistente. Utile per diagnosticare timeout e latenze sui log.
- **#106 chiuso**: i warning Linux DRI3/dconf sono environment-related e coperti dalla mitigazione `WEBKIT_DISABLE_DMABUF_RENDERER=1` già presente in `package.json`. Nessun fix product-level necessario.

## Test plan

- [ ] `cargo clippy` — zero warning ✅
- [ ] `cargo test` — 100 test verdi ✅
- [ ] Run manuale con documenti lunghi: verificare nei log che "Shared cloud HTTP client pool initialised" appare una sola volta (non per ogni chunk)
- [ ] Verificare che "LLM call starting" e "LLM call completed" appaiano in coppia nel log per ogni stage