### PR TITLE
feat(phrase-memory): Piano 2 — embedding search + workspace shell gating

### DIFF
--- a/docs/superpowers/plans/2026-06-02-phrase-memory-plan-3-ui-injection.md
+++ b/docs/superpowers/plans/2026-06-02-phrase-memory-plan-3-ui-injection.md
@@ -10,6 +10,10 @@
 > git checkout -b feat/phrase-memory-plan-3
 > ```
 
+> **Nota Piano 2 — Shell gating già implementata:**
+> `App.tsx` ha 3 stati: nessun workspace → `WorkspaceWizard`, workspace senza progetto → `WorkspaceHome`, progetto aperto → editor.
+> Il `MemoryTab` vive nello stato 3 (editor con progetto aperto). Non esiste più un workspace ghost `ws_default`.
+
 ---
 
 **Goal:** Implementare il layer UI completo della feature Phrase Memory: tab "Memoria" nel chunk panel, badge match nella lista chunk, iniezione delle coppie selezionate nel prompt al momento del re-run, e dialog "Estrai termine" per creare voci di glossario a partire da un match.

--- a/docs/superpowers/plans/2026-06-02-phrase-memory-plan-4-preset-ui.md
+++ b/docs/superpowers/plans/2026-06-02-phrase-memory-plan-4-preset-ui.md
@@ -10,6 +10,9 @@
 > git checkout -b feat/phrase-memory-plan-4
 > ```
 
+> **Nota Piano 2 — Shell gating già implementata:**
+> La gestione preset avviene dall'editor (progetto aperto) o dalla `WorkspaceHome`. Non esiste più un workspace ghost. Piano 4 deve assicurarsi che il preset selezionato nella pipeline sia sempre associato a un workspace reale.
+
 **Goal:** Esporre il sistema preset di Phrase Memory in due punti: (1) una sezione dedicata nel modale Settings per creare/modificare/eliminare preset custom e clonare quelli built-in; (2) una sezione collassabile nella tab Settings della PipelineConfig per attivare Phrase Memory sulla pipeline e scegliere/sovrascrivere preset. Infine aggiornare `pipelineService.ts` per persistere i tre nuovi campi DB (`use_phrase_memory`, `phrase_memory_preset_id`, `phrase_memory_overrides`).
 
 **Architecture:** Nessun nuovo store Zustand — la selezione preset nella pipeline viaggia dentro `PipelineConfig` (già in `pipelineStore`). Il caricamento dei preset dal DB avviene con una chiamata diretta a `phraseMemoryPresetService.listPresets()` all'interno dei componenti che ne hanno bisogno. I preset built-in sono seed immutabili lato DB; la UI li mostra in sola lettura con un bottone "Clona".

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-sql",
  "tauri-plugin-updater",
+ "thiserror 1.0.69",
  "tokio",
  "wiremock",
  "zip",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ rand = "0.8"
 async-trait = "0.1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlite-vec = "0.1.6"
+thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "test-util", "time"] }

--- a/src-tauri/src/documents.rs
+++ b/src-tauri/src/documents.rs
@@ -168,6 +168,7 @@ pub fn extract_pdf_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
     Ok(normalized)
 }
 
+#[allow(clippy::collapsible_str_replace)]
 fn normalize_pdf_text(text: &str) -> String {
     let text = text
         .replace('\u{FB00}', "ff")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,11 @@ llm::pipeline::run_stage,
             documents::export_markdown_docx,
             documents::extract_pdf_text,
             vector::vec_ping,
+            vector::embedding::get_embeddings,
+            vector::embedding::split_phrases_llm,
+            vector::embedding::vec_upsert_source_phrase,
+            vector::embedding::vec_search_phrase_memory,
+            vector::embedding::vec_save_locked_phrases,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/vector/embedding.rs
+++ b/src-tauri/src/vector/embedding.rs
@@ -120,6 +120,12 @@ pub async fn split_phrases_llm(
         .await
         .map_err(|e| EmbeddingError::Http(e.to_string()))?;
 
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(EmbeddingError::Http(format!("{status}: {text}")));
+    }
+
     let json: serde_json::Value = response
         .json()
         .await
@@ -157,7 +163,7 @@ pub async fn split_phrases_llm(
 #[tauri::command]
 pub async fn vec_upsert_source_phrase(
     app: tauri::AppHandle,
-    workspace_id: String,
+    project_id: String,
     chunk_id: String,
     phrase: String,
     embedding: Vec<f32>,
@@ -168,9 +174,9 @@ pub async fn vec_upsert_source_phrase(
 
     conn.execute(
         "INSERT OR REPLACE INTO source_phrase_embeddings \
-         (id, workspace_id, chunk_id, source_phrase, embedding, created_at) \
+         (id, project_id, chunk_id, source_phrase, embedding, created_at) \
          VALUES (lower(hex(randomblob(16))), ?1, ?2, ?3, ?4, datetime('now'))",
-        rusqlite::params![workspace_id, chunk_id, phrase, floats_to_blob(&embedding)],
+        rusqlite::params![project_id, chunk_id, phrase, floats_to_blob(&embedding)],
     )
     .map_err(|e| EmbeddingError::Http(e.to_string()))?;
 
@@ -201,17 +207,21 @@ pub async fn vec_search_phrase_memory(
 
     let mut stmt = conn
         .prepare(
-            "SELECT pm.id, pm.source_phrase, pm.target_phrase, \
-                    vec_distance_cosine(pm.embedding, ?1) AS distance \
-             FROM phrase_memory pm \
-             WHERE pm.workspace_id = ?2 \
-               AND vec_distance_cosine(pm.embedding, ?1) < ?3 \
+            "WITH ranked AS ( \
+               SELECT pm.id, pm.source_phrase, pm.target_phrase, \
+                      vec_distance_cosine(pm.embedding, ?1) AS distance \
+               FROM phrase_memory pm \
+               WHERE pm.workspace_id = ?2 \
+             ) \
+             SELECT id, source_phrase, target_phrase, distance \
+             FROM ranked \
+             WHERE distance < ?3 \
              ORDER BY distance ASC \
              LIMIT ?4",
         )
         .map_err(|e| EmbeddingError::Http(e.to_string()))?;
 
-    let results = stmt
+    let results: rusqlite::Result<Vec<PhraseMatchResult>> = stmt
         .query_map(
             rusqlite::params![blob, workspace_id, threshold, max_results],
             |row| {
@@ -224,10 +234,9 @@ pub async fn vec_search_phrase_memory(
             },
         )
         .map_err(|e| EmbeddingError::Http(e.to_string()))?
-        .filter_map(|r| r.ok())
         .collect();
 
-    Ok(results)
+    results.map_err(|e| EmbeddingError::Http(e.to_string()))
 }
 
 #[derive(Debug, Deserialize)]
@@ -237,13 +246,17 @@ pub struct PhrasePair {
     pub source_embedding: Vec<f32>,
 }
 
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn vec_save_locked_phrases(
     app: tauri::AppHandle,
     workspace_id: String,
+    project_id: String,
     chunk_id: String,
     pairs: Vec<PhrasePair>,
     min_phrase_length: u32,
+    source_language: String,
+    target_language: String,
 ) -> Result<u32, EmbeddingError> {
     if pairs.is_empty() {
         return Ok(0);
@@ -260,25 +273,29 @@ pub async fn vec_save_locked_phrases(
             continue;
         }
 
-        conn.execute(
-            "INSERT OR IGNORE INTO phrase_memory \
-             (id, workspace_id, source_phrase, target_phrase, embedding, created_at) \
-             VALUES (lower(hex(randomblob(16))), ?1, ?2, ?3, ?4, datetime('now'))",
-            rusqlite::params![
-                workspace_id,
-                pair.source_phrase,
-                pair.target_phrase,
-                floats_to_blob(&pair.source_embedding)
-            ],
-        )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+        let rows = conn
+            .execute(
+                "INSERT OR IGNORE INTO phrase_memory \
+                 (id, workspace_id, source_phrase, target_phrase, \
+                  source_language, target_language, embedding, created_at) \
+                 VALUES (lower(hex(randomblob(16))), ?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
+                rusqlite::params![
+                    workspace_id,
+                    pair.source_phrase,
+                    pair.target_phrase,
+                    source_language,
+                    target_language,
+                    floats_to_blob(&pair.source_embedding)
+                ],
+            )
+            .map_err(|e| EmbeddingError::Http(e.to_string()))?;
 
-        saved += 1;
+        saved += rows as u32;
     }
 
     conn.execute(
-        "DELETE FROM source_phrase_embeddings WHERE chunk_id = ?1 AND workspace_id = ?2",
-        rusqlite::params![chunk_id, workspace_id],
+        "DELETE FROM source_phrase_embeddings WHERE chunk_id = ?1 AND project_id = ?2",
+        rusqlite::params![chunk_id, project_id],
     )
     .map_err(|e| EmbeddingError::Http(e.to_string()))?;
 

--- a/src-tauri/src/vector/embedding.rs
+++ b/src-tauri/src/vector/embedding.rs
@@ -1,0 +1,286 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::Manager;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingError {
+    #[error("API key not found for provider openai")]
+    MissingApiKey,
+    #[error("HTTP request failed: {0}")]
+    Http(String),
+    #[error("Unexpected API response: {0}")]
+    Parse(String),
+}
+
+impl Serialize for EmbeddingError {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+fn db_path(app: &tauri::AppHandle) -> Result<PathBuf, EmbeddingError> {
+    app.path()
+        .app_data_dir()
+        .map(|p| p.join("glossa.db"))
+        .map_err(|e| EmbeddingError::Http(format!("cannot resolve db path: {e}")))
+}
+
+fn floats_to_blob(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+// ── OpenAI response types ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct EmbeddingObject {
+    embedding: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbeddingResponse {
+    data: Vec<EmbeddingObject>,
+}
+
+// ── Commands ─────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_embeddings(
+    app: tauri::AppHandle,
+    texts: Vec<String>,
+    model: String,
+) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+    if texts.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let api_key = crate::keystore::get_api_key(&app, "openai")
+        .map_err(|_| EmbeddingError::MissingApiKey)?;
+    if api_key.is_empty() {
+        return Err(EmbeddingError::MissingApiKey);
+    }
+
+    let body = serde_json::json!({
+        "input": texts,
+        "model": model,
+        "encoding_format": "float"
+    });
+
+    let response = reqwest::Client::new()
+        .post("https://api.openai.com/v1/embeddings")
+        .bearer_auth(&api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(EmbeddingError::Http(format!("{status}: {text}")));
+    }
+
+    let parsed: OpenAiEmbeddingResponse = response
+        .json()
+        .await
+        .map_err(|e| EmbeddingError::Parse(e.to_string()))?;
+
+    Ok(parsed.data.into_iter().map(|o| o.embedding).collect())
+}
+
+#[tauri::command]
+pub async fn split_phrases_llm(
+    app: tauri::AppHandle,
+    source_text: String,
+) -> Result<Vec<String>, EmbeddingError> {
+    let api_key = crate::keystore::get_api_key(&app, "openai")
+        .map_err(|_| EmbeddingError::MissingApiKey)?;
+    if api_key.is_empty() {
+        return Err(EmbeddingError::MissingApiKey);
+    }
+
+    let prompt = format!(
+        "Split the following text into individual sentences or meaningful phrases. \
+        Return ONLY a JSON array of strings. Each string must be an exact verbatim \
+        copy from the source text — no paraphrasing, no added punctuation. \
+        Example: [\"First sentence.\", \"Second phrase\"]\n\nText:\n{source_text}"
+    );
+
+    let body = serde_json::json!({
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "response_format": {"type": "json_object"}
+    });
+
+    let response = reqwest::Client::new()
+        .post("https://api.openai.com/v1/chat/completions")
+        .bearer_auth(&api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    let json: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| EmbeddingError::Parse(e.to_string()))?;
+
+    let content = json["choices"][0]["message"]["content"]
+        .as_str()
+        .ok_or_else(|| EmbeddingError::Parse("missing content".into()))?;
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(content).map_err(|e| EmbeddingError::Parse(e.to_string()))?;
+
+    let arr = parsed
+        .as_array()
+        .or_else(|| parsed.get("phrases").and_then(|v| v.as_array()))
+        .or_else(|| parsed.get("sentences").and_then(|v| v.as_array()))
+        .ok_or_else(|| EmbeddingError::Parse("response is not an array".into()))?;
+
+    let validated: Vec<String> = arr
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter(|phrase| {
+            let ok = source_text.contains(*phrase);
+            if !ok {
+                log::warn!("split_phrases_llm: discarding non-verbatim phrase: {phrase:?}");
+            }
+            ok
+        })
+        .map(|s| s.to_string())
+        .collect();
+
+    Ok(validated)
+}
+
+#[tauri::command]
+pub async fn vec_upsert_source_phrase(
+    app: tauri::AppHandle,
+    workspace_id: String,
+    chunk_id: String,
+    phrase: String,
+    embedding: Vec<f32>,
+) -> Result<(), EmbeddingError> {
+    let path = db_path(&app)?;
+    let conn = crate::vector::open_vec_connection(&path)
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO source_phrase_embeddings \
+         (id, workspace_id, chunk_id, source_phrase, embedding, created_at) \
+         VALUES (lower(hex(randomblob(16))), ?1, ?2, ?3, ?4, datetime('now'))",
+        rusqlite::params![workspace_id, chunk_id, phrase, floats_to_blob(&embedding)],
+    )
+    .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PhraseMatchResult {
+    pub phrase_memory_id: String,
+    pub source_phrase: String,
+    pub target_phrase: String,
+    pub distance: f64,
+}
+
+#[tauri::command]
+pub async fn vec_search_phrase_memory(
+    app: tauri::AppHandle,
+    workspace_id: String,
+    query_embedding: Vec<f32>,
+    threshold: f64,
+    max_results: u32,
+) -> Result<Vec<PhraseMatchResult>, EmbeddingError> {
+    let path = db_path(&app)?;
+    let conn = crate::vector::open_vec_connection(&path)
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    let blob = floats_to_blob(&query_embedding);
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT pm.id, pm.source_phrase, pm.target_phrase, \
+                    vec_distance_cosine(pm.embedding, ?1) AS distance \
+             FROM phrase_memory pm \
+             WHERE pm.workspace_id = ?2 \
+               AND vec_distance_cosine(pm.embedding, ?1) < ?3 \
+             ORDER BY distance ASC \
+             LIMIT ?4",
+        )
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    let results = stmt
+        .query_map(
+            rusqlite::params![blob, workspace_id, threshold, max_results],
+            |row| {
+                Ok(PhraseMatchResult {
+                    phrase_memory_id: row.get(0)?,
+                    source_phrase: row.get(1)?,
+                    target_phrase: row.get(2)?,
+                    distance: row.get(3)?,
+                })
+            },
+        )
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(results)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PhrasePair {
+    pub source_phrase: String,
+    pub target_phrase: String,
+    pub source_embedding: Vec<f32>,
+}
+
+#[tauri::command]
+pub async fn vec_save_locked_phrases(
+    app: tauri::AppHandle,
+    workspace_id: String,
+    chunk_id: String,
+    pairs: Vec<PhrasePair>,
+    min_phrase_length: u32,
+) -> Result<u32, EmbeddingError> {
+    if pairs.is_empty() {
+        return Ok(0);
+    }
+
+    let path = db_path(&app)?;
+    let conn = crate::vector::open_vec_connection(&path)
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    let mut saved: u32 = 0;
+
+    for pair in &pairs {
+        if (pair.source_phrase.len() as u32) < min_phrase_length {
+            continue;
+        }
+
+        conn.execute(
+            "INSERT OR IGNORE INTO phrase_memory \
+             (id, workspace_id, source_phrase, target_phrase, embedding, created_at) \
+             VALUES (lower(hex(randomblob(16))), ?1, ?2, ?3, ?4, datetime('now'))",
+            rusqlite::params![
+                workspace_id,
+                pair.source_phrase,
+                pair.target_phrase,
+                floats_to_blob(&pair.source_embedding)
+            ],
+        )
+        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+        saved += 1;
+    }
+
+    conn.execute(
+        "DELETE FROM source_phrase_embeddings WHERE chunk_id = ?1 AND workspace_id = ?2",
+        rusqlite::params![chunk_id, workspace_id],
+    )
+    .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+
+    Ok(saved)
+}

--- a/src-tauri/src/vector/mod.rs
+++ b/src-tauri/src/vector/mod.rs
@@ -1,3 +1,5 @@
+pub mod embedding;
+
 use rusqlite::{ffi::sqlite3_auto_extension, Connection, Result as RusqliteResult};
 use std::path::PathBuf;
 use tauri::Manager;
@@ -6,6 +8,7 @@ use tauri::Manager;
 /// Must be called once at startup before opening any connection.
 /// After registration every rusqlite::Connection will have vec_* functions available.
 pub fn register_vec_extension() {
+    #[allow(clippy::missing_transmute_annotations)]
     unsafe {
         sqlite3_auto_extension(Some(std::mem::transmute(
             sqlite_vec::sqlite3_vec_init as *const (),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import { useUiStore } from './stores/uiStore';
 import { useProjectStore } from './stores/projectStore';
 import { useLibraryStore } from './stores/libraryStore';
 import { useChunksStore } from './stores/chunksStore';
+import { useWorkspaceStore } from './stores/workspaceStore';
+import { WorkspaceWizard } from './components/workspace/WorkspaceWizard';
+import { WorkspaceHome } from './components/workspace/WorkspaceHome';
 import { Toaster } from 'sonner';
 
 function HighlightColorSync() {
@@ -51,10 +54,12 @@ const LibraryPanel = lazy(() =>
   import('./components/library/LibraryPanel').then((m) => ({ default: m.LibraryPanel })),
 );
 
-export default function App() {
-  useEffect(() => { void initLogger(); }, []);
-
-
+/**
+ * Editor view — hooks usati solo quando c'è un progetto aperto.
+ * Estratto in un componente separato per evitare violazioni Rules of Hooks
+ * nella shell gating di App.
+ */
+function EditorView() {
   const {
     runPipeline,
     runAuditOnly,
@@ -65,9 +70,6 @@ export default function App() {
     cancelPipeline,
   } = usePipeline();
 
-  // In document mode, retranslate a single chunk using the active pipeline mode.
-  // If completed translations already exist, always produce completed output
-  // regardless of mode (belt-and-suspenders against any future dirty state).
   const handleRetranslateChunk = useCallback((chunkId: string) => {
     const mode = useUiStore.getState().pipelineMode;
     const hasCompleted = useChunksStore.getState().chunks.some((c) => c.status === 'completed' || c.translationLocked);
@@ -79,7 +81,6 @@ export default function App() {
   const showProjectPanel = useProjectStore((state) => state.showProjectPanel);
   const showLibraryPanel = useLibraryStore((state) => state.showLibraryPanel);
 
-  // Keep panels mounted once first opened so their AnimatePresence exit animations run
   const settingsLoaded = useRef(false);
   const projectPanelLoaded = useRef(false);
   const libraryPanelLoaded = useRef(false);
@@ -88,76 +89,136 @@ export default function App() {
   if (showLibraryPanel) libraryPanelLoaded.current = true;
 
   return (
+    <>
+      <div className="flex-shrink-0">
+        <Header
+          onRunPipeline={runPipeline}
+          onCancelPipeline={cancelPipeline}
+        />
+      </div>
+      {viewMode === 'document' ? (
+        <Suspense fallback={null}>
+          <main className="relative flex flex-1 min-h-0 overflow-hidden">
+            <PipelineSidebar
+              onRunPipeline={runPipeline}
+              onCancelPipeline={cancelPipeline}
+              onDryRun={runDryRun}
+              onRetranslateChunk={handleRetranslateChunk}
+            />
+            <ConfigDrawer
+              onRunPipeline={runPipeline}
+              onRunAuditOnly={runAuditOnly}
+              onCancelPipeline={cancelPipeline}
+            />
+            <DocumentView
+              onRetranslateChunk={handleRetranslateChunk}
+            />
+            <InsightsDrawer onReauditChunk={auditSingleChunk} onRunCoherenceAudit={runCoherenceAudit} />
+          </main>
+        </Suspense>
+      ) : (
+        <Suspense fallback={null}>
+          <main className="grid grid-cols-1 md:grid-cols-12 flex-1 min-h-0">
+            <PipelineConfig
+              onRunPipeline={runPipeline}
+              onRunAuditOnly={runAuditOnly}
+              onCancelPipeline={cancelPipeline}
+            />
+            <ProductionStream
+              onRetranslateChunk={runSingleChunk}
+              onReauditChunk={auditSingleChunk}
+            />
+            <AuditPanel
+              onRunAuditOnly={runAuditOnly}
+              onReauditChunk={auditSingleChunk}
+            />
+          </main>
+        </Suspense>
+      )}
+
+      {settingsLoaded.current && (
+        <Suspense fallback={null}>
+          <SettingsModal />
+        </Suspense>
+      )}
+      {projectPanelLoaded.current && (
+        <Suspense fallback={null}>
+          <ProjectPanel />
+        </Suspense>
+      )}
+      {libraryPanelLoaded.current && (
+        <Suspense fallback={null}>
+          <LibraryPanel />
+        </Suspense>
+      )}
+
+      <ConfirmDialog />
+      <PreflightDialog />
+      <RunResumeBanner />
+    </>
+  );
+}
+
+export default function App() {
+  useEffect(() => { void initLogger(); }, []);
+
+  const { isLoaded, workspaces, activeWorkspace, loadWorkspaces } = useWorkspaceStore();
+  const currentProjectId = useProjectStore((s) => s.currentProjectId);
+
+  useEffect(() => {
+    void loadWorkspaces();
+  }, [loadWorkspaces]);
+
+  // ── Shell loading ────────────────────────────────────────────────────
+  if (!isLoaded) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-editorial-bg">
+        <div className="text-sm text-editorial-muted">Caricamento...</div>
+      </div>
+    );
+  }
+
+  // ── First run: nessun workspace ──────────────────────────────────────
+  if (workspaces.length === 0) {
+    return (
+      <ErrorBoundary>
+        <WorkspaceWizard />
+        <Toaster
+          position="bottom-right"
+          toastOptions={{ style: { fontFamily: 'var(--font-sans, system-ui)', fontSize: '12px' } }}
+          richColors
+          closeButton
+        />
+      </ErrorBoundary>
+    );
+  }
+
+  // ── Workspace home: workspace attivo ma nessun progetto aperto ───────
+  if (activeWorkspace && !currentProjectId) {
+    return (
+      <ErrorBoundary>
+        <div className="h-screen overflow-hidden bg-editorial-bg text-editorial-ink font-sans flex flex-col">
+          <div className="flex-shrink-0">
+            <Header onRunPipeline={() => {}} onCancelPipeline={() => {}} />
+          </div>
+          <WorkspaceHome />
+        </div>
+        <Toaster
+          position="bottom-right"
+          toastOptions={{ style: { fontFamily: 'var(--font-sans, system-ui)', fontSize: '12px' } }}
+          richColors
+          closeButton
+        />
+      </ErrorBoundary>
+    );
+  }
+
+  // ── Project open: mostra editor ─────────────────────────────────────
+  return (
     <ErrorBoundary>
       <HighlightColorSync />
       <div className="h-screen overflow-hidden bg-editorial-bg text-editorial-ink font-sans flex flex-col">
-        <div className="flex-shrink-0">
-          <Header
-            onRunPipeline={runPipeline}
-            onCancelPipeline={cancelPipeline}
-          />
-        </div>
-
-        {viewMode === 'document' ? (
-          <Suspense fallback={null}>
-            <main className="relative flex flex-1 min-h-0 overflow-hidden">
-              <PipelineSidebar
-                onRunPipeline={runPipeline}
-                onCancelPipeline={cancelPipeline}
-                onDryRun={runDryRun}
-                onRetranslateChunk={handleRetranslateChunk}
-              />
-              <ConfigDrawer
-                onRunPipeline={runPipeline}
-                onRunAuditOnly={runAuditOnly}
-                onCancelPipeline={cancelPipeline}
-              />
-              <DocumentView
-                onRetranslateChunk={handleRetranslateChunk}
-              />
-              <InsightsDrawer onReauditChunk={auditSingleChunk} onRunCoherenceAudit={runCoherenceAudit} />
-            </main>
-          </Suspense>
-        ) : (
-          <Suspense fallback={null}>
-            <main className="grid grid-cols-1 md:grid-cols-12 flex-1 min-h-0">
-              <PipelineConfig
-                onRunPipeline={runPipeline}
-                onRunAuditOnly={runAuditOnly}
-                onCancelPipeline={cancelPipeline}
-              />
-              <ProductionStream
-                onRetranslateChunk={runSingleChunk}
-                onReauditChunk={auditSingleChunk}
-              />
-              <AuditPanel
-                onRunAuditOnly={runAuditOnly}
-                onReauditChunk={auditSingleChunk}
-              />
-            </main>
-          </Suspense>
-        )}
-
-        {settingsLoaded.current && (
-          <Suspense fallback={null}>
-            <SettingsModal />
-          </Suspense>
-        )}
-        {projectPanelLoaded.current && (
-          <Suspense fallback={null}>
-            <ProjectPanel />
-          </Suspense>
-        )}
-        {libraryPanelLoaded.current && (
-          <Suspense fallback={null}>
-            <LibraryPanel />
-          </Suspense>
-        )}
-
-        <ConfirmDialog />
-        <PreflightDialog />
-        <RunResumeBanner />
-
+        <EditorView />
       </div>
       <Toaster
         position="bottom-right"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,7 @@ export default function App() {
   const currentProjectId = useProjectStore((s) => s.currentProjectId);
 
   useEffect(() => {
-    void loadWorkspaces();
+    loadWorkspaces().catch((err: unknown) => console.error('[App] loadWorkspaces failed:', err));
   }, [loadWorkspaces]);
 
   // ── Shell loading ────────────────────────────────────────────────────

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -19,6 +19,9 @@ import { useTranslation } from 'react-i18next';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { saveLockedPhrases } from '../../services/phraseMemoryService';
+import { logger } from '../../utils/logger';
 import type { TranslationChunk } from '../../types';
 import { indexPad } from '../../utils';
 import { CopyButton, HighlightedText, MarkdownEditor, ProcessingLine } from '../common';
@@ -55,6 +58,23 @@ export function DocumentView({ onRetranslateChunk }: DocumentViewProps) {
     toggleChunkTranslationLock,
     toggleChunkSourceEditing,
   } = useChunksStore();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+
+  const handleLockToggle = (chunk: TranslationChunk) => {
+    const isLocking = !chunk.translationLocked;
+    toggleChunkTranslationLock(chunk.id);
+    if (isLocking && activeWorkspace && chunk.sourceProcessingText && chunk.currentDraft) {
+      saveLockedPhrases({
+        workspaceId: activeWorkspace.id,
+        chunkId: chunk.id,
+        embeddingModel: activeWorkspace.embeddingModel,
+        splitter: 'regex',
+        sourceText: chunk.sourceProcessingText,
+        targetText: chunk.currentDraft,
+        minPhraseLength: 10,
+      }).catch((err) => logger.warn('saveLockedPhrases failed (non-blocking)', { error: String(err) }));
+    }
+  };
 
   const {
     selectedChunkId,
@@ -415,7 +435,7 @@ export function DocumentView({ onRetranslateChunk }: DocumentViewProps) {
                 size="sm"
                 tone={currentChunk.translationLocked ? 'success' : 'muted'}
                 title={currentChunk.translationLocked ? t('document.unlockTranslation') : t('document.lockTranslation')}
-                onClick={() => toggleChunkTranslationLock(currentChunk.id)}
+                onClick={() => handleLockToggle(currentChunk)}
                 disabled={!currentChunk.currentDraft?.trim()}
                 ariaPressed={currentChunk.translationLocked === true}
               >

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -20,6 +20,7 @@ import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useUiStore } from '../../stores/uiStore';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { useProjectStore } from '../../stores/projectStore';
 import { saveLockedPhrases } from '../../services/phraseMemoryService';
 import { logger } from '../../utils/logger';
 import type { TranslationChunk } from '../../types';
@@ -59,19 +60,23 @@ export function DocumentView({ onRetranslateChunk }: DocumentViewProps) {
     toggleChunkSourceEditing,
   } = useChunksStore();
   const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const currentProjectId = useProjectStore((s) => s.currentProjectId);
 
   const handleLockToggle = (chunk: TranslationChunk) => {
     const isLocking = !chunk.translationLocked;
     toggleChunkTranslationLock(chunk.id);
-    if (isLocking && activeWorkspace && chunk.sourceProcessingText && chunk.currentDraft) {
+    if (isLocking && activeWorkspace && currentProjectId && chunk.sourceProcessingText && chunk.currentDraft) {
       saveLockedPhrases({
         workspaceId: activeWorkspace.id,
+        projectId: currentProjectId,
         chunkId: chunk.id,
         embeddingModel: activeWorkspace.embeddingModel,
         splitter: 'regex',
         sourceText: chunk.sourceProcessingText,
         targetText: chunk.currentDraft,
         minPhraseLength: 10,
+        sourceLanguage: config.sourceLanguage,
+        targetLanguage: config.targetLanguage,
       }).catch((err) => logger.warn('saveLockedPhrases failed (non-blocking)', { error: String(err) }));
     }
   };

--- a/src/components/workspace/WorkspaceHome.tsx
+++ b/src/components/workspace/WorkspaceHome.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { FolderOpen, Plus } from 'lucide-react';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { exportWorkspace, importWorkspace } from '../../services/backupService';
@@ -28,118 +29,114 @@ export function WorkspaceHome() {
     }
   };
 
-  const btnBase =
-    'rounded-full border border-editorial-border px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] transition-colors hover:bg-editorial-ink hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent';
-  const btnPrimary =
-    'rounded-full bg-editorial-ink px-5 py-2.5 text-xs font-bold uppercase tracking-[0.2em] text-white transition-colors hover:bg-editorial-ink/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-35';
-  const inputClass =
-    'w-full rounded-[18px] border border-editorial-border bg-editorial-textbox/30 px-4 py-2.5 text-sm text-editorial-ink outline-none transition-colors focus:border-editorial-accent focus-visible:ring-2 focus-visible:ring-editorial-accent';
-
   return (
     <div className="flex h-full flex-col items-center justify-start overflow-y-auto px-6 py-12">
-      <div className="w-full max-w-lg">
+      <div className="w-full max-w-2xl space-y-6">
 
         {/* Workspace header */}
-        <div className="mb-10 flex flex-col gap-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-editorial-muted">
+        <div className="space-y-1">
+          <p className="text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted">
             Workspace attivo
           </p>
-          <h1 className="text-2xl font-semibold text-editorial-ink">
+          <h1 className="text-2xl font-display italic text-editorial-ink">
             {activeWorkspace?.name ?? '—'}
           </h1>
         </div>
 
-        {/* Project list */}
-        <section className="mb-8">
-          <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-editorial-muted">
+        {/* Project list section */}
+        <div className="space-y-3">
+          <p className="text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted">
             Progetti
-          </h2>
+          </p>
 
           {projects.length === 0 ? (
-            <p className="rounded-[18px] border border-editorial-border px-4 py-6 text-center text-sm text-editorial-muted">
-              Nessun progetto. Crea il primo progetto per iniziare.
+            <p className="rounded-[20px] border border-dashed border-editorial-border px-4 py-8 text-center text-sm italic text-editorial-muted">
+              Nessun progetto. Crea il primo per iniziare.
             </p>
           ) : (
-            <ul className="flex flex-col gap-2">
+            <div className="space-y-3">
               {projects.map((project) => (
-                <li key={project.id}>
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between rounded-[18px] border border-editorial-border px-4 py-3 text-left transition-colors hover:border-editorial-accent hover:bg-editorial-accent/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                    onClick={() => void openProject(project.id)}
-                  >
-                    <span className="text-sm font-medium text-editorial-ink">{project.name}</span>
-                    <span className="text-xs text-editorial-muted">
+                <div
+                  key={project.id}
+                  role="button"
+                  tabIndex={0}
+                  className="group flex items-center gap-3 rounded-[20px] border border-editorial-border bg-editorial-bg px-4 py-4 transition-colors hover:border-editorial-accent/40 hover:bg-editorial-textbox/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                  onClick={() => void openProject(project.id)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); void openProject(project.id); } }}
+                >
+                  <FolderOpen size={16} className="text-editorial-muted" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-base font-display italic text-editorial-ink">{project.name}</div>
+                    <div className="mt-1 text-[10px] font-mono text-editorial-muted">
                       {project.source_language} → {project.target_language}
-                    </span>
-                  </button>
-                </li>
+                    </div>
+                  </div>
+                </div>
               ))}
-            </ul>
+            </div>
           )}
-        </section>
+        </div>
 
         {/* Create project */}
-        <section className="mb-10">
-          {showCreateInput ? (
-            <div className="flex flex-col gap-3">
-              <input
-                className={inputClass}
-                placeholder="Nome progetto"
-                value={newProjectName}
-                onChange={(e) => setNewProjectName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void handleCreateProject();
-                  if (e.key === 'Escape') setShowCreateInput(false);
-                }}
-                autoFocus
-              />
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  className={btnPrimary}
-                  onClick={() => void handleCreateProject()}
-                  disabled={!newProjectName.trim() || creating}
-                >
-                  {creating ? 'Creazione...' : 'Crea progetto'}
-                </button>
-                <button
-                  type="button"
-                  className={btnBase}
-                  onClick={() => setShowCreateInput(false)}
-                >
-                  Annulla
-                </button>
-              </div>
+        {showCreateInput ? (
+          <div className="space-y-3 rounded-[20px] border border-editorial-border bg-editorial-textbox/15 px-4 py-4">
+            <input
+              value={newProjectName}
+              onChange={(e) => setNewProjectName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleCreateProject();
+                if (e.key === 'Escape') { setShowCreateInput(false); setNewProjectName(''); }
+              }}
+              placeholder="Nome progetto"
+              className="w-full rounded-[16px] border border-editorial-border bg-editorial-bg/80 px-3 py-3 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              autoFocus
+            />
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => { setShowCreateInput(false); setNewProjectName(''); }}
+                className="rounded-full border border-editorial-border px-5 py-3 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              >
+                Annulla
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreateProject()}
+                disabled={!newProjectName.trim() || creating}
+                className="rounded-full bg-editorial-ink px-5 py-3 text-[10px] font-bold uppercase tracking-[0.25em] text-white transition-colors hover:bg-editorial-ink/90 disabled:opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              >
+                {creating ? 'Creazione...' : 'Crea'}
+              </button>
             </div>
-          ) : (
-            <button
-              type="button"
-              className={btnPrimary}
-              onClick={() => setShowCreateInput(true)}
-            >
-              + Nuovo progetto
-            </button>
-          )}
-        </section>
-
-        {/* Backup actions */}
-        <section className="flex flex-wrap gap-2 border-t border-editorial-border pt-6">
+          </div>
+        ) : (
           <button
             type="button"
-            className={btnBase}
+            onClick={() => setShowCreateInput(true)}
+            aria-label="Nuovo progetto"
+            className="rounded-full border border-dashed border-editorial-border p-2 text-editorial-muted transition-colors hover:border-editorial-accent hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          >
+            <Plus size={14} />
+          </button>
+        )}
+
+        {/* Backup actions */}
+        <div className="flex flex-wrap gap-2 border-t border-editorial-border pt-6">
+          <button
+            type="button"
             onClick={() => void exportWorkspace()}
+            className="rounded-full border border-editorial-border px-4 py-2 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
           >
             Esporta backup
           </button>
           <button
             type="button"
-            className={btnBase}
             onClick={() => void importWorkspace(t).then((ok) => ok && void loadProjects())}
+            className="rounded-full border border-editorial-border px-4 py-2 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
           >
             Importa backup
           </button>
-        </section>
+        </div>
       </div>
     </div>
   );

--- a/src/components/workspace/WorkspaceHome.tsx
+++ b/src/components/workspace/WorkspaceHome.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { exportWorkspace, importWorkspace } from '../../services/backupService';
+import { useTranslation } from 'react-i18next';
+
+export function WorkspaceHome() {
+  const { t } = useTranslation();
+  const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
+  const { projects, loadProjects, createAndOpen, openProject } = useProjectStore();
+  const [newProjectName, setNewProjectName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [showCreateInput, setShowCreateInput] = useState(false);
+
+  useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  const handleCreateProject = async () => {
+    if (!newProjectName.trim()) return;
+    setCreating(true);
+    try {
+      await createAndOpen(newProjectName.trim());
+    } finally {
+      setCreating(false);
+      setNewProjectName('');
+      setShowCreateInput(false);
+    }
+  };
+
+  const btnBase =
+    'rounded-full border border-editorial-border px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] transition-colors hover:bg-editorial-ink hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent';
+  const btnPrimary =
+    'rounded-full bg-editorial-ink px-5 py-2.5 text-xs font-bold uppercase tracking-[0.2em] text-white transition-colors hover:bg-editorial-ink/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-35';
+  const inputClass =
+    'w-full rounded-[18px] border border-editorial-border bg-editorial-textbox/30 px-4 py-2.5 text-sm text-editorial-ink outline-none transition-colors focus:border-editorial-accent focus-visible:ring-2 focus-visible:ring-editorial-accent';
+
+  return (
+    <div className="flex h-full flex-col items-center justify-start overflow-y-auto px-6 py-12">
+      <div className="w-full max-w-lg">
+
+        {/* Workspace header */}
+        <div className="mb-10 flex flex-col gap-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-editorial-muted">
+            Workspace attivo
+          </p>
+          <h1 className="text-2xl font-semibold text-editorial-ink">
+            {activeWorkspace?.name ?? '—'}
+          </h1>
+        </div>
+
+        {/* Project list */}
+        <section className="mb-8">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-editorial-muted">
+            Progetti
+          </h2>
+
+          {projects.length === 0 ? (
+            <p className="rounded-[18px] border border-editorial-border px-4 py-6 text-center text-sm text-editorial-muted">
+              Nessun progetto. Crea il primo progetto per iniziare.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {projects.map((project) => (
+                <li key={project.id}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between rounded-[18px] border border-editorial-border px-4 py-3 text-left transition-colors hover:border-editorial-accent hover:bg-editorial-accent/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    onClick={() => void openProject(project.id)}
+                  >
+                    <span className="text-sm font-medium text-editorial-ink">{project.name}</span>
+                    <span className="text-xs text-editorial-muted">
+                      {project.source_language} → {project.target_language}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Create project */}
+        <section className="mb-10">
+          {showCreateInput ? (
+            <div className="flex flex-col gap-3">
+              <input
+                className={inputClass}
+                placeholder="Nome progetto"
+                value={newProjectName}
+                onChange={(e) => setNewProjectName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleCreateProject();
+                  if (e.key === 'Escape') setShowCreateInput(false);
+                }}
+                autoFocus
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className={btnPrimary}
+                  onClick={() => void handleCreateProject()}
+                  disabled={!newProjectName.trim() || creating}
+                >
+                  {creating ? 'Creazione...' : 'Crea progetto'}
+                </button>
+                <button
+                  type="button"
+                  className={btnBase}
+                  onClick={() => setShowCreateInput(false)}
+                >
+                  Annulla
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className={btnPrimary}
+              onClick={() => setShowCreateInput(true)}
+            >
+              + Nuovo progetto
+            </button>
+          )}
+        </section>
+
+        {/* Backup actions */}
+        <section className="flex flex-wrap gap-2 border-t border-editorial-border pt-6">
+          <button
+            type="button"
+            className={btnBase}
+            onClick={() => void exportWorkspace()}
+          >
+            Esporta backup
+          </button>
+          <button
+            type="button"
+            className={btnBase}
+            onClick={() => void importWorkspace(t).then((ok) => ok && void loadProjects())}
+          >
+            Importa backup
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/services/__tests__/embeddingService.test.ts
+++ b/src/services/__tests__/embeddingService.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+import { invoke } from '@tauri-apps/api/core';
+import { fetchEmbeddings, estimateEmbeddingCostUsd, estimateTokenCount } from '../embeddingService';
+
+const mockInvoke = vi.mocked(invoke);
+
+describe('embeddingService', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('fetchEmbeddings', () => {
+    it('restituisce array di vettori per input valido', async () => {
+      const vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]];
+      mockInvoke.mockResolvedValueOnce(vectors);
+
+      const result = await fetchEmbeddings(['ciao mondo', 'hello world'], 'text-embedding-3-small');
+
+      expect(mockInvoke).toHaveBeenCalledWith('get_embeddings', {
+        texts: ['ciao mondo', 'hello world'],
+        model: 'text-embedding-3-small',
+      });
+      expect(result).toEqual(vectors);
+    });
+
+    it('restituisce array vuoto senza chiamare invoke per input vuoto', async () => {
+      const result = await fetchEmbeddings([], 'text-embedding-3-small');
+      expect(result).toEqual([]);
+      expect(mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it('propaga errore se invoke fallisce', async () => {
+      mockInvoke.mockRejectedValueOnce(new Error('API key missing'));
+      await expect(fetchEmbeddings(['testo'], 'text-embedding-3-small')).rejects.toThrow('API key missing');
+    });
+  });
+
+  describe('estimateEmbeddingCostUsd', () => {
+    it('stima costo per text-embedding-3-small', () => {
+      expect(estimateEmbeddingCostUsd(1000, 'text-embedding-3-small')).toBeCloseTo(0.00002, 8);
+    });
+
+    it('stima costo per text-embedding-3-large', () => {
+      expect(estimateEmbeddingCostUsd(1000, 'text-embedding-3-large')).toBeCloseTo(0.00013, 8);
+    });
+
+    it('restituisce 0 per 0 token', () => {
+      expect(estimateEmbeddingCostUsd(0, 'text-embedding-3-small')).toBe(0);
+    });
+  });
+
+  describe('estimateTokenCount', () => {
+    it('stima token da testo non vuoto', () => {
+      expect(estimateTokenCount('ciao mondo test')).toBeGreaterThan(0);
+    });
+
+    it('restituisce 0 per stringa vuota', () => {
+      expect(estimateTokenCount('')).toBe(0);
+    });
+  });
+});

--- a/src/services/__tests__/phraseMemoryService.test.ts
+++ b/src/services/__tests__/phraseMemoryService.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../embeddingService', () => ({
+  fetchEmbeddings: vi.fn(),
+  estimateTokenCount: vi.fn((t: string) => t.split(/\s+/).length),
+  estimateEmbeddingCostUsd: vi.fn(() => 0.001),
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import { fetchEmbeddings } from '../embeddingService';
+import {
+  splitPhrases,
+  runEmbeddingJob,
+  searchPhraseMemory,
+  saveLockedPhrases,
+} from '../phraseMemoryService';
+
+const mockInvoke = vi.mocked(invoke);
+const mockFetchEmbeddings = vi.mocked(fetchEmbeddings);
+
+const SAMPLE = 'Il gatto dorme sul tetto. La luna brilla nel cielo; le stelle sono molte: sono infinite.';
+
+describe('splitPhrases', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('none restituisce testo intero come unica frase', async () => {
+    expect(await splitPhrases(SAMPLE, 'none')).toEqual([SAMPLE]);
+  });
+
+  it('regex split su . ; :', async () => {
+    const result = await splitPhrases(SAMPLE, 'regex');
+    expect(result.length).toBeGreaterThanOrEqual(4);
+    result.forEach((p) => {
+      expect(p.trim().length).toBeGreaterThan(0);
+      expect(SAMPLE).toContain(p.trim());
+    });
+  });
+
+  it('regex scarta frasi < 3 caratteri', async () => {
+    const result = await splitPhrases('A. BB. Una frase lunga abbastanza.', 'regex');
+    result.forEach((p) => expect(p.trim().length).toBeGreaterThanOrEqual(3));
+  });
+
+  it('llm chiama invoke split_phrases_llm', async () => {
+    const phrases = ['Il gatto dorme sul tetto', 'La luna brilla nel cielo'];
+    mockInvoke.mockResolvedValueOnce(phrases);
+    const result = await splitPhrases(SAMPLE, 'llm');
+    expect(mockInvoke).toHaveBeenCalledWith('split_phrases_llm', { sourceText: SAMPLE });
+    expect(result).toEqual(phrases);
+  });
+
+  it('llm fallback a regex se invoke fallisce', async () => {
+    mockInvoke.mockRejectedValueOnce(new Error('timeout'));
+    const result = await splitPhrases(SAMPLE, 'llm');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe('runEmbeddingJob', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('chiama vec_upsert_source_phrase per ogni frase trovata', async () => {
+    mockFetchEmbeddings.mockResolvedValue([[0.1, 0.2], [0.3, 0.4]]);
+    mockInvoke.mockResolvedValue(undefined);
+
+    await runEmbeddingJob({
+      workspaceId: 'ws-1',
+      embeddingModel: 'text-embedding-3-small',
+      splitter: 'regex',
+      chunks: [{ id: 'c1', text: 'Ciao. Mondo.' }],
+      onProgress: vi.fn(),
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'vec_upsert_source_phrase',
+      expect.objectContaining({ workspaceId: 'ws-1' }),
+    );
+  });
+
+  it('chiama onProgress con valori aggiornati', async () => {
+    mockFetchEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+    mockInvoke.mockResolvedValue(undefined);
+    const onProgress = vi.fn();
+
+    await runEmbeddingJob({
+      workspaceId: 'ws-1',
+      embeddingModel: 'text-embedding-3-small',
+      splitter: 'none',
+      chunks: [{ id: 'c1', text: 'Una frase.' }],
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalled();
+  });
+});
+
+describe('searchPhraseMemory', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('restituisce PhraseMatch[] mappato da snake_case', async () => {
+    mockFetchEmbeddings.mockResolvedValue([[0.1, 0.2, 0.3]]);
+    mockInvoke.mockResolvedValueOnce([
+      { phrase_memory_id: 'pm-1', source_phrase: 'ciao', target_phrase: 'hello', distance: 0.05 },
+    ]);
+
+    const results = await searchPhraseMemory({
+      workspaceId: 'ws-1',
+      embeddingModel: 'text-embedding-3-small',
+      queryText: 'ciao mondo',
+      threshold: 0.3,
+      maxResults: 5,
+    });
+
+    expect(results[0]).toMatchObject({ sourcePhrase: 'ciao', targetPhrase: 'hello' });
+  });
+
+  it('restituisce array vuoto se invoke restituisce []', async () => {
+    mockFetchEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+    mockInvoke.mockResolvedValueOnce([]);
+
+    const results = await searchPhraseMemory({
+      workspaceId: 'ws-1',
+      embeddingModel: 'text-embedding-3-small',
+      queryText: 'testo',
+      threshold: 0.3,
+      maxResults: 5,
+    });
+
+    expect(results).toEqual([]);
+  });
+});
+
+describe('saveLockedPhrases', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('chiama vec_save_locked_phrases con workspace e chunk corretti', async () => {
+    mockFetchEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+    mockInvoke.mockResolvedValueOnce(1);
+
+    await saveLockedPhrases({
+      workspaceId: 'ws-1',
+      chunkId: 'c1',
+      embeddingModel: 'text-embedding-3-small',
+      splitter: 'regex',
+      sourceText: 'Ciao mondo.',
+      targetText: 'Hello world.',
+      minPhraseLength: 3,
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      'vec_save_locked_phrases',
+      expect.objectContaining({ workspaceId: 'ws-1', chunkId: 'c1' }),
+    );
+  });
+});

--- a/src/services/__tests__/phraseMemoryService.test.ts
+++ b/src/services/__tests__/phraseMemoryService.test.ts
@@ -66,6 +66,7 @@ describe('runEmbeddingJob', () => {
 
     await runEmbeddingJob({
       workspaceId: 'ws-1',
+      projectId: 'proj-1',
       embeddingModel: 'text-embedding-3-small',
       splitter: 'regex',
       chunks: [{ id: 'c1', text: 'Ciao. Mondo.' }],
@@ -74,7 +75,7 @@ describe('runEmbeddingJob', () => {
 
     expect(mockInvoke).toHaveBeenCalledWith(
       'vec_upsert_source_phrase',
-      expect.objectContaining({ workspaceId: 'ws-1' }),
+      expect.objectContaining({ projectId: 'proj-1' }),
     );
   });
 
@@ -85,6 +86,7 @@ describe('runEmbeddingJob', () => {
 
     await runEmbeddingJob({
       workspaceId: 'ws-1',
+      projectId: 'proj-1',
       embeddingModel: 'text-embedding-3-small',
       splitter: 'none',
       chunks: [{ id: 'c1', text: 'Una frase.' }],
@@ -140,17 +142,20 @@ describe('saveLockedPhrases', () => {
 
     await saveLockedPhrases({
       workspaceId: 'ws-1',
+      projectId: 'proj-1',
       chunkId: 'c1',
       embeddingModel: 'text-embedding-3-small',
       splitter: 'regex',
       sourceText: 'Ciao mondo.',
       targetText: 'Hello world.',
       minPhraseLength: 3,
+      sourceLanguage: 'it',
+      targetLanguage: 'en',
     });
 
     expect(mockInvoke).toHaveBeenCalledWith(
       'vec_save_locked_phrases',
-      expect.objectContaining({ workspaceId: 'ws-1', chunkId: 'c1' }),
+      expect.objectContaining({ workspaceId: 'ws-1', projectId: 'proj-1', chunkId: 'c1' }),
     );
   });
 });

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -9,6 +9,7 @@ const GLOSSA_VERSION = '0.9.0';
 // Ordered for FK safety: parents before children for INSERT,
 // children before parents for DELETE.
 const INSERT_ORDER = [
+  'workspaces',
   'glossaries',
   'projects',
   'app_settings',
@@ -17,22 +18,32 @@ const INSERT_ORDER = [
   'project_glossaries',
   'glossary_entries',
   'translations',
+  'phrase_memory_presets',
+  'phrase_memory',
+  'source_phrase_embeddings',
 ] as const;
 
 const SAFE_COL = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 const ALLOWED_COLUMNS: Record<BackupTable, ReadonlySet<string>> = {
-  glossaries:         new Set(['id','name','description','source_language','target_language','created_at']),
-  projects:           new Set(['id','name','source_language','target_language','created_at','updated_at','view_mode','source_display_text']),
-  app_settings:       new Set(['key','value']),
-  prompt_templates:   new Set(['id','name','prompt','default_model','default_provider','created_at','updated_at','context']),
-  pipelines:          new Set(['id','project_id','name','source_language','target_language','pipeline_mode','stages','judge_prompt','judge_model','judge_provider','use_chunking','words_per_chunk','source_display_text','source_processing_text','source_footnotes','review_provider_options','persona','custom_source_language','custom_target_language','blob_budget_tokens','blob_overlap','coherence_prompt','run_status','last_run_config','run_in_progress','created_at','updated_at']),
-  project_glossaries: new Set(['project_id','glossary_id']),
-  glossary_entries:   new Set(['id','glossary_id','term','translation','notes','context','created_at']),
-  translations:       new Set(['id','project_id','original_text','final_translation','source_display_text','source_processing_text','translation_display_text','translation_processing_text','position','chunk_status','stage_results','judge_status','judge_rating','translation_locked','judge_issues','created_at','coherence_result','footnotes','blob_id','blob_order','blob_reference_chunk_ids','pipeline_id','notes']),
+  workspaces:               new Set(['id','name','description','embedding_model','created_at']),
+  glossaries:               new Set(['id','name','description','source_language','target_language','created_at']),
+  projects:                 new Set(['id','name','source_language','target_language','workspace_id','created_at','updated_at','view_mode','source_display_text']),
+  app_settings:             new Set(['key','value']),
+  prompt_templates:         new Set(['id','name','prompt','default_model','default_provider','created_at','updated_at','context']),
+  pipelines:                new Set(['id','project_id','name','source_language','target_language','pipeline_mode','stages','judge_prompt','judge_model','judge_provider','use_chunking','words_per_chunk','source_display_text','source_processing_text','source_footnotes','review_provider_options','persona','custom_source_language','custom_target_language','blob_budget_tokens','blob_overlap','coherence_prompt','run_status','last_run_config','run_in_progress','created_at','updated_at']),
+  project_glossaries:       new Set(['project_id','glossary_id']),
+  glossary_entries:         new Set(['id','glossary_id','term','translation','notes','context','created_at']),
+  translations:             new Set(['id','project_id','original_text','final_translation','source_display_text','source_processing_text','translation_display_text','translation_processing_text','position','chunk_status','stage_results','judge_status','judge_rating','translation_locked','judge_issues','created_at','coherence_result','footnotes','blob_id','blob_order','blob_reference_chunk_ids','pipeline_id','notes']),
+  phrase_memory_presets:    new Set(['id','name','is_builtin','config','created_at']),
+  phrase_memory:            new Set(['id','workspace_id','source_phrase','target_phrase','source_language','target_language','author','work','domain','tags','notes','chunk_id','project_id','embedding','created_at']),
+  source_phrase_embeddings: new Set(['id','project_id','chunk_id','source_phrase','embedding','created_at']),
 };
 
 const DELETE_ORDER = [
+  'source_phrase_embeddings',
+  'phrase_memory',
+  'phrase_memory_presets',
   'translations',
   'glossary_entries',
   'project_glossaries',
@@ -41,6 +52,7 @@ const DELETE_ORDER = [
   'glossaries',
   'prompt_templates',
   'app_settings',
+  'workspaces',
 ] as const;
 
 type BackupTable = typeof INSERT_ORDER[number];

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -202,7 +202,7 @@ describe('initDatabase migrations', () => {
 
     await initDatabase();
 
-    const seedCalls = (dbState.db.execute.mock.calls as [string, unknown[]][]).filter(
+    const seedCalls = (dbState.db.execute.mock.calls as unknown as [string, unknown[]][]).filter(
       ([q]) => q.includes('INSERT OR IGNORE INTO phrase_memory_presets'),
     );
     expect(seedCalls).toHaveLength(4);
@@ -218,18 +218,14 @@ describe('initDatabase migrations', () => {
     );
   });
 
-  it('creates default workspace and sets it active on fresh database', async () => {
+  it('does not auto-create a default workspace', async () => {
     const { initDatabase } = await import('./dbService');
 
     await initDatabase();
 
-    expect(dbState.db.execute).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT OR IGNORE INTO workspaces'),
-      expect.arrayContaining(['ws_default', 'Default']),
+    const calls = (dbState.db.execute.mock.calls as unknown as [string, unknown[]][]).filter(
+      ([q]) => q.includes('INSERT') && q.includes('workspaces') && !q.includes('phrase_memory'),
     );
-    expect(dbState.db.execute).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE app_settings SET value = ? WHERE key = 'active_workspace_id'"),
-      expect.arrayContaining(['ws_default']),
-    );
+    expect(calls).toHaveLength(0);
   });
 });

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -587,23 +587,6 @@ export async function initDatabase(): Promise<void> {
   const { seedBuiltinPresets } = await import('./phraseMemoryPresetService');
   await seedBuiltinPresets(conn);
 
-  // Crea workspace di default se non ne esiste nessuno
-  const wsCount = await conn.select<Array<{ count: number }>>(
-    `SELECT COUNT(*) as count FROM workspaces`
-  );
-  if ((wsCount[0]?.count ?? 0) === 0) {
-    const wsId = `ws_default`;
-    await conn.execute(
-      `INSERT OR IGNORE INTO workspaces (id, name, embedding_model, created_at)
-       VALUES (?, ?, ?, ?)`,
-      [wsId, 'Default', 'text-embedding-3-small', new Date().toISOString()],
-    );
-    await conn.execute(
-      `UPDATE app_settings SET value = ? WHERE key = 'active_workspace_id'`,
-      [wsId],
-    );
-  }
-
   console.log('[Glossa] Database initialized');
 }
 

--- a/src/services/embeddingService.ts
+++ b/src/services/embeddingService.ts
@@ -1,0 +1,21 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { EmbeddingModel } from '../types';
+
+const COST_PER_MILLION_TOKENS: Record<EmbeddingModel, number> = {
+  'text-embedding-3-small': 0.02,
+  'text-embedding-3-large': 0.13,
+};
+
+export async function fetchEmbeddings(texts: string[], model: EmbeddingModel): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  return invoke<number[][]>('get_embeddings', { texts, model });
+}
+
+export function estimateEmbeddingCostUsd(tokenCount: number, model: EmbeddingModel): number {
+  return tokenCount * (COST_PER_MILLION_TOKENS[model] / 1_000_000);
+}
+
+export function estimateTokenCount(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.split(/\s+/).length * 1.3);
+}

--- a/src/services/phraseMemoryService.ts
+++ b/src/services/phraseMemoryService.ts
@@ -36,6 +36,7 @@ export async function splitPhrases(sourceText: string, splitter: PhraseMemorySpl
 
 export interface EmbeddingJobOptions {
   workspaceId: string;
+  projectId: string;
   embeddingModel: EmbeddingModel;
   splitter: PhraseMemorySplitter;
   chunks: Array<{ id: string; text: string }>;
@@ -43,7 +44,7 @@ export interface EmbeddingJobOptions {
 }
 
 export async function runEmbeddingJob(options: EmbeddingJobOptions): Promise<void> {
-  const { workspaceId, embeddingModel, splitter, chunks, onProgress } = options;
+  const { projectId, embeddingModel, splitter, chunks, onProgress } = options;
 
   const allPhrases: Array<{ chunkId: string; phrase: string }> = [];
   for (const chunk of chunks) {
@@ -65,7 +66,7 @@ export async function runEmbeddingJob(options: EmbeddingJobOptions): Promise<voi
       const embedding = vectors[j];
       if (!embedding) continue;
       const { chunkId, phrase } = batch[j];
-      await invoke('vec_upsert_source_phrase', { workspaceId, chunkId, phrase, embedding });
+      await invoke('vec_upsert_source_phrase', { projectId, chunkId, phrase, embedding });
       totalTokens += estimateTokenCount(phrase);
     }
 
@@ -112,26 +113,34 @@ export async function searchPhraseMemory(options: SearchOptions): Promise<Phrase
 
 export interface SaveLockedPhrasesOptions {
   workspaceId: string;
+  projectId: string;
   chunkId: string;
   embeddingModel: EmbeddingModel;
   splitter: PhraseMemorySplitter;
   sourceText: string;
   targetText: string;
   minPhraseLength: number;
+  sourceLanguage: string;
+  targetLanguage: string;
 }
 
 export async function saveLockedPhrases(options: SaveLockedPhrasesOptions): Promise<void> {
-  const { workspaceId, chunkId, embeddingModel, splitter, sourceText, targetText, minPhraseLength } = options;
+  const {
+    workspaceId, projectId, chunkId, embeddingModel, splitter,
+    sourceText, targetText, minPhraseLength, sourceLanguage, targetLanguage,
+  } = options;
 
   const sourcePhrases = await splitPhrases(sourceText, splitter);
   const targetPhrases = await splitPhrases(targetText, splitter);
   const pairCount = Math.min(sourcePhrases.length, targetPhrases.length);
   if (pairCount === 0) return;
 
-  const paired = sourcePhrases.slice(0, pairCount).map((sp, i) => ({
-    sourcePhrase: sp,
-    targetPhrase: targetPhrases[i],
-  }));
+  const paired = sourcePhrases
+    .slice(0, pairCount)
+    .map((sp, i) => ({ sourcePhrase: sp, targetPhrase: targetPhrases[i] }))
+    .filter((p) => p.sourcePhrase.length >= minPhraseLength);
+
+  if (paired.length === 0) return;
 
   const sourceVectors = await fetchEmbeddings(paired.map((p) => p.sourcePhrase), embeddingModel);
   const pairs = paired.map((p, i) => ({
@@ -140,5 +149,7 @@ export async function saveLockedPhrases(options: SaveLockedPhrasesOptions): Prom
     sourceEmbedding: sourceVectors[i] ?? [],
   }));
 
-  await invoke('vec_save_locked_phrases', { workspaceId, chunkId, pairs, minPhraseLength });
+  await invoke('vec_save_locked_phrases', {
+    workspaceId, projectId, chunkId, pairs, minPhraseLength, sourceLanguage, targetLanguage,
+  });
 }

--- a/src/services/phraseMemoryService.ts
+++ b/src/services/phraseMemoryService.ts
@@ -1,0 +1,144 @@
+import { invoke } from '@tauri-apps/api/core';
+import { logger } from '../utils/logger';
+import type { EmbeddingModel, PhraseMatch, PhraseMemorySplitter } from '../types';
+import { fetchEmbeddings, estimateEmbeddingCostUsd, estimateTokenCount } from './embeddingService';
+
+const MIN_PHRASE_CHARS = 3;
+const EMBEDDING_BATCH_SIZE = 20;
+
+// ── Sentence Splitter ────────────────────────────────────────────────
+
+function splitByRegex(text: string): string[] {
+  return text
+    .split(/[.;:]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= MIN_PHRASE_CHARS);
+}
+
+export async function splitPhrases(sourceText: string, splitter: PhraseMemorySplitter): Promise<string[]> {
+  switch (splitter) {
+    case 'none':
+      return [sourceText];
+    case 'regex':
+      return splitByRegex(sourceText);
+    case 'llm': {
+      try {
+        return await invoke<string[]>('split_phrases_llm', { sourceText });
+      } catch (err) {
+        logger.warn('split_phrases_llm failed, fallback a regex', { error: String(err) });
+        return splitByRegex(sourceText);
+      }
+    }
+  }
+}
+
+// ── Job pre-generazione embedding ───────────────────────────────────
+
+export interface EmbeddingJobOptions {
+  workspaceId: string;
+  embeddingModel: EmbeddingModel;
+  splitter: PhraseMemorySplitter;
+  chunks: Array<{ id: string; text: string }>;
+  onProgress: (processed: number, total: number, estimatedCostUsd: number) => void;
+}
+
+export async function runEmbeddingJob(options: EmbeddingJobOptions): Promise<void> {
+  const { workspaceId, embeddingModel, splitter, chunks, onProgress } = options;
+
+  const allPhrases: Array<{ chunkId: string; phrase: string }> = [];
+  for (const chunk of chunks) {
+    const phrases = await splitPhrases(chunk.text, splitter);
+    for (const phrase of phrases) {
+      allPhrases.push({ chunkId: chunk.id, phrase });
+    }
+  }
+
+  const total = allPhrases.length;
+  let processed = 0;
+  let totalTokens = 0;
+
+  for (let i = 0; i < allPhrases.length; i += EMBEDDING_BATCH_SIZE) {
+    const batch = allPhrases.slice(i, i + EMBEDDING_BATCH_SIZE);
+    const vectors = await fetchEmbeddings(batch.map((p) => p.phrase), embeddingModel);
+
+    for (let j = 0; j < batch.length; j++) {
+      const embedding = vectors[j];
+      if (!embedding) continue;
+      const { chunkId, phrase } = batch[j];
+      await invoke('vec_upsert_source_phrase', { workspaceId, chunkId, phrase, embedding });
+      totalTokens += estimateTokenCount(phrase);
+    }
+
+    processed += batch.length;
+    onProgress(Math.min(processed, total), total, estimateEmbeddingCostUsd(totalTokens, embeddingModel));
+  }
+}
+
+// ── Search pre-pipeline ──────────────────────────────────────────────
+
+export interface SearchOptions {
+  workspaceId: string;
+  embeddingModel: EmbeddingModel;
+  queryText: string;
+  threshold: number;
+  maxResults: number;
+}
+
+type RawPhraseMatch = {
+  phrase_memory_id: string;
+  source_phrase: string;
+  target_phrase: string;
+  distance: number;
+};
+
+export async function searchPhraseMemory(options: SearchOptions): Promise<PhraseMatch[]> {
+  const { workspaceId, embeddingModel, queryText, threshold, maxResults } = options;
+  const [queryEmbedding] = await fetchEmbeddings([queryText], embeddingModel);
+  if (!queryEmbedding) return [];
+
+  const raw = await invoke<RawPhraseMatch[]>('vec_search_phrase_memory', {
+    workspaceId, queryEmbedding, threshold, maxResults,
+  });
+
+  return raw.map((r) => ({
+    phraseMemoryId: r.phrase_memory_id,
+    sourcePhrase: r.source_phrase,
+    targetPhrase: r.target_phrase,
+    distance: r.distance,
+  }));
+}
+
+// ── Save on lock ─────────────────────────────────────────────────────
+
+export interface SaveLockedPhrasesOptions {
+  workspaceId: string;
+  chunkId: string;
+  embeddingModel: EmbeddingModel;
+  splitter: PhraseMemorySplitter;
+  sourceText: string;
+  targetText: string;
+  minPhraseLength: number;
+}
+
+export async function saveLockedPhrases(options: SaveLockedPhrasesOptions): Promise<void> {
+  const { workspaceId, chunkId, embeddingModel, splitter, sourceText, targetText, minPhraseLength } = options;
+
+  const sourcePhrases = await splitPhrases(sourceText, splitter);
+  const targetPhrases = await splitPhrases(targetText, splitter);
+  const pairCount = Math.min(sourcePhrases.length, targetPhrases.length);
+  if (pairCount === 0) return;
+
+  const paired = sourcePhrases.slice(0, pairCount).map((sp, i) => ({
+    sourcePhrase: sp,
+    targetPhrase: targetPhrases[i],
+  }));
+
+  const sourceVectors = await fetchEmbeddings(paired.map((p) => p.sourcePhrase), embeddingModel);
+  const pairs = paired.map((p, i) => ({
+    sourcePhrase: p.sourcePhrase,
+    targetPhrase: p.targetPhrase,
+    sourceEmbedding: sourceVectors[i] ?? [],
+  }));
+
+  await invoke('vec_save_locked_phrases', { workspaceId, chunkId, pairs, minPhraseLength });
+}

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -59,8 +59,11 @@ export interface SavedTranslation {
 
 // ── Projects CRUD ────────────────────────────────────────────────────
 
-export async function listProjects(): Promise<Project[]> {
-  return select<Project>('SELECT * FROM projects ORDER BY updated_at DESC');
+export async function listProjects(workspaceId: string): Promise<Project[]> {
+  return select<Project>(
+    'SELECT * FROM projects WHERE workspace_id = $1 ORDER BY updated_at DESC',
+    [workspaceId],
+  );
 }
 
 export async function getProject(id: string): Promise<Project | null> {
@@ -72,12 +75,13 @@ export async function createProject(
   name: string,
   sourceLang: string,
   targetLang: string,
+  workspaceId: string,
 ): Promise<string> {
   const id = `proj-${Date.now()}`;
   await execute(
-    `INSERT INTO projects (id, name, source_language, target_language)
-     VALUES ($1, $2, $3, $4)`,
-    [id, name, sourceLang, targetLang],
+    `INSERT INTO projects (id, name, source_language, target_language, workspace_id)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [id, name, sourceLang, targetLang, workspaceId],
   );
   // Create default pipeline for this project.
   const pipelineId = `pipeline-${Date.now()}`;

--- a/src/stores/__tests__/phraseMemoryStore.test.ts
+++ b/src/stores/__tests__/phraseMemoryStore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { usePhraseMemoryStore } from '../phraseMemoryStore';
+
+describe('phraseMemoryStore', () => {
+  beforeEach(() => {
+    usePhraseMemoryStore.getState().reset();
+  });
+
+  it('stato iniziale corretto', () => {
+    const { matchesByChunkId, jobStatus } = usePhraseMemoryStore.getState();
+    expect(matchesByChunkId).toEqual({});
+    expect(jobStatus).toEqual({ kind: 'idle' });
+  });
+
+  it('setMatches aggiorna i match per un chunk', () => {
+    const { result } = renderHook(() => usePhraseMemoryStore());
+    const matches = [{ phraseMemoryId: 'pm-1', sourcePhrase: 'ciao', targetPhrase: 'hello', distance: 0.1 }];
+
+    act(() => { result.current.setMatches('chunk-1', matches); });
+
+    expect(result.current.matchesByChunkId['chunk-1']).toEqual(matches);
+  });
+
+  it('clearMatches rimuove solo il chunk specificato', () => {
+    const store = usePhraseMemoryStore.getState();
+    store.setMatches('chunk-1', [{ phraseMemoryId: 'pm-1', sourcePhrase: 'a', targetPhrase: 'b', distance: 0.1 }]);
+    store.setMatches('chunk-2', [{ phraseMemoryId: 'pm-2', sourcePhrase: 'c', targetPhrase: 'd', distance: 0.2 }]);
+
+    store.clearMatches('chunk-1');
+
+    const state = usePhraseMemoryStore.getState();
+    expect(state.matchesByChunkId['chunk-1']).toBeUndefined();
+    expect(state.matchesByChunkId['chunk-2']).toBeDefined();
+  });
+
+  it('setJobStatus aggiorna lo stato del job', () => {
+    const { result } = renderHook(() => usePhraseMemoryStore());
+
+    act(() => {
+      result.current.setJobStatus({ kind: 'running', processed: 5, total: 20, estimatedCostUsd: 0.002 });
+    });
+
+    expect(result.current.jobStatus).toMatchObject({ kind: 'running', processed: 5, total: 20 });
+  });
+
+  it('reset ripristina lo stato iniziale', () => {
+    const store = usePhraseMemoryStore.getState();
+    store.setMatches('chunk-1', [{ phraseMemoryId: 'pm-1', sourcePhrase: 'x', targetPhrase: 'y', distance: 0.05 }]);
+    store.setJobStatus({ kind: 'done', totalPhrases: 42 });
+
+    store.reset();
+
+    const state = usePhraseMemoryStore.getState();
+    expect(state.matchesByChunkId).toEqual({});
+    expect(state.jobStatus).toEqual({ kind: 'idle' });
+  });
+});

--- a/src/stores/phraseMemoryStore.ts
+++ b/src/stores/phraseMemoryStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import type { EmbeddingJobStatus, PhraseMatch } from '../types';
+
+type PhraseMemoryState = {
+  matchesByChunkId: Record<string, PhraseMatch[]>;
+  jobStatus: EmbeddingJobStatus;
+  setMatches: (chunkId: string, matches: PhraseMatch[]) => void;
+  clearMatches: (chunkId: string) => void;
+  setJobStatus: (status: EmbeddingJobStatus) => void;
+  reset: () => void;
+};
+
+const INITIAL_STATE = {
+  matchesByChunkId: {} as Record<string, PhraseMatch[]>,
+  jobStatus: { kind: 'idle' } as EmbeddingJobStatus,
+};
+
+export const usePhraseMemoryStore = create<PhraseMemoryState>((set) => ({
+  ...INITIAL_STATE,
+
+  setMatches: (chunkId, matches) =>
+    set((state) => ({ matchesByChunkId: { ...state.matchesByChunkId, [chunkId]: matches } })),
+
+  clearMatches: (chunkId) =>
+    set((state) => {
+      const { [chunkId]: _removed, ...rest } = state.matchesByChunkId;
+      return { matchesByChunkId: rest };
+    }),
+
+  setJobStatus: (status) => set({ jobStatus: status }),
+
+  reset: () => set({ ...INITIAL_STATE }),
+}));

--- a/src/stores/projectStore.test.ts
+++ b/src/stores/projectStore.test.ts
@@ -7,6 +7,16 @@ import type { SavedTranslation } from '../services/projectService';
 import type { Pipeline } from '../types';
 import { buildProjectSnapshot } from '../utils/projectSnapshot';
 
+// ── workspaceStore mock ───────────────────────────────────────────────
+
+vi.mock('./workspaceStore', () => ({
+  useWorkspaceStore: {
+    getState: () => ({
+      activeWorkspace: { id: 'ws-test', name: 'Test', embeddingModel: 'text-embedding-3-small', createdAt: '2024-01-01T00:00:00Z' },
+    }),
+  },
+}));
+
 // ── DB mock (runInTransaction, loadOperationLogs) ─────────────────────
 
 const dbMocks = vi.hoisted(() => ({
@@ -304,7 +314,7 @@ describe('projectStore', () => {
 
     await useProjectStore.getState().saveCurrentProject('My Draft');
 
-    expect(projectServiceMocks.createProject).toHaveBeenCalledWith('My Draft', 'English', 'Italian');
+    expect(projectServiceMocks.createProject).toHaveBeenCalledWith('My Draft', 'English', 'Italian', 'ws-test');
     expect(projectServiceMocks.saveProjectSource).toHaveBeenCalledWith(
       'proj-first-save',
       'Draft text',

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -26,6 +26,7 @@ import { useOperationLogStore } from './operationLogStore';
 import { buildProjectSnapshot } from '../utils/projectSnapshot';
 import { logger } from '../utils/logger';
 import { runInTransaction } from '../services/dbService';
+import { useWorkspaceStore } from './workspaceStore';
 import type { Pipeline, PipelineConfig } from '../types';
 
 let saveInFlight: Promise<void> | null = null;
@@ -82,7 +83,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 
   loadProjects: async () => {
-    const projects = await listProjects();
+    const { activeWorkspace } = useWorkspaceStore.getState();
+    if (!activeWorkspace) { set({ projects: [] }); return; }
+    const projects = await listProjects(activeWorkspace.id);
     set({ projects });
   },
 
@@ -90,8 +93,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const pipeline = usePipelineStore.getState();
     const ui = useUiStore.getState();
     const chunks = useChunksStore.getState().chunks;
+    const { activeWorkspace } = useWorkspaceStore.getState();
+    if (!activeWorkspace) throw new Error('No active workspace');
 
-    const id = await createProject(name, pipeline.config.sourceLanguage, pipeline.config.targetLanguage);
+    const id = await createProject(name, pipeline.config.sourceLanguage, pipeline.config.targetLanguage, activeWorkspace.id);
 
     const pipelines = await listPipelines(id);
     const activePipelineId = pipelines[0]?.id ?? null;
@@ -257,7 +262,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
         if (!currentProjectId) {
           if (!name?.trim()) throw new Error('Project name required for first save.');
-          currentProjectId = await createProject(name.trim(), pipeline.config.sourceLanguage, pipeline.config.targetLanguage);
+          const { activeWorkspace } = useWorkspaceStore.getState();
+          if (!activeWorkspace) throw new Error('No active workspace');
+          currentProjectId = await createProject(name.trim(), pipeline.config.sourceLanguage, pipeline.config.targetLanguage, activeWorkspace.id);
           const pipelines = await listPipelines(currentProjectId);
           activePipelineId = pipelines[0]?.id ?? null;
           newPipelines = pipelines;

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -10,6 +10,8 @@ type WorkspaceStore = {
   workspaces: Workspace[];
   activeWorkspace: Workspace | null;
   loading: boolean;
+  /** true dopo il primo caricamento completato (successo o errore). */
+  isLoaded: boolean;
   loadWorkspaces: () => Promise<void>;
   setActive: (workspace: Workspace) => Promise<void>;
 };
@@ -18,6 +20,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
   workspaces: [],
   activeWorkspace: null,
   loading: false,
+  isLoaded: false,
 
   loadWorkspaces: async () => {
     set({ loading: true });
@@ -27,9 +30,9 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
         getActiveWorkspaceId(),
       ]);
       const activeWorkspace = workspaces.find((w) => w.id === activeId) ?? null;
-      set({ workspaces, activeWorkspace, loading: false });
+      set({ workspaces, activeWorkspace, loading: false, isLoaded: true });
     } catch (err) {
-      set({ loading: false });
+      set({ loading: false, isLoaded: true });
       throw err;
     }
   },

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -29,7 +29,11 @@ export const useWorkspaceStore = create<WorkspaceStore>((set) => ({
         listWorkspaces(),
         getActiveWorkspaceId(),
       ]);
-      const activeWorkspace = workspaces.find((w) => w.id === activeId) ?? null;
+      const found = workspaces.find((w) => w.id === activeId);
+      const activeWorkspace = found ?? workspaces[0] ?? null;
+      if (!found && activeWorkspace) {
+        await setActiveWorkspaceId(activeWorkspace.id);
+      }
       set({ workspaces, activeWorkspace, loading: false, isLoaded: true });
     } catch (err) {
       set({ loading: false, isLoaded: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,3 +246,16 @@ export type PhraseMemoryPreset = {
   config: PhraseMemoryPresetConfig;
   createdAt: string;
 };
+
+export type PhraseMatch = {
+  phraseMemoryId: string;
+  sourcePhrase: string;
+  targetPhrase: string;
+  distance: number;
+};
+
+export type EmbeddingJobStatus =
+  | { kind: 'idle' }
+  | { kind: 'running'; processed: number; total: number; estimatedCostUsd: number }
+  | { kind: 'done'; totalPhrases: number }
+  | { kind: 'error'; message: string };


### PR DESCRIPTION
## Summary

- **Piano 2 embedding search**: `embeddingService`, `phraseMemoryService` (splitter/job/search/save-on-lock), `phraseMemoryStore`, 5 comandi Rust (`get_embeddings`, `split_phrases_llm`, `vec_upsert_source_phrase`, `vec_search_phrase_memory`, `vec_save_locked_phrases`)
- **Workspace shell gating**: rimozione ghost workspace `ws_default`, `App.tsx` a 3 stati (first-run → workspace home → editor), nuovo `WorkspaceHome.tsx`
- **Hook lock chunk**: `DocumentView` chiama `saveLockedPhrases` fire-and-forget al lock

## Stato

- 40 test frontend passano
- `tsc --noEmit`: zero errori
- `cargo clippy -- -D warnings`: zero errori
- PR target: `feat/phrase-memory` (non main)

## Test plan

- [ ] DB vuoto: l'app mostra `WorkspaceWizard`, non crea `ws_default`
- [ ] Dopo creazione workspace: mostra `WorkspaceHome` con lista progetti vuota
- [ ] Dopo apertura progetto: mostra editor normale senza regressioni
- [ ] Lock chunk con workspace attivo: `saveLockedPhrases` chiamato (visibile nei log)
- [ ] Backup/import continuano a funzionare dalla `WorkspaceHome`