### PR TITLE
fix: increase non-streaming request timeout 120s → 300s

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,8 @@
 | File | Responsabilità |
 |---|---|
 | `hooks/usePipeline.ts` | **Engine principale** — runPipeline, runSingleChunk, auditSingleChunk, cancelPipeline. 3 blocchi blob assembler duplicati (refactor pendente). |
+
+> **INVARIANTE — non toccare senza motivo esplicito**: Ollama usa `runStageStream` (streaming). Tutti gli altri provider (OpenAI, Anthropic, Gemini, DeepSeek) usano `runStage` (non-streaming). Questa separazione è intenzionale: i cloud provider hanno timeout e gestione errori diversi. Non "uniformare" i due path.
 | `hooks/useProjectAutosave.ts` | Autosave con debounce |
 | `hooks/useChunkWatchdog.ts` | Timeout detection per chunk inattivi |
 

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -19,7 +19,7 @@ use crate::llm::provider::{LlmProvider, StreamFormat, UsageAccumulator};
 // ── Timeout constants ────────────────────────────────────────────────
 
 pub(crate) const HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
-pub(crate) const HTTP_REQUEST_TIMEOUT_SECS: u64 = 120;
+pub(crate) const HTTP_REQUEST_TIMEOUT_SECS: u64 = 300;
 pub(crate) const OLLAMA_HTTP_REQUEST_TIMEOUT_SECS: u64 = 300;
 pub(crate) const HTTP_STREAM_HEADER_TIMEOUT_SECS: u64 = 30;
 pub(crate) const HTTP_STREAM_IDLE_TIMEOUT_SECS: u64 = 30;


### PR DESCRIPTION
## Summary

- Aumenta `HTTP_REQUEST_TIMEOUT_SECS` da 120s a 300s per i client HTTP non-streaming dei cloud provider
- gpt-5.4 con reasoning attivo o documenti grandi (28K+ token) supera regolarmente i 2 minuti → timeout → retry loop infinito
- Aggiunto invariante in ARCHITECTURE.md: Ollama usa streaming, cloud provider usano non-streaming — non cambiare senza motivo esplicito

## Test plan

- [ ] Ricompilare con `npm run tauri:dev`
- [ ] Eseguire una pipeline su chunk grande con gpt-5.4
- [ ] Verificare che non scatti il timeout a 2 minuti
- [ ] Verificare che il retry non parta per timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)