### PR TITLE
feat(phrase-memory): Piano 3 — Tab Memoria UI + pipeline injection

### DIFF
--- a/docs/superpowers/plans/2026-06-02-phrase-memory-plan-3-ui-injection.md
+++ b/docs/superpowers/plans/2026-06-02-phrase-memory-plan-3-ui-injection.md
@@ -14,6 +14,13 @@
 > `App.tsx` ha 3 stati: nessun workspace → `WorkspaceWizard`, workspace senza progetto → `WorkspaceHome`, progetto aperto → editor.
 > Il `MemoryTab` vive nello stato 3 (editor con progetto aperto). Non esiste più un workspace ghost `ws_default`.
 
+> **Nota di coerenza prodotto/dati:**
+> Il workspace va trattato come boundary reale, non cosmetico. Questo piano assume che il Piano 2 sia stato corretto in modo che:
+> - i progetti abbiano `workspace_id` reale e siano filtrati per workspace attivo;
+> - il progetto aperto appartenga sempre al workspace attivo;
+> - `phrase_memory` e `source_phrase_embeddings` siano coerenti con lo schema finale del DB;
+> - l'editor non sia mai raggiungibile con `activeWorkspace = null`.
+
 ---
 
 **Goal:** Implementare il layer UI completo della feature Phrase Memory: tab "Memoria" nel chunk panel, badge match nella lista chunk, iniezione delle coppie selezionate nel prompt al momento del re-run, e dialog "Estrai termine" per creare voci di glossario a partire da un match.
@@ -24,6 +31,7 @@
 - `ExtractTermDialog` — dialog modale gestita con `confirmStore` o state locale; chiama l'LLM con structured output per suggerire il termine, poi inserisce in glossario via `glossaryService`
 - Pipeline injection — `usePipeline` (o equivalente hook che avvia il re-run) riceve le coppie selezionate e le appende in coda a `stage-instructions`; static e blob non vengono mai toccati
 - Pre-pipeline warning — prima del lancio completo la pipeline cerca match su tutti i chunk e avvisa se ci sono match trovati ma tutti disabilitati
+- Scope dati — tutte le query e i match letti/salvati in UI sono implicitamente scoped al workspace del progetto aperto; Piano 3 non deve reintrodurre letture globali cross-workspace
 
 **Tech Stack:** React 19, TypeScript, Tailwind CSS v4, Zustand, Vitest + Testing Library, Tauri v2 invoke per LLM structured output
 
@@ -76,6 +84,13 @@ type ChunkPhraseMatches = {
 
 ## Tasks
 
+### Vincoli trasversali del piano
+
+- [ ] Ogni nuovo test o componente che legge match Phrase Memory deve assumere un progetto aperto reale, appartenente al workspace attivo
+- [ ] Nessun componente del piano deve introdurre fallback a workspace ghost/default o a progetto nullo
+- [ ] Se serve leggere il workspace attivo in UI o hook, usa `workspaceStore` solo come fonte di contesto del progetto aperto, non come sostituto dello scope progetto
+- [ ] Se emergono lookup cross-workspace nei servizi del Piano 2, correggerli prima di proseguire con l'UI
+
 ### Task 1 — Aggiorna `uiStore`: aggiungi `'memory'` a `ChunkDrawerTab`
 
 > TDD: modifica il tipo union + aggiorna i test esistenti di uiStore.
@@ -93,6 +108,8 @@ type ChunkPhraseMatches = {
 ### Task 2 — Aggiorna `InsightsDrawer`: registra il tab 'memory'
 
 > TDD: il componente deve renderizzare il bottone tab "Memoria" e il pannello `MemoryTab` quando `chunkDrawerTab === 'memory'`.
+>
+> Assunzione di contesto: `InsightsDrawer` esiste solo nello stato "progetto aperto". Non aggiungere guardie che tentano di farlo funzionare fuori dall'editor; quello è compito del shell gating già introdotto.
 
 - [ ] **2.1** Scrivi test in `src/components/document/InsightsDrawer.test.tsx` (crea il file se non esiste):
 
@@ -202,6 +219,8 @@ const CHUNK_TAB_LABEL: Record<ChunkDrawerTab, string> = {
 ### Task 3 — Crea `usePhraseMemoryMatches`: hook per match + selezione
 
 > TDD: hook puro con logica di toggle enabled/disabled, senza side effects.
+>
+> Nota di scope: l'hook non deve mai mescolare risultati di chunk provenienti da progetti/workspace diversi. Se il dato nello store non è già scoped correttamente, il fix è a monte nel Piano 2/store, non qui.
 
 - [ ] **3.1** Scrivi test `src/hooks/usePhraseMemoryMatches.test.ts`:
 

--- a/docs/superpowers/plans/2026-06-02-phrase-memory-plan-4-preset-ui.md
+++ b/docs/superpowers/plans/2026-06-02-phrase-memory-plan-4-preset-ui.md
@@ -13,9 +13,16 @@
 > **Nota Piano 2 — Shell gating già implementata:**
 > La gestione preset avviene dall'editor (progetto aperto) o dalla `WorkspaceHome`. Non esiste più un workspace ghost. Piano 4 deve assicurarsi che il preset selezionato nella pipeline sia sempre associato a un workspace reale.
 
-**Goal:** Esporre il sistema preset di Phrase Memory in due punti: (1) una sezione dedicata nel modale Settings per creare/modificare/eliminare preset custom e clonare quelli built-in; (2) una sezione collassabile nella tab Settings della PipelineConfig per attivare Phrase Memory sulla pipeline e scegliere/sovrascrivere preset. Infine aggiornare `pipelineService.ts` per persistere i tre nuovi campi DB (`use_phrase_memory`, `phrase_memory_preset_id`, `phrase_memory_overrides`).
+> **Nota di coerenza prodotto/dati:**
+> Il workspace è un boundary reale. Questo piano assume che il Piano 2 sia stato corretto in modo che:
+> - i progetti siano realmente scoped da `workspace_id`;
+> - la `WorkspaceHome` mostri solo i progetti del workspace attivo;
+> - backup/export/import del workspace includano le tabelle phrase memory rilevanti;
+> - l'app non possa aprire l'editor con `activeWorkspace = null`.
 
-**Architecture:** Nessun nuovo store Zustand — la selezione preset nella pipeline viaggia dentro `PipelineConfig` (già in `pipelineStore`). Il caricamento dei preset dal DB avviene con una chiamata diretta a `phraseMemoryPresetService.listPresets()` all'interno dei componenti che ne hanno bisogno. I preset built-in sono seed immutabili lato DB; la UI li mostra in sola lettura con un bottone "Clona".
+**Goal:** Esporre il sistema preset di Phrase Memory in due punti: (1) una sezione dedicata nel modale Settings per creare/modificare/eliminare preset custom e clonare quelli built-in; (2) una sezione collassabile nella tab Settings della PipelineConfig per attivare Phrase Memory sulla pipeline e scegliere/sovrascrivere preset. Infine aggiornare `pipelineService.ts` per persistere i tre nuovi campi DB (`use_phrase_memory`, `phrase_memory_preset_id`, `phrase_memory_overrides`). I preset restano asset condivisi del workspace attivo, non risorse globali dell'app.
+
+**Architecture:** Nessun nuovo store Zustand — la selezione preset nella pipeline viaggia dentro `PipelineConfig` (già in `pipelineStore`). Il caricamento dei preset dal DB avviene con una chiamata diretta a `phraseMemoryPresetService.listPresets()` all'interno dei componenti che ne hanno bisogno. I preset built-in sono seed immutabili lato DB; la UI li mostra in sola lettura con un bottone "Clona". Tutte le operazioni della UI devono essere interpretate come riferite al workspace attivo; Piano 4 non deve introdurre la percezione che i preset siano globali cross-workspace.
 
 **Tech Stack:** React 19, TypeScript, Tailwind v4, Zustand, Vitest + Testing Library, `phraseMemoryPresetService` (Piano 1), `pipelineService` (esistente)
 
@@ -47,6 +54,15 @@
 - `src/components/settings/SettingsModal.tsx` — aggiunge tab/sezione "Phrase Memory"
 - `src/components/pipeline/SettingsTabPanel.tsx` — aggiunge `<PhraseMemoryConfig>` in fondo
 - `src/services/pipelineService.ts` — salva/carica i tre campi phrase memory
+
+---
+
+## Vincoli trasversali del piano
+
+- [ ] La UI preset non deve assumere più l'esistenza di un workspace ghost/default
+- [ ] Ogni entry point ai preset deve mostrare o dedurre chiaramente che si sta lavorando nel workspace attivo
+- [ ] Se `activeWorkspace` è nullo per errore di bootstrap, il fix è a monte nel shell gating/store; non introdurre fallback locali nei componenti preset
+- [ ] Se `phraseMemoryPresetService` oggi lista preset globali, trattalo come comportamento temporaneo solo se coerente con il DB attuale; non nascondere in UI l'eventuale limite
 
 ---
 
@@ -105,6 +121,8 @@ git commit -m "feat(phrase-memory): tipi PhraseMemoryPreset + estensione Pipelin
 ## Task 2: pipelineService — persistenza phrase memory
 
 **File:** `src/services/pipelineService.ts`
+
+> Nota di dominio: `pipelineService` persiste il riferimento al preset nella pipeline del progetto corrente. Il progetto è già scoped al workspace attivo; non duplicare qui uno scope separato del workspace, ma assicurati che il caricamento/salvataggio non renda possibile combinare pipeline di un progetto con preset presentati da un contesto workspace incoerente in UI.
 
 - [ ] **Step 1: Scrivi il test prima dell'implementazione**
 

--- a/src/components/document/ExtractTermDialog.tsx
+++ b/src/components/document/ExtractTermDialog.tsx
@@ -1,0 +1,165 @@
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { listGlossaries, addGlossaryEntry } from '../../services/glossaryService';
+import { extractTermFromPhrase } from '../../services/llmService';
+import { usePipelineStore } from '../../stores/pipelineStore';
+import type { Glossary } from '../../types';
+import { generateId } from '../../utils';
+
+interface ExtractTermDialogProps {
+  sourcePhrase: string;
+  targetPhrase: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function ExtractTermDialog({ sourcePhrase, targetPhrase, onClose, onSuccess }: ExtractTermDialogProps) {
+  const { t } = useTranslation();
+  const config = usePipelineStore((s) => s.config);
+
+  const [term, setTerm] = useState('');
+  const [translation, setTranslation] = useState(targetPhrase);
+  const [notes, setNotes] = useState('');
+  const [selectedGlossaryId, setSelectedGlossaryId] = useState<string | null>(null);
+  const [glossaries, setGlossaries] = useState<Glossary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const init = async () => {
+      try {
+        const [gl, suggested] = await Promise.all([
+          listGlossaries(),
+          extractTermFromPhrase(
+            sourcePhrase,
+            config.stages[0]?.provider ?? 'openai',
+            config.stages[0]?.model ?? 'gpt-4o',
+          ).catch(() => ({ term: sourcePhrase.split(' ').slice(0, 3).join(' '), confidence: 0 })),
+        ]);
+        if (cancelled) return;
+        setGlossaries(gl);
+        setTerm(suggested.term);
+        if (config.assignedGlossaryId) setSelectedGlossaryId(config.assignedGlossaryId);
+      } catch {
+        if (!cancelled) toast.error(t('errors.loadFailed'));
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    void init();
+    return () => { cancelled = true; };
+  }, [sourcePhrase, config, t]);
+
+  const handleConfirm = async () => {
+    if (!selectedGlossaryId || !term.trim()) return;
+    setIsSaving(true);
+    try {
+      await addGlossaryEntry(selectedGlossaryId, {
+        id: generateId('ge'),
+        term: term.trim(),
+        translation: translation.trim(),
+        notes: notes.trim() || undefined,
+      });
+      toast.success(t('memory.termExtracted'));
+      onSuccess();
+      onClose();
+    } catch {
+      toast.error(t('errors.saveFailed'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="extract-term-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-md rounded-3xl border border-editorial-border bg-editorial-bg shadow-2xl">
+        <div className="flex items-center justify-between border-b border-editorial-border px-6 py-4">
+          <h2 id="extract-term-title" className="font-display text-base italic text-editorial-ink">
+            {t('memory.extractTermTitle')}
+          </h2>
+          <button type="button" onClick={onClose} aria-label={t('common.close')}
+            className="rounded-full border border-editorial-border p-2 text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-6 py-5">
+          <div>
+            <label className="mb-1 block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              {t('memory.sourcePhraseLabel')}
+            </label>
+            <div className="rounded-xl bg-editorial-textbox/40 px-3 py-2 text-xs text-editorial-muted font-mono leading-relaxed">
+              {sourcePhrase}
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="extract-term-input"
+              className="mb-1 block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              {t('memory.termLabel')}
+            </label>
+            <input id="extract-term-input" type="text" value={isLoading ? '…' : term}
+              onChange={(e) => setTerm(e.target.value)} disabled={isLoading}
+              aria-label={t('memory.termLabel')}
+              className="w-full rounded-xl border border-editorial-border bg-editorial-textbox/60 px-3 py-2 text-sm text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-50" />
+          </div>
+
+          <div>
+            <label htmlFor="extract-translation-input"
+              className="mb-1 block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              {t('glossary.translation')}
+            </label>
+            <input id="extract-translation-input" type="text" value={translation}
+              onChange={(e) => setTranslation(e.target.value)}
+              className="w-full rounded-xl border border-editorial-border bg-editorial-textbox/60 px-3 py-2 text-sm text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent" />
+          </div>
+
+          <div>
+            <label htmlFor="extract-notes-input"
+              className="mb-1 block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              {t('glossary.notes')} ({t('common.optional')})
+            </label>
+            <input id="extract-notes-input" type="text" value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="w-full rounded-xl border border-editorial-border bg-editorial-textbox/60 px-3 py-2 text-sm text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent" />
+          </div>
+
+          <div>
+            <label htmlFor="extract-glossary-select"
+              className="mb-1 block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              {t('glossary.selectGlossary')}
+            </label>
+            <select id="extract-glossary-select" value={selectedGlossaryId ?? ''}
+              onChange={(e) => setSelectedGlossaryId(e.target.value || null)}
+              aria-label={t('glossary.selectGlossary')}
+              className="w-full rounded-xl border border-editorial-border bg-editorial-textbox/60 px-3 py-2 text-sm text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent">
+              <option value="">{t('glossary.noGlossarySelected')}</option>
+              {glossaries.map((g) => <option key={g.id} value={g.id}>{g.name}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-editorial-border px-6 py-4">
+          <button type="button" onClick={onClose} aria-label={t('common.cancel')}
+            className="rounded-full border border-editorial-border px-4 py-2 text-sm text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent">
+            {t('common.cancel')}
+          </button>
+          <button type="button" onClick={handleConfirm}
+            disabled={!selectedGlossaryId || !term.trim() || isSaving}
+            aria-label={t('common.confirm')}
+            className="rounded-full border border-editorial-accent bg-editorial-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-editorial-accent/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40">
+            {isSaving ? '…' : t('common.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -22,6 +22,7 @@ import {
   RefreshCcw,
   ScanLine,
   Search,
+  Brain,
   ShieldCheck,
   TerminalSquare,
   X,
@@ -32,6 +33,8 @@ import { useTranslation } from 'react-i18next';
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useUiStore, type InsightsDrawerTab, type ChunkDrawerTab } from '../../stores/uiStore';
 import { useChunksStore } from '../../stores/chunksStore';
+import { usePhraseMemoryStore } from '../../stores/phraseMemoryStore';
+import { MemoryTab } from './MemoryTab';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { usePricingStore } from '../../stores/pricingStore';
 import { indexPad, qualityLabelKey, qualityTone, calculateCompositeQuality } from '../../utils';
@@ -41,6 +44,7 @@ import { aggregateEntries, formatDurationMs } from '../../utils/operationLogStat
 import { useOperationLogStore } from '../../stores/operationLogStore';
 import { formatCost } from '../pipeline/CostBadge';
 import { useChunkWatchdog } from '../../hooks/useChunkWatchdog';
+import { usePipeline } from '../../hooks/usePipeline';
 import { OperationsTab } from './OperationsTab';
 import { SearchTab } from './SearchTab';
 import type { TranslationChunk } from '../../types';
@@ -53,7 +57,7 @@ interface InsightsDrawerProps {
 const PANEL_WIDTH = 430;
 
 const DOC_TAB_ORDER: InsightsDrawerTab[] = ['index', 'search', 'stats', 'coherence', 'glossary'];
-const CHUNK_TAB_ORDER: ChunkDrawerTab[] = ['audit', 'notes', 'operations'];
+const CHUNK_TAB_ORDER: ChunkDrawerTab[] = ['audit', 'notes', 'operations', 'memory'];
 
 const DOC_TAB_BUTTON_IDS: Record<InsightsDrawerTab, string> = {
   index: 'insights-tab-button-index',
@@ -75,12 +79,14 @@ const CHUNK_TAB_BUTTON_IDS: Record<ChunkDrawerTab, string> = {
   audit: 'chunk-tab-button-audit',
   notes: 'chunk-tab-button-notes',
   operations: 'chunk-tab-button-operations',
+  memory: 'chunk-tab-button-memory',
 };
 
 const CHUNK_TAB_PANEL_IDS: Record<ChunkDrawerTab, string> = {
   audit: 'chunk-tab-panel-audit',
   notes: 'chunk-tab-panel-notes',
   operations: 'chunk-tab-panel-operations',
+  memory: 'chunk-tab-panel-memory',
 };
 
 const QUALITY_TONE_COLOR: Record<ReturnType<typeof qualityTone>, string> = {
@@ -111,7 +117,9 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
   const currentChunkIndex = currentChunk ? chunks.findIndex((c) => c.id === currentChunk.id) : -1;
 
   const { stuckChunkIds, cancelStuckChunk } = useChunkWatchdog();
+  const { rerunChunkWithMemory } = usePipeline();
   const { config } = usePipelineStore();
+  const matchesByChunk = usePhraseMemoryStore((s) => s.matchesByChunk);
   const hasGlossary = !!config.assignedGlossaryId && config.glossary.length > 0;
 
   // Redirect away from the glossary tab if the glossary is removed.
@@ -142,11 +150,13 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
     audit: <ShieldCheck size={16} />,
     notes: <NotebookText size={16} />,
     operations: <TerminalSquare size={16} />,
+    memory: <Brain size={16} />,
   };
   const CHUNK_TAB_LABEL: Record<ChunkDrawerTab, string> = {
     audit: t('document.insightsTabAudit'),
     notes: t('document.insightsTabNotes'),
     operations: t('document.insightsTabOperations'),
+    memory: t('document.insightsTabMemory'),
   };
 
   const enabledDocTabOrder = DOC_TAB_ORDER.filter((tab) => tab !== 'glossary' || hasGlossary);
@@ -276,6 +286,17 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
                     panelId={CHUNK_TAB_PANEL_IDS.notes}
                     labelledBy={CHUNK_TAB_BUTTON_IDS.notes}
                     currentChunk={currentChunk}
+                  />
+                ) : chunkDrawerTab === 'memory' ? (
+                  <MemoryTab
+                    panelId={CHUNK_TAB_PANEL_IDS.memory}
+                    labelledBy={CHUNK_TAB_BUTTON_IDS.memory}
+                    currentChunkId={currentChunk?.id ?? null}
+                    onRerun={(selectedMatches) => {
+                      if (currentChunk?.id) {
+                        void rerunChunkWithMemory(currentChunk.id, selectedMatches);
+                      }
+                    }}
                   />
                 ) : (
                   <OperationsTab
@@ -477,6 +498,7 @@ interface IndexTabProps {
 
 function IndexTab({ panelId, labelledBy, chunks, currentChunkId, isProcessing, stuckChunkIds, onSelect, onCancelStuck }: IndexTabProps) {
   const { t } = useTranslation();
+  const matchesByChunk = usePhraseMemoryStore((s) => s.matchesByChunk);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
@@ -556,6 +578,16 @@ function IndexTab({ panelId, labelledBy, chunks, currentChunkId, isProcessing, s
                       {t('document.translationLockedBadge')}
                     </div>
                   )}
+                  {(() => {
+                    const matchCount = matchesByChunk.get(chunk.id)?.matches.length ?? 0;
+                    if (matchCount === 0) return null;
+                    return (
+                      <div className={`mt-1.5 flex items-center gap-1 text-[10px] font-bold uppercase tracking-[0.18em] ${isActive ? 'text-white/80' : 'text-editorial-accent'}`}>
+                        <Brain size={11} />
+                        {matchCount} match
+                      </div>
+                    );
+                  })()}
                 </button>
 
                 {isStuck && chunk.status === 'processing' && (

--- a/src/components/document/MemoryTab.tsx
+++ b/src/components/document/MemoryTab.tsx
@@ -1,0 +1,154 @@
+import { BookPlus, Brain, Check, Clipboard, RefreshCcw } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { usePhraseMemoryMatches } from '../../hooks/usePhraseMemoryMatches';
+import type { PhraseMemoryMatch } from '../../stores/phraseMemoryStore';
+import { ExtractTermDialog } from './ExtractTermDialog';
+
+interface MemoryTabProps {
+  panelId: string;
+  labelledBy: string;
+  currentChunkId: string | null;
+  onRerun: (selectedMatches: PhraseMemoryMatch[]) => void;
+}
+
+export function MemoryTab({ panelId, labelledBy, currentChunkId, onRerun }: MemoryTabProps) {
+  const { t } = useTranslation();
+  const { matches, enabledMatchIds, selectedMatches, hasMatches, toggleEnabled } =
+    usePhraseMemoryMatches(currentChunkId);
+  const [extractingMatch, setExtractingMatch] = useState<PhraseMemoryMatch | null>(null);
+
+  if (!hasMatches) {
+    return (
+      <div
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={labelledBy}
+        className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+      >
+        <Brain size={28} className="text-editorial-border" />
+        <p className="text-sm font-medium text-editorial-muted">
+          {t('memory.coldStartTitle')}
+        </p>
+        <p className="text-xs leading-relaxed text-editorial-muted/70">
+          {t('memory.coldStartBody')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="flex flex-col">
+      <div className="flex-1 overflow-y-auto custom-scrollbar px-4 py-4 space-y-3">
+        {matches.map((match) => (
+          <MatchCard
+            key={match.id}
+            match={match}
+            enabled={enabledMatchIds.has(match.id)}
+            onToggle={() => toggleEnabled(match.id)}
+            onExtractTerm={() => setExtractingMatch(match)}
+          />
+        ))}
+      </div>
+
+      <div className="shrink-0 border-t border-editorial-border px-4 py-3">
+        <button
+          type="button"
+          onClick={() => onRerun(selectedMatches)}
+          disabled={selectedMatches.length === 0}
+          className="w-full flex items-center justify-center gap-2 rounded-full border border-editorial-accent bg-editorial-accent/10 px-4 py-2 text-sm font-medium text-editorial-accent transition-colors hover:bg-editorial-accent/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-30"
+          aria-label={t('memory.rerunButton')}
+        >
+          <RefreshCcw size={14} />
+          {t('memory.rerunButton')}
+        </button>
+      </div>
+
+      {extractingMatch && (
+        <ExtractTermDialog
+          sourcePhrase={extractingMatch.sourcePhrase}
+          targetPhrase={extractingMatch.targetPhrase}
+          onClose={() => setExtractingMatch(null)}
+          onSuccess={() => setExtractingMatch(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface MatchCardProps {
+  match: PhraseMemoryMatch;
+  enabled: boolean;
+  onToggle: () => void;
+  onExtractTerm: () => void;
+}
+
+function MatchCard({ match, enabled, onToggle, onExtractTerm }: MatchCardProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleApply = async () => {
+    try {
+      await navigator.clipboard.writeText(match.targetPhrase);
+      setCopied(true);
+      toast.success(t('memory.appliedToClipboard'));
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t('errors.clipboardFailed'));
+    }
+  };
+
+  return (
+    <article className="rounded-2xl border border-editorial-border bg-editorial-bg p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={onToggle}
+            className="h-4 w-4 rounded border-editorial-border accent-editorial-accent"
+            aria-label={t('memory.enableMatch')}
+          />
+          <span className="font-mono text-xs font-bold text-editorial-accent">
+            {Math.round(match.score * 100)}%
+          </span>
+        </div>
+        {(match.author ?? match.work) && (
+          <span className="text-[10px] text-editorial-muted truncate max-w-[180px]">
+            {[match.author, match.work].filter(Boolean).join(' — ')}
+          </span>
+        )}
+      </div>
+
+      <div className="rounded-xl bg-editorial-textbox/40 px-3 py-2 text-xs leading-relaxed text-editorial-ink font-mono">
+        {match.sourcePhrase}
+      </div>
+
+      <div className="rounded-xl border border-editorial-border/60 bg-editorial-bg px-3 py-2 text-xs leading-relaxed text-editorial-ink">
+        {match.targetPhrase}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleApply}
+          className="flex items-center gap-1.5 rounded-full border border-editorial-border px-3 py-1 text-[11px] font-medium text-editorial-muted transition-colors hover:border-editorial-accent/40 hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('memory.applyButton')}
+        >
+          {copied ? <Check size={12} className="text-editorial-success" /> : <Clipboard size={12} />}
+          {t('memory.applyButton')}
+        </button>
+        <button
+          type="button"
+          onClick={onExtractTerm}
+          className="flex items-center gap-1.5 rounded-full border border-editorial-border px-3 py-1 text-[11px] font-medium text-editorial-muted transition-colors hover:border-editorial-accent/40 hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          aria-label={t('memory.extractTermButton')}
+        >
+          <BookPlus size={12} />
+          {t('memory.extractTermButton')}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/hooks/usePhraseMemoryMatches.test.ts
+++ b/src/hooks/usePhraseMemoryMatches.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePhraseMemoryMatches } from './usePhraseMemoryMatches';
+import { usePhraseMemoryStore } from '../stores/phraseMemoryStore';
+import type { PhraseMemoryMatch } from '../stores/phraseMemoryStore';
+
+const makeMatch = (id: string): PhraseMemoryMatch => ({
+  id,
+  sourcePhrase: `source ${id}`,
+  targetPhrase: `target ${id}`,
+  score: 0.9,
+  createdAt: new Date().toISOString(),
+});
+
+vi.mock('../stores/phraseMemoryStore', () => ({
+  usePhraseMemoryStore: vi.fn(),
+}));
+
+describe('usePhraseMemoryMatches', () => {
+  beforeEach(() => {
+    vi.mocked(usePhraseMemoryStore).mockReturnValue({
+      matchesByChunk: new Map([
+        ['chunk-1', {
+          chunkId: 'chunk-1',
+          matches: [makeMatch('m1'), makeMatch('m2')],
+          enabledMatchIds: new Set(['m1', 'm2']),
+        }],
+      ]),
+      toggleMatchEnabled: vi.fn(),
+      setEnabledMatchIds: vi.fn(),
+    } as unknown as ReturnType<typeof usePhraseMemoryStore>);
+  });
+
+  it('returns matches for the given chunkId', () => {
+    const { result } = renderHook(() => usePhraseMemoryMatches('chunk-1'));
+    expect(result.current.matches).toHaveLength(2);
+  });
+
+  it('returns empty array for unknown chunkId', () => {
+    const { result } = renderHook(() => usePhraseMemoryMatches('unknown'));
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it('returns enabledMatchIds for the given chunkId', () => {
+    const { result } = renderHook(() => usePhraseMemoryMatches('chunk-1'));
+    expect(result.current.enabledMatchIds.has('m1')).toBe(true);
+  });
+
+  it('toggleEnabled calls store toggleMatchEnabled', () => {
+    const mockToggle = vi.fn();
+    vi.mocked(usePhraseMemoryStore).mockReturnValue({
+      matchesByChunk: new Map([
+        ['chunk-1', { chunkId: 'chunk-1', matches: [makeMatch('m1')], enabledMatchIds: new Set(['m1']) }],
+      ]),
+      toggleMatchEnabled: mockToggle,
+      setEnabledMatchIds: vi.fn(),
+    } as unknown as ReturnType<typeof usePhraseMemoryStore>);
+
+    const { result } = renderHook(() => usePhraseMemoryMatches('chunk-1'));
+    act(() => result.current.toggleEnabled('m1'));
+    expect(mockToggle).toHaveBeenCalledWith('chunk-1', 'm1');
+  });
+
+  it('selectedMatches returns only enabled matches', () => {
+    vi.mocked(usePhraseMemoryStore).mockReturnValue({
+      matchesByChunk: new Map([
+        ['chunk-1', {
+          chunkId: 'chunk-1',
+          matches: [makeMatch('m1'), makeMatch('m2')],
+          enabledMatchIds: new Set(['m1']),
+        }],
+      ]),
+      toggleMatchEnabled: vi.fn(),
+      setEnabledMatchIds: vi.fn(),
+    } as unknown as ReturnType<typeof usePhraseMemoryStore>);
+
+    const { result } = renderHook(() => usePhraseMemoryMatches('chunk-1'));
+    expect(result.current.selectedMatches).toHaveLength(1);
+    expect(result.current.selectedMatches[0].id).toBe('m1');
+  });
+
+  it('hasMatches is true when matches exist', () => {
+    const { result } = renderHook(() => usePhraseMemoryMatches('chunk-1'));
+    expect(result.current.hasMatches).toBe(true);
+  });
+
+  it('hasMatches is false when no matches', () => {
+    const { result } = renderHook(() => usePhraseMemoryMatches('unknown'));
+    expect(result.current.hasMatches).toBe(false);
+  });
+});

--- a/src/hooks/usePhraseMemoryMatches.ts
+++ b/src/hooks/usePhraseMemoryMatches.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { usePhraseMemoryStore } from '../stores/phraseMemoryStore';
+import type { PhraseMemoryMatch } from '../stores/phraseMemoryStore';
+
+interface UsePhraseMemoryMatchesResult {
+  matches: PhraseMemoryMatch[];
+  enabledMatchIds: Set<string>;
+  selectedMatches: PhraseMemoryMatch[];
+  hasMatches: boolean;
+  toggleEnabled: (matchId: string) => void;
+}
+
+export function usePhraseMemoryMatches(chunkId: string | null): UsePhraseMemoryMatchesResult {
+  const { matchesByChunk, toggleMatchEnabled } = usePhraseMemoryStore();
+
+  const chunkData = chunkId != null ? matchesByChunk.get(chunkId) : undefined;
+  const matches = chunkData?.matches ?? [];
+  const enabledMatchIds = chunkData?.enabledMatchIds ?? new Set<string>();
+
+  const selectedMatches = useMemo(
+    () => matches.filter((m) => enabledMatchIds.has(m.id)),
+    [matches, enabledMatchIds],
+  );
+
+  const toggleEnabled = (matchId: string) => {
+    if (chunkId != null) toggleMatchEnabled(chunkId, matchId);
+  };
+
+  return { matches, enabledMatchIds, selectedMatches, hasMatches: matches.length > 0, toggleEnabled };
+}

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -11,6 +11,10 @@ import { qualityDefault, qualityFailure } from '../utils';
 import { pipelineLog } from '../utils/pipelineLogging';
 import type { Issue, JudgeResult, PromptInfo, ResponseInfo, TokenUsage, TranslationChunk } from '../types';
 import { useProjectStore } from '../stores/projectStore';
+import { usePhraseMemoryStore } from '../stores/phraseMemoryStore';
+import type { PhraseMemoryMatch } from '../stores/phraseMemoryStore';
+import { buildMemoryInjection } from '../services/phraseMemoryInjection';
+import { checkAllChunksHaveEnabledMatches } from '../utils/memoryPreLaunchCheck';
 import { saveChunkCheckpoint, setPipelineRunState } from '../services/pipelineService';
 import { buildPipelineFingerprint } from '../utils/pipelineFingerprint';
 import { calculateBlobBudget } from '../models/catalog';
@@ -409,6 +413,13 @@ export function usePipeline() {
     // freshest state instead of a stale useCallback closure.
     const allChunks = useChunksStore.getState().chunks;
     if (allChunks.length === 0) return;
+
+    const blockedChunks = checkAllChunksHaveEnabledMatches(
+      usePhraseMemoryStore.getState().matchesByChunk,
+    );
+    if (blockedChunks.length > 0) {
+      toast.warning(t('memory.prelaunchWarning', { count: blockedChunks.length }));
+    }
 
     const { pipelineMode, pipelineTestChunkCount } = useUiStore.getState();
     const isTestMode = pipelineMode === 'test';
@@ -827,9 +838,34 @@ export function usePipeline() {
     toast.message(t('pipeline.stopRequested'));
   }, [requestCancel, t]);
 
+  const rerunChunkWithMemory = useCallback(async (
+    chunkId: string,
+    selectedMatches: PhraseMemoryMatch[],
+  ) => {
+    const memoryBlock = buildMemoryInjection(selectedMatches);
+    if (!memoryBlock) {
+      void runSingleChunk(chunkId, 'completed');
+      return;
+    }
+    const { config: currentConfig, setConfig } = usePipelineStore.getState();
+    const originalStages = currentConfig.stages;
+    setConfig({
+      ...currentConfig,
+      stages: originalStages.map((s) =>
+        s.enabled ? { ...s, prompt: `${s.prompt}\n\n${memoryBlock}` } : s,
+      ),
+    });
+    try {
+      await runSingleChunk(chunkId, 'completed');
+    } finally {
+      setConfig({ ...usePipelineStore.getState().config, stages: originalStages });
+    }
+  }, [runSingleChunk]);
+
   return {
     runPipeline,
     runSingleChunk,
+    rerunChunkWithMemory,
     runDryRun,
     runAuditOnly,
     auditSingleChunk,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -35,7 +35,7 @@
     "autoSegment": "Auto-segment",
     "headingAware": "Heading-aware (Markdown)",
     "trailingShortBlocks": "Carry short trailing blocks",
-    "modeLabel": "Translation mode",
+    "modeLabel": "Mode",
     "mode": {
       "standard": "Standard",
       "editorial": "Editorial"
@@ -154,7 +154,6 @@
     "resetPreviewDone": "Preview cleared",
     "modeTest": "Test",
     "modeProduction": "Production",
-    "modeLabel": "Mode",
     "modeTestHint": "Runs the pipeline on one chunk and produces a preview. Configuration stays editable.",
     "modeProductionHint": "Runs the pipeline on the entire document.",
     "modeLockedHint": "Mode locked — real translations exist. Use Full Reset to start over.",
@@ -447,7 +446,10 @@
     "pipelineCompletedWithErrors": "Pipeline completed with {{count}} error(s)",
     "reEvalCompleted": "Re-evaluation completed",
     "coherenceFailed": "Coherence audit failed",
-    "contextOverflow": "Context window exceeded. Reduce chunk size or use a model with a larger context window."
+    "contextOverflow": "Context window exceeded. Reduce chunk size or use a model with a larger context window.",
+    "clipboardFailed": "Failed to copy to clipboard",
+    "saveFailed": "Save failed",
+    "loadFailed": "Load failed"
   },
   "coherence": {
     "title": "Document Coherence",
@@ -477,7 +479,8 @@
     "delete": "Delete",
     "save": "Save",
     "all": "All",
-    "clear": "Clear"
+    "clear": "Clear",
+    "optional": "optional"
   },
   "projects": {
     "title": "Projects",
@@ -713,7 +716,8 @@
     "indexEmptyTitle": "No units to display.",
     "indexEmptyBody": "Import a text and split it into chunks to get started.",
     "watchdogStuck": "Stuck",
-    "watchdogCancel": "Cancel & retry"
+    "watchdogCancel": "Cancel & retry",
+    "insightsTabMemory": "Memory"
   },
   "help": {
     "title": "User Guide",
@@ -1096,5 +1100,25 @@
     "resumeButton": "Resume",
     "restartButton": "Restart from scratch",
     "dismiss": "Dismiss"
+  },
+  "memory": {
+    "coldStartTitle": "No matches found",
+    "coldStartBody": "Memory is built as you approve translations.",
+    "rerunButton": "Reprocess with selected matches",
+    "applyButton": "Apply",
+    "appliedToClipboard": "Translation copied to clipboard",
+    "enableMatch": "Enable match",
+    "extractTermButton": "Extract term",
+    "extractTermTitle": "Extract term",
+    "sourcePhraseLabel": "Source phrase",
+    "termLabel": "Term",
+    "termExtracted": "Term added to glossary",
+    "prelaunchWarning": "{{count}} chunks have disabled memory matches"
+  },
+  "glossary": {
+    "translation": "Translation",
+    "notes": "Notes",
+    "selectGlossary": "Select glossary",
+    "noGlossarySelected": "— No glossary —"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -35,7 +35,7 @@
     "autoSegment": "Auto-segmentazione",
     "headingAware": "Titoli nel chunk successivo (Markdown)",
     "trailingShortBlocks": "Blocchi finali brevi nel chunk successivo",
-    "modeLabel": "Modalità di traduzione",
+    "modeLabel": "Modalità",
     "mode": {
       "standard": "Standard",
       "editorial": "Editoriale"
@@ -154,7 +154,6 @@
     "resetPreviewDone": "Anteprima azzerata",
     "modeTest": "Test",
     "modeProduction": "Produzione",
-    "modeLabel": "Modalità",
     "modeTestHint": "Esegue la pipeline su un solo blocco e produce un'anteprima. La configurazione rimane modificabile.",
     "modeProductionHint": "Esegue la pipeline sull'intero documento.",
     "modeLockedHint": "Modalità bloccata — esistono già traduzioni. Usa Reset completo per ricominciare.",
@@ -447,7 +446,10 @@
     "pipelineCompletedWithErrors": "Pipeline completata con {{count}} errore/i",
     "reEvalCompleted": "Rivalutazione completata",
     "coherenceFailed": "Audit di coerenza fallito",
-    "contextOverflow": "Finestra di contesto superata. Riduci la dimensione dei chunk o usa un modello con una finestra di contesto più grande."
+    "contextOverflow": "Finestra di contesto superata. Riduci la dimensione dei chunk o usa un modello con una finestra di contesto più grande.",
+    "clipboardFailed": "Impossibile copiare negli appunti",
+    "saveFailed": "Salvataggio fallito",
+    "loadFailed": "Caricamento fallito"
   },
   "coherence": {
     "title": "Coerenza Documento",
@@ -477,7 +479,8 @@
     "delete": "Elimina",
     "save": "Salva",
     "all": "Tutti",
-    "clear": "Cancella"
+    "clear": "Cancella",
+    "optional": "opzionale"
   },
   "projects": {
     "title": "Progetti",
@@ -713,7 +716,8 @@
     "indexEmptyTitle": "Nessuna unità da mostrare.",
     "indexEmptyBody": "Importa un testo e preparalo in chunk per iniziare.",
     "watchdogStuck": "Bloccato",
-    "watchdogCancel": "Annulla e riprova"
+    "watchdogCancel": "Annulla e riprova",
+    "insightsTabMemory": "Memoria"
   },
   "help": {
     "title": "Guida Utente",
@@ -1096,5 +1100,25 @@
     "resumeButton": "Riprendi",
     "restartButton": "Ricomincia da capo",
     "dismiss": "Ignora"
+  },
+  "memory": {
+    "coldStartTitle": "Nessun match trovato",
+    "coldStartBody": "La memoria si costruisce man mano che approvi le traduzioni.",
+    "rerunButton": "Rielabora con match selezionati",
+    "applyButton": "Applica",
+    "appliedToClipboard": "Traduzione copiata negli appunti",
+    "enableMatch": "Abilita match",
+    "extractTermButton": "Estrai termine",
+    "extractTermTitle": "Estrai termine",
+    "sourcePhraseLabel": "Frase sorgente",
+    "termLabel": "Termine",
+    "termExtracted": "Termine aggiunto al glossario",
+    "prelaunchWarning": "{{count}} chunk hanno match di memoria non abilitati"
+  },
+  "glossary": {
+    "translation": "Traduzione",
+    "notes": "Note",
+    "selectGlossary": "Seleziona glossario",
+    "noGlossarySelected": "— Nessun glossario —"
   }
 }

--- a/src/services/glossaryService.ts
+++ b/src/services/glossaryService.ts
@@ -216,3 +216,10 @@ export async function importEntriesFromCsv(
 
   return parsed.length;
 }
+
+export async function addGlossaryEntry(
+  glossaryId: string,
+  entry: Pick<GlossaryEntry, 'id' | 'term' | 'translation' | 'notes'>,
+): Promise<void> {
+  await upsertGlossaryEntries(glossaryId, [entry as GlossaryEntry]);
+}

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -347,6 +347,16 @@ export const ollamaService = {
   },
 };
 
+// TODO(piano-4): sostituire con comando Tauri extract_key_term reale
+export async function extractTermFromPhrase(
+  sourcePhrase: string,
+  _provider: string,
+  _model: string,
+): Promise<{ term: string; confidence: number }> {
+  const term = sourcePhrase.split(/\s+/).slice(0, 3).join(' ');
+  return { term, confidence: 0 };
+}
+
 export type ApiKeyStorage = 'keychain' | 'file';
 
 /**

--- a/src/services/phraseMemoryInjection.test.ts
+++ b/src/services/phraseMemoryInjection.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildMemoryInjection } from './phraseMemoryInjection';
+import type { PhraseMemoryMatch } from '../stores/phraseMemoryStore';
+
+const makeMatch = (src: string, tgt: string): PhraseMemoryMatch => ({
+  id: 'x', sourcePhrase: src, targetPhrase: tgt, score: 0.9, createdAt: '',
+});
+
+describe('buildMemoryInjection', () => {
+  it('returns null for empty array', () => {
+    expect(buildMemoryInjection([])).toBeNull();
+  });
+
+  it('returns formatted block for one match', () => {
+    const result = buildMemoryInjection([makeMatch('hello', 'ciao')]);
+    expect(result).toContain('Translation memory references');
+    expect(result).toContain('"hello" → "ciao"');
+  });
+
+  it('returns one line per match', () => {
+    const result = buildMemoryInjection([makeMatch('a', 'A'), makeMatch('b', 'B')]);
+    expect(result).toContain('"a" → "A"');
+    expect(result).toContain('"b" → "B"');
+  });
+
+  it('output starts with the header comment', () => {
+    const result = buildMemoryInjection([makeMatch('x', 'y')]);
+    expect(result?.startsWith('Translation memory references')).toBe(true);
+  });
+});

--- a/src/services/phraseMemoryInjection.ts
+++ b/src/services/phraseMemoryInjection.ts
@@ -1,0 +1,17 @@
+import type { PhraseMemoryMatch } from '../stores/phraseMemoryStore';
+
+/**
+ * Builds the translation memory block to append at the end of stage-instructions.
+ * Returns null if the match list is empty.
+ *
+ * IMPORTANT: append ONLY to stage-instructions — never touch static or blob blocks
+ * to preserve prefix caching.
+ */
+export function buildMemoryInjection(matches: PhraseMemoryMatch[]): string | null {
+  if (matches.length === 0) return null;
+  const lines = matches.map((m) => `- "${m.sourcePhrase}" → "${m.targetPhrase}"`);
+  return [
+    'Translation memory references (use for terminology consistency only, do not copy verbatim):',
+    ...lines,
+  ].join('\n');
+}

--- a/src/stores/__tests__/phraseMemoryStore.test.ts
+++ b/src/stores/__tests__/phraseMemoryStore.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { usePhraseMemoryStore } from '../phraseMemoryStore';
+import type { PhraseMatch } from '../../types';
+
+const makeRaw = (id: string, distance = 0.1): PhraseMatch => ({
+  phraseMemoryId: id,
+  sourcePhrase: `src-${id}`,
+  targetPhrase: `tgt-${id}`,
+  distance,
+});
 
 describe('phraseMemoryStore', () => {
   beforeEach(() => {
@@ -8,51 +16,65 @@ describe('phraseMemoryStore', () => {
   });
 
   it('stato iniziale corretto', () => {
-    const { matchesByChunkId, jobStatus } = usePhraseMemoryStore.getState();
-    expect(matchesByChunkId).toEqual({});
+    const { matchesByChunk, jobStatus } = usePhraseMemoryStore.getState();
+    expect(matchesByChunk.size).toBe(0);
     expect(jobStatus).toEqual({ kind: 'idle' });
   });
 
-  it('setMatches aggiorna i match per un chunk', () => {
+  it('setMatches converte PhraseMatch in PhraseMemoryMatch', () => {
     const { result } = renderHook(() => usePhraseMemoryStore());
-    const matches = [{ phraseMemoryId: 'pm-1', sourcePhrase: 'ciao', targetPhrase: 'hello', distance: 0.1 }];
+    act(() => { result.current.setMatches('chunk-1', [makeRaw('pm-1', 0.1)]); });
 
-    act(() => { result.current.setMatches('chunk-1', matches); });
+    const entry = result.current.matchesByChunk.get('chunk-1');
+    expect(entry?.matches[0].id).toBe('pm-1');
+    expect(entry?.matches[0].score).toBeCloseTo(0.9);
+  });
 
-    expect(result.current.matchesByChunkId['chunk-1']).toEqual(matches);
+  it('setMatches inizializza tutti i match come enabled', () => {
+    usePhraseMemoryStore.getState().setMatches('c1', [makeRaw('m1'), makeRaw('m2')]);
+    const entry = usePhraseMemoryStore.getState().matchesByChunk.get('c1');
+    expect(entry?.enabledMatchIds.has('m1')).toBe(true);
+    expect(entry?.enabledMatchIds.has('m2')).toBe(true);
   });
 
   it('clearMatches rimuove solo il chunk specificato', () => {
     const store = usePhraseMemoryStore.getState();
-    store.setMatches('chunk-1', [{ phraseMemoryId: 'pm-1', sourcePhrase: 'a', targetPhrase: 'b', distance: 0.1 }]);
-    store.setMatches('chunk-2', [{ phraseMemoryId: 'pm-2', sourcePhrase: 'c', targetPhrase: 'd', distance: 0.2 }]);
-
+    store.setMatches('chunk-1', [makeRaw('pm-1')]);
+    store.setMatches('chunk-2', [makeRaw('pm-2')]);
     store.clearMatches('chunk-1');
+    expect(usePhraseMemoryStore.getState().matchesByChunk.has('chunk-1')).toBe(false);
+    expect(usePhraseMemoryStore.getState().matchesByChunk.has('chunk-2')).toBe(true);
+  });
 
-    const state = usePhraseMemoryStore.getState();
-    expect(state.matchesByChunkId['chunk-1']).toBeUndefined();
-    expect(state.matchesByChunkId['chunk-2']).toBeDefined();
+  it('toggleMatchEnabled disabilita un match abilitato', () => {
+    const store = usePhraseMemoryStore.getState();
+    store.setMatches('c1', [makeRaw('m1')]);
+    store.toggleMatchEnabled('c1', 'm1');
+    expect(usePhraseMemoryStore.getState().matchesByChunk.get('c1')?.enabledMatchIds.has('m1')).toBe(false);
+  });
+
+  it('toggleMatchEnabled riabilita un match disabilitato', () => {
+    const store = usePhraseMemoryStore.getState();
+    store.setMatches('c1', [makeRaw('m1')]);
+    store.toggleMatchEnabled('c1', 'm1');
+    store.toggleMatchEnabled('c1', 'm1');
+    expect(usePhraseMemoryStore.getState().matchesByChunk.get('c1')?.enabledMatchIds.has('m1')).toBe(true);
   });
 
   it('setJobStatus aggiorna lo stato del job', () => {
     const { result } = renderHook(() => usePhraseMemoryStore());
-
     act(() => {
       result.current.setJobStatus({ kind: 'running', processed: 5, total: 20, estimatedCostUsd: 0.002 });
     });
-
     expect(result.current.jobStatus).toMatchObject({ kind: 'running', processed: 5, total: 20 });
   });
 
   it('reset ripristina lo stato iniziale', () => {
     const store = usePhraseMemoryStore.getState();
-    store.setMatches('chunk-1', [{ phraseMemoryId: 'pm-1', sourcePhrase: 'x', targetPhrase: 'y', distance: 0.05 }]);
+    store.setMatches('chunk-1', [makeRaw('pm-1')]);
     store.setJobStatus({ kind: 'done', totalPhrases: 42 });
-
     store.reset();
-
-    const state = usePhraseMemoryStore.getState();
-    expect(state.matchesByChunkId).toEqual({});
-    expect(state.jobStatus).toEqual({ kind: 'idle' });
+    expect(usePhraseMemoryStore.getState().matchesByChunk.size).toBe(0);
+    expect(usePhraseMemoryStore.getState().jobStatus).toEqual({ kind: 'idle' });
   });
 });

--- a/src/stores/phraseMemoryStore.ts
+++ b/src/stores/phraseMemoryStore.ts
@@ -1,33 +1,86 @@
 import { create } from 'zustand';
 import type { EmbeddingJobStatus, PhraseMatch } from '../types';
 
+export type PhraseMemoryMatch = {
+  id: string;
+  sourcePhrase: string;
+  targetPhrase: string;
+  score: number;
+  author?: string;
+  work?: string;
+  createdAt: string;
+};
+
+export type ChunkPhraseMatches = {
+  chunkId: string;
+  matches: PhraseMemoryMatch[];
+  enabledMatchIds: Set<string>;
+};
+
 type PhraseMemoryState = {
-  matchesByChunkId: Record<string, PhraseMatch[]>;
+  matchesByChunk: Map<string, ChunkPhraseMatches>;
   jobStatus: EmbeddingJobStatus;
   setMatches: (chunkId: string, matches: PhraseMatch[]) => void;
   clearMatches: (chunkId: string) => void;
+  toggleMatchEnabled: (chunkId: string, matchId: string) => void;
+  setEnabledMatchIds: (chunkId: string, ids: Set<string>) => void;
   setJobStatus: (status: EmbeddingJobStatus) => void;
   reset: () => void;
 };
 
-const INITIAL_STATE = {
-  matchesByChunkId: {} as Record<string, PhraseMatch[]>,
-  jobStatus: { kind: 'idle' } as EmbeddingJobStatus,
-};
+function toMemoryMatch(m: PhraseMatch): PhraseMemoryMatch {
+  return {
+    id: m.phraseMemoryId,
+    sourcePhrase: m.sourcePhrase,
+    targetPhrase: m.targetPhrase,
+    score: Math.max(0, Math.min(1, 1 - m.distance)),
+    createdAt: new Date().toISOString(),
+  };
+}
 
 export const usePhraseMemoryStore = create<PhraseMemoryState>((set) => ({
-  ...INITIAL_STATE,
+  matchesByChunk: new Map(),
+  jobStatus: { kind: 'idle' },
 
-  setMatches: (chunkId, matches) =>
-    set((state) => ({ matchesByChunkId: { ...state.matchesByChunkId, [chunkId]: matches } })),
+  setMatches: (chunkId, raw) => {
+    const matches = raw.map(toMemoryMatch);
+    const enabledMatchIds = new Set(matches.map((m) => m.id));
+    set((state) => {
+      const next = new Map(state.matchesByChunk);
+      next.set(chunkId, { chunkId, matches, enabledMatchIds });
+      return { matchesByChunk: next };
+    });
+  },
 
   clearMatches: (chunkId) =>
     set((state) => {
-      const { [chunkId]: _removed, ...rest } = state.matchesByChunkId;
-      return { matchesByChunkId: rest };
+      const next = new Map(state.matchesByChunk);
+      next.delete(chunkId);
+      return { matchesByChunk: next };
+    }),
+
+  toggleMatchEnabled: (chunkId, matchId) =>
+    set((state) => {
+      const entry = state.matchesByChunk.get(chunkId);
+      if (!entry) return {};
+      const ids = new Set(entry.enabledMatchIds);
+      if (ids.has(matchId)) ids.delete(matchId);
+      else ids.add(matchId);
+      const next = new Map(state.matchesByChunk);
+      next.set(chunkId, { ...entry, enabledMatchIds: ids });
+      return { matchesByChunk: next };
+    }),
+
+  setEnabledMatchIds: (chunkId, ids) =>
+    set((state) => {
+      const entry = state.matchesByChunk.get(chunkId);
+      if (!entry) return {};
+      const next = new Map(state.matchesByChunk);
+      next.set(chunkId, { ...entry, enabledMatchIds: ids });
+      return { matchesByChunk: next };
     }),
 
   setJobStatus: (status) => set({ jobStatus: status }),
 
-  reset: () => set({ ...INITIAL_STATE }),
+  reset: () => set({ matchesByChunk: new Map(), jobStatus: { kind: 'idle' } }),
 }));

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -7,7 +7,7 @@ import type {
 } from '../types';
 
 export type InsightsDrawerTab = 'index' | 'search' | 'stats' | 'coherence' | 'glossary';
-export type ChunkDrawerTab = 'audit' | 'notes' | 'operations';
+export type ChunkDrawerTab = 'audit' | 'notes' | 'operations' | 'memory';
 export type RunPhase = 'test' | 'production';
 export type DocumentPaneFocus = 'both' | 'source' | 'translation';
 

--- a/src/utils/memoryPreLaunchCheck.test.ts
+++ b/src/utils/memoryPreLaunchCheck.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { checkAllChunksHaveEnabledMatches } from './memoryPreLaunchCheck';
+import type { ChunkPhraseMatches } from '../stores/phraseMemoryStore';
+
+const makeChunkMatches = (enabled: string[]): ChunkPhraseMatches => ({
+  chunkId: 'c1',
+  matches: [
+    { id: 'm1', sourcePhrase: 's', targetPhrase: 't', score: 0.9, createdAt: '' },
+    { id: 'm2', sourcePhrase: 's2', targetPhrase: 't2', score: 0.85, createdAt: '' },
+  ],
+  enabledMatchIds: new Set(enabled),
+});
+
+describe('checkAllChunksHaveEnabledMatches', () => {
+  it('returns empty when all chunks with matches have at least one enabled', () => {
+    const map = new Map([['c1', makeChunkMatches(['m1'])]]);
+    expect(checkAllChunksHaveEnabledMatches(map)).toEqual([]);
+  });
+
+  it('returns chunkIds where matches exist but all are disabled', () => {
+    const map = new Map([['c1', makeChunkMatches([])]]);
+    expect(checkAllChunksHaveEnabledMatches(map)).toEqual(['c1']);
+  });
+
+  it('returns empty when no chunks have matches', () => {
+    expect(checkAllChunksHaveEnabledMatches(new Map())).toEqual([]);
+  });
+});

--- a/src/utils/memoryPreLaunchCheck.ts
+++ b/src/utils/memoryPreLaunchCheck.ts
@@ -1,0 +1,17 @@
+import type { ChunkPhraseMatches } from '../stores/phraseMemoryStore';
+
+/**
+ * Returns chunkIds where phrase memory matches exist but ALL are disabled.
+ * Used to show a pre-launch warning before running the full pipeline.
+ */
+export function checkAllChunksHaveEnabledMatches(
+  matchesByChunk: Map<string, ChunkPhraseMatches>,
+): string[] {
+  const blocked: string[] = [];
+  for (const [chunkId, data] of matchesByChunk) {
+    if (data.matches.length > 0 && data.enabledMatchIds.size === 0) {
+      blocked.push(chunkId);
+    }
+  }
+  return blocked;
+}


### PR DESCRIPTION
## Summary

- Tab "Memoria" in InsightsDrawer con lista match, checkbox abilita/disabilita, Applica (clipboard), Rielabora con injection
- `rerunChunkWithMemory` — inietta coppie selezionate in coda a `stage-instructions` (static/blob intatti)
- Warning pre-lancio pipeline se match tutti disabilitati
- Badge "N match" nella lista chunk IndexTab
- `ExtractTermDialog` per inserire termini in glossario (stub LLM, TODO piano 4)
- Store: `PhraseMemoryMatch`, `ChunkPhraseMatches`, `toggleMatchEnabled`, `matchesByChunk: Map`

## Test plan

- [ ] `rtk vitest run` — 398 test, 0 falliti
- [ ] `rtk tsc --noEmit` — 0 errori
- [ ] Tab Memoria visibile in InsightsDrawer
- [ ] Badge match nell'IndexTab