### PR TITLE
chore: hardening pre-1.0 (#232 + #233)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,21 +279,17 @@ Overall average: **60-90% token reduction** on common development operations.
 <!-- code-review-graph MCP tools -->
 ## MCP Tools: code-review-graph
 
-**IMPORTANT: This project has a knowledge graph. ALWAYS use the
-code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
-the codebase.** The graph is faster, cheaper (fewer tokens), and gives
-you structural context (callers, dependents, test coverage) that file
-scanning cannot.
+This project has a knowledge graph built by a hook at every file change. When the `code-review-graph` MCP tools are available in session, prefer them over Grep/Glob/Read — they are faster, cheaper (fewer tokens), and give structural context (callers, dependents, test coverage) that file scanning cannot.
 
-### When to use graph tools FIRST
+**If the tools are not connected** (not listed in the available tool set), fall back to Grep/Glob/Read normally.
+
+### When to use graph tools (when available)
 
 - **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
 - **Understanding impact**: `get_impact_radius` instead of manually tracing imports
 - **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
 - **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
 - **Architecture questions**: `get_architecture_overview` + `list_communities`
-
-Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
 
 ### Key Tools
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,12 +346,10 @@ source_phrase_embeddings
 
 | Area | Descrizione | Priorità |
 |---|---|---|
-| `hooks/usePipeline.ts` | 3 blocchi blob assembler identici da estrarre in helper condiviso | bassa (cosmesi) |
-| `src-tauri/src/llm/providers/anthropic.rs` | Supporto reasoning da rivedere (verifica integrazione, parametri, formato risposta) | alta |
-| `src-tauri/src/llm/providers/deepseek.rs` | Supporto reasoning da rivedere (verifica integrazione, parametri, formato risposta) | alta |
-| `src-tauri/src/llm/providers/gemini.rs` | Supporto reasoning da rivedere (verifica integrazione, parametri, formato risposta) | alta |
+| `src-tauri/src/llm/providers/anthropic.rs` | Reasoning non supportato: nessun campo `thinking` nella request, parsing assume `content[0]` sia testo (corretto senza thinking). Per abilitare: aggiungere `"thinking": {"type":"enabled","budget_tokens":N}` + filtrare blocchi `"type":"thinking"` nel parsing. | alta |
+| `src-tauri/src/llm/providers/gemini.rs` | Reasoning parziale: `thinkingConfig.thinkingBudget` inviato se configurato, ma parsing usa `parts[0]` — se thinking attivo, `parts[0]` è il blocco thinking (campo `thought:true`), non il testo finale. Fix: cercare il primo part senza `thought:true`. | alta |
 | OpenAI gpt-5.x — prompt caching | Bug lato OpenAI: prefix caching non funziona in modo affidabile su tutta la famiglia gpt-5 (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.4). Su gpt-4o funziona al 100%. Thread community aperto da ott 2025, non risolto a gen 2026. Da monitorare; non fixabile lato Glossa. Ref: [community.openai.com/t/1359574](https://community.openai.com/t/caching-is-borked-for-gpt-5-models/1359574) | monitoraggio |
 
 ---
 
-*Ultimo aggiornamento: 2026-06-06 — branch feat/phrase-memory*
+*Ultimo aggiornamento: 2026-06-08 — branch chore/hardening-pre-1.0*

--- a/src/components/library/LibraryPanel.tsx
+++ b/src/components/library/LibraryPanel.tsx
@@ -13,8 +13,8 @@ import { EditorialModalShell } from '../common';
 import { IconButton } from '../ui';
 
 const TABS: { id: LibraryTab; labelKey: string }[] = [
-  { id: 'dictionaries', labelKey: 'library.tabDictionaries' },
   { id: 'templates', labelKey: 'library.tabTemplates' },
+  { id: 'dictionaries', labelKey: 'library.tabDictionaries' },
   { id: 'memories', labelKey: 'library.tabMemories' },
 ];
 

--- a/src/components/library/MemoriesTab.tsx
+++ b/src/components/library/MemoriesTab.tsx
@@ -1,15 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Brain, Check, Loader2, Pencil, RefreshCcw, Trash2, X } from 'lucide-react';
+import { BookMarked, Brain, Check, Loader2, Pencil, RefreshCcw, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
   deletePhraseMemoryEntry,
+  getChunkPositions,
   listPhraseMemoryEntries,
   updatePhraseMemoryEntry,
   type PhraseMemoryEntry,
 } from '../../services/phraseMemoryService';
+import { addGlossaryEntry, getGlossaryEntries } from '../../services/glossaryService';
+import { listProjects } from '../../services/projectService';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { useLibraryStore } from '../../stores/libraryStore';
 import { confirm } from '../../stores/confirmStore';
+import { generateId } from '../../utils';
 import { IconButton, SectionLabel } from '../ui';
 import type { Workspace } from '../../types';
 
@@ -17,17 +22,25 @@ export function MemoriesTab() {
   const { t } = useTranslation();
   const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const glossaries = useLibraryStore((s) => s.glossaries);
   const [entries, setEntries] = useState<PhraseMemoryEntry[]>([]);
+  const [projectNameMap, setProjectNameMap] = useState<Record<string, string>>({});
+  const [chunkPositionMap, setChunkPositionMap] = useState<Record<string, number>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [workspaceFilter, setWorkspaceFilter] = useState<string>('all');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftSource, setDraftSource] = useState('');
   const [draftTarget, setDraftTarget] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [pickerOpenId, setPickerOpenId] = useState<string | null>(null);
+  const [pickerGlossaryId, setPickerGlossaryId] = useState<string>('');
+  const [addingId, setAddingId] = useState<string | null>(null);
 
   const loadEntries = useCallback(async () => {
     if (workspaces.length === 0) {
       setEntries([]);
+      setProjectNameMap({});
+      setChunkPositionMap({});
       return;
     }
     setIsLoading(true);
@@ -40,11 +53,20 @@ export function MemoriesTab() {
       const results = await Promise.all(
         targetWorkspaces.map((workspace) => listPhraseMemoryEntries(workspace.id)),
       );
-      setEntries(
-        results
-          .flat()
-          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-      );
+      const loaded = results
+        .flat()
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      setEntries(loaded);
+
+      const uniqueWsIds = [...new Set(loaded.map((e) => e.workspaceId))];
+      const projectLists = await Promise.all(uniqueWsIds.map((id) => listProjects(id).catch(() => [])));
+      const projectMap: Record<string, string> = {};
+      projectLists.flat().forEach((p) => { projectMap[p.id] = p.name; });
+      setProjectNameMap(projectMap);
+
+      const chunkIds = loaded.map((e) => e.chunkId).filter((id): id is string => id !== null);
+      const posMap = await getChunkPositions(chunkIds).catch(() => ({}));
+      setChunkPositionMap(posMap);
     } catch (err: unknown) {
       toast.error(t('library.memoryLoadError'), {
         description: err instanceof Error ? err.message : String(err),
@@ -59,6 +81,7 @@ export function MemoriesTab() {
   }, [loadEntries]);
 
   const startEdit = (entry: PhraseMemoryEntry) => {
+    setPickerOpenId(null);
     setEditingId(entry.id);
     setDraftSource(entry.sourcePhrase);
     setDraftTarget(entry.targetPhrase);
@@ -114,6 +137,32 @@ export function MemoriesTab() {
       });
     } finally {
       setBusyId(null);
+    }
+  };
+
+  const handleAddToGlossary = async (entry: PhraseMemoryEntry, glossaryId: string) => {
+    if (!glossaryId) return;
+    setAddingId(entry.id);
+    try {
+      await addGlossaryEntry(glossaryId, {
+        id: generateId('gle'),
+        term: entry.sourcePhrase,
+        translation: entry.targetPhrase,
+      });
+      const freshEntries = await getGlossaryEntries(glossaryId);
+      const store = useLibraryStore.getState();
+      store.setGlossaryEntries(glossaryId, freshEntries);
+      setPickerOpenId(null);
+      setPickerGlossaryId('');
+      toast.success(t('library.addedToGlossary'));
+      store.setShowLibraryPanel(true, 'dictionaries');
+      store.setExpandedGlossaryId(glossaryId);
+    } catch (err: unknown) {
+      toast.error(t('library.addToGlossaryError'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setAddingId(null);
     }
   };
 
@@ -192,6 +241,8 @@ export function MemoriesTab() {
           {entries.map((entry) => {
             const isEditing = editingId === entry.id;
             const isBusy = busyId === entry.id;
+            const isAdding = addingId === entry.id;
+            const isPickerOpen = pickerOpenId === entry.id;
             return (
               <article
                 key={entry.id}
@@ -205,9 +256,11 @@ export function MemoriesTab() {
                     <p className="mt-1 truncate text-xs text-editorial-muted/80">
                       {workspaceName(entry.workspaceId, workspaces)} · {formatDate(entry.createdAt)}
                     </p>
-                    <EmbeddingModelBadge
-                      entryModel={entry.embeddingModel}
-                      workspaceModel={workspaces.find((w) => w.id === entry.workspaceId)?.embeddingModel ?? null}
+                    <OriginLine
+                      entry={entry}
+                      projectNameMap={projectNameMap}
+                      chunkPositionMap={chunkPositionMap}
+                      workspaceEmbeddingModel={workspaces.find((w) => w.id === entry.workspaceId)?.embeddingModel ?? null}
                     />
                   </div>
                   <div className="flex shrink-0 items-center gap-1.5">
@@ -233,6 +286,24 @@ export function MemoriesTab() {
                       </>
                     ) : (
                       <>
+                        <IconButton
+                          size="sm"
+                          tone={isPickerOpen ? 'accent' : 'default'}
+                          onClick={() => {
+                            if (isPickerOpen) {
+                              setPickerOpenId(null);
+                              setPickerGlossaryId('');
+                            } else {
+                              setEditingId(null);
+                              setPickerOpenId(entry.id);
+                              setPickerGlossaryId(glossaries[0]?.id ?? '');
+                            }
+                          }}
+                          title={t('library.addToGlossary')}
+                          disabled={busyId !== null || isAdding || glossaries.length === 0}
+                        >
+                          {isAdding ? <Loader2 size={13} className="animate-spin" /> : <BookMarked size={13} />}
+                        </IconButton>
                         <IconButton
                           size="sm"
                           onClick={() => startEdit(entry)}
@@ -279,6 +350,17 @@ export function MemoriesTab() {
                     </div>
                   </div>
                 )}
+
+                {isPickerOpen && (
+                  <GlossaryPicker
+                    glossaries={glossaries}
+                    selectedId={pickerGlossaryId}
+                    isAdding={isAdding}
+                    onSelect={setPickerGlossaryId}
+                    onConfirm={() => void handleAddToGlossary(entry, pickerGlossaryId)}
+                    onCancel={() => { setPickerOpenId(null); setPickerGlossaryId(''); }}
+                  />
+                )}
               </article>
             );
           })}
@@ -287,6 +369,92 @@ export function MemoriesTab() {
     </div>
   );
 }
+
+// ── Origin line ───────────────────────────────────────────────────────────────
+// Single compact line: ProjectName · chunk:N · embeddingModel
+
+function OriginLine({
+  entry,
+  projectNameMap,
+  chunkPositionMap,
+  workspaceEmbeddingModel,
+}: {
+  entry: PhraseMemoryEntry;
+  projectNameMap: Record<string, string>;
+  chunkPositionMap: Record<string, number>;
+  workspaceEmbeddingModel: string | null;
+}) {
+  const parts: string[] = [];
+
+  if (entry.projectId) {
+    parts.push(projectNameMap[entry.projectId] ?? entry.projectId.slice(0, 8) + '…');
+  }
+  if (entry.chunkId) {
+    const pos = chunkPositionMap[entry.chunkId];
+    parts.push(pos !== undefined ? `chunk:${pos + 1}` : `chunk:${entry.chunkId.slice(0, 6)}…`);
+  }
+  if (entry.embeddingModel) {
+    parts.push(entry.embeddingModel);
+  }
+
+  if (parts.length === 0) return null;
+
+  const stale = entry.embeddingModel !== workspaceEmbeddingModel;
+  return (
+    <p className={`mt-1 font-mono text-[10px] ${stale ? 'text-editorial-accent/80' : 'text-editorial-muted/50'}`}>
+      {parts.join(' · ')}
+    </p>
+  );
+}
+
+// ── Glossary picker ───────────────────────────────────────────────────────────
+
+interface GlossaryPickerProps {
+  glossaries: { id: string; name: string }[];
+  selectedId: string;
+  isAdding: boolean;
+  onSelect: (id: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function GlossaryPicker({ glossaries, selectedId, isAdding, onSelect, onConfirm, onCancel }: GlossaryPickerProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="mt-3 flex items-center gap-2 rounded-[14px] border border-editorial-accent/30 bg-editorial-textbox/20 px-3 py-2.5">
+      <select
+        value={selectedId}
+        onChange={(e) => onSelect(e.target.value)}
+        disabled={isAdding}
+        className="min-w-0 flex-1 rounded-full border border-editorial-border bg-editorial-bg px-3 py-1.5 text-xs text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-50"
+        aria-label={t('glossary.selectGlossary')}
+      >
+        {glossaries.map((g) => (
+          <option key={g.id} value={g.id}>{g.name}</option>
+        ))}
+      </select>
+      <IconButton
+        size="sm"
+        tone="accent"
+        onClick={onConfirm}
+        title={t('common.confirm')}
+        disabled={isAdding || !selectedId}
+      >
+        {isAdding ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+      </IconButton>
+      <IconButton
+        size="sm"
+        onClick={onCancel}
+        title={t('common.cancel')}
+        disabled={isAdding}
+      >
+        <X size={13} />
+      </IconButton>
+    </div>
+  );
+}
+
+// ── Shared sub-components ─────────────────────────────────────────────────────
 
 function MemoryTextarea({
   label,
@@ -312,22 +480,6 @@ function MemoryTextarea({
         className="w-full resize-y rounded-[16px] border border-editorial-border bg-editorial-bg/80 px-4 py-3 text-sm leading-relaxed text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
       />
     </label>
-  );
-}
-
-function EmbeddingModelBadge({
-  entryModel,
-  workspaceModel,
-}: {
-  entryModel: string | null;
-  workspaceModel: string | null;
-}) {
-  const stale = entryModel !== workspaceModel;
-  const label = entryModel ?? '—';
-  return (
-    <span className={`mt-1 inline-block font-mono text-[10px] ${stale ? 'text-editorial-accent/80' : 'text-editorial-muted/50'}`}>
-      {label}
-    </span>
   );
 }
 

--- a/src/hooks/usePipeline.test.ts
+++ b/src/hooks/usePipeline.test.ts
@@ -727,6 +727,49 @@ describe('usePipeline', () => {
     expect(coherenceCall[0].currentChunkId).toBe('chunk-0');
   });
 
+  it('source blob assembler excludes reference chunks with empty sourceProcessingText', async () => {
+    useChunksStore.setState({
+      chunks: [
+        makeTranslationChunk({
+          id: 'chunk-0',
+          originalText: 'First',
+          sourceProcessingText: 'First',
+          status: 'ready',
+          stageResults: {},
+          judgeResult: { content: '', status: 'idle', rating: 'fair', issues: [] },
+          currentDraft: '',
+        }),
+        makeTranslationChunk({
+          id: 'chunk-1',
+          originalText: 'Second',
+          sourceProcessingText: '',
+          status: 'ready',
+          stageResults: {},
+          judgeResult: { content: '', status: 'idle', rating: 'fair', issues: [] },
+          currentDraft: '',
+        }),
+      ],
+      isProcessing: false,
+      cancelRequested: false,
+      activeStreamId: null,
+    });
+    llmMocks.computeBlobs.mockResolvedValueOnce([
+      { chunkId: 'chunk-0', blobId: 'blob-1', position: 0, referenceChunkIds: ['chunk-0', 'chunk-1'] },
+      { chunkId: 'chunk-1', blobId: 'blob-1', position: 1, referenceChunkIds: ['chunk-0', 'chunk-1'] },
+    ]);
+    llmMocks.runStage.mockResolvedValue({ content: 'Translated' });
+    llmMocks.judgeTranslation.mockResolvedValue({ content: '', rating: 'good', issues: [] });
+
+    const { result } = renderHook(() => usePipeline());
+    await act(async () => {
+      await result.current.runPipeline();
+    });
+
+    const firstStageConfig = llmMocks.runStage.mock.calls[0][2];
+    expect(firstStageConfig.blobContext).toContain('<chunk id="chunk-0">');
+    expect(firstStageConfig.blobContext).not.toContain('<chunk id="chunk-1">');
+  });
+
   it('marks chunk as error and calls toast.error on non-cancellation stage failure', async () => {
     // Use a config-class error so withRetry gives up immediately (no delay).
     llmMocks.runStage.mockRejectedValueOnce(

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -33,29 +33,20 @@ function formatReferenceChunk(chunkId: string, text: string): string {
   return `<chunk id="${escapeChunkId(chunkId)}">\n${text}\n</chunk>`;
 }
 
-function assembleBlobContext(chunks: TranslationChunk[], chunkId: string): string | undefined {
+function buildBlobContext(
+  chunks: TranslationChunk[],
+  chunkId: string,
+  selector: (c: TranslationChunk) => string | undefined,
+): string | undefined {
   const current = chunks.find((c) => c.id === chunkId);
   if (!current?.blobReferenceChunkIds?.length) return undefined;
   const byId = new Map(chunks.map((chunk) => [chunk.id, chunk]));
   const referenceChunks = current.blobReferenceChunkIds
     .map((id) => byId.get(id))
-    .filter((chunk): chunk is TranslationChunk => !!chunk && !!chunk.sourceProcessingText);
+    .filter((chunk): chunk is TranslationChunk => !!chunk && !!selector(chunk));
   if (referenceChunks.length === 0) return undefined;
   return referenceChunks
-    .map((chunk) => formatReferenceChunk(chunk.id, chunk.sourceProcessingText))
-    .join('\n\n') || undefined;
-}
-
-function assembleTranslationBlobContext(chunks: TranslationChunk[], chunkId: string): string | undefined {
-  const current = chunks.find((c) => c.id === chunkId);
-  if (!current?.blobReferenceChunkIds?.length) return undefined;
-  const byId = new Map(chunks.map((chunk) => [chunk.id, chunk]));
-  const referenceChunks = current.blobReferenceChunkIds
-    .map((id) => byId.get(id))
-    .filter((chunk): chunk is TranslationChunk => !!chunk?.translationProcessingText?.trim());
-  if (referenceChunks.length === 0) return undefined;
-  return referenceChunks
-    .map((chunk) => formatReferenceChunk(chunk.id, chunk.translationProcessingText))
+    .map((chunk) => formatReferenceChunk(chunk.id, selector(chunk)!))
     .join('\n\n') || undefined;
 }
 
@@ -225,7 +216,7 @@ export function usePipeline() {
       const liveChunks = useChunksStore.getState().chunks;
       const stageRole = stage.role ?? 'translation';
       const isFormatStage = stageRole === 'format';
-      const blobContext = isFormatStage ? undefined : assembleBlobContext(liveChunks, chunk.id);
+      const blobContext = isFormatStage ? undefined : buildBlobContext(liveChunks, chunk.id, (c) => c.sourceProcessingText || undefined);
       const effectiveConfig = {
         ...config,
         ...(!config.persona && stage.sourceLanguage ? { sourceLanguage: stage.sourceLanguage } : {}),
@@ -785,7 +776,7 @@ export function usePipeline() {
       if (!chunk.translationProcessingText?.trim()) continue;
       if (useChunksStore.getState().cancelRequested) { cancelled = true; break; }
 
-      const blobContext = assembleTranslationBlobContext(liveChunks, chunk.id);
+      const blobContext = buildBlobContext(liveChunks, chunk.id, (c) => c.translationProcessingText?.trim() ? c.translationProcessingText : undefined);
 
       updateChunkCoherence(chunk.id, { status: 'processing', issues: [] });
       const coherenceRef = { provider: config.judgeProvider, model: config.judgeModel };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1201,7 +1201,12 @@
     "memoryDeleteTitle": "Delete this memory?",
     "memoryDeleteMessage": "The selected memory will be removed from this workspace.",
     "memoryDeleteError": "Delete error",
-    "embeddingModel": "Embedding model"
+    "embeddingModel": "Embedding model",
+    "fromProject": "Project",
+    "fromChunk": "Chunk",
+    "addToGlossary": "Add to glossary",
+    "addedToGlossary": "Added to glossary",
+    "addToGlossaryError": "Error adding to glossary"
   },
   "cost": {
     "free": "Free",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1201,7 +1201,12 @@
     "memoryDeleteTitle": "Eliminare questa memoria?",
     "memoryDeleteMessage": "La memoria selezionata verrà rimossa dal workspace.",
     "memoryDeleteError": "Errore nell'eliminazione",
-    "embeddingModel": "Modello embedding"
+    "embeddingModel": "Modello embedding",
+    "fromProject": "Progetto",
+    "fromChunk": "Chunk",
+    "addToGlossary": "Aggiungi a glossario",
+    "addedToGlossary": "Aggiunto al glossario",
+    "addToGlossaryError": "Errore nell'aggiunta al glossario"
   },
   "cost": {
     "free": "Gratuito",

--- a/src/services/phraseMemoryService.ts
+++ b/src/services/phraseMemoryService.ts
@@ -566,6 +566,24 @@ export async function savePhrasePairs(options: SavePhrasePairsOptions): Promise<
       : [];
   });
 
+  const droppedCount = extractedPairs.length - pairs.length;
+  if (droppedCount > 0 && pairs.length > 0) {
+    logger.warn('phrase_memory.save_pairs.partial_embedding_drop', {
+      workspaceId,
+      projectId,
+      chunkId,
+      candidatePairCount: extractedPairs.length,
+      droppedCount,
+    });
+    logOperation({
+      level: 'warn',
+      scope: 'memory',
+      chunkId,
+      message: `${droppedCount} pair(s) discarded — embedding unavailable`,
+      meta: { workspaceId, projectId, candidatePairCount: extractedPairs.length, droppedCount },
+    });
+  }
+
   if (pairs.length === 0) {
     logger.warn('phrase_memory.save_pairs.no_valid_embeddings', {
       workspaceId,

--- a/src/services/phraseMemoryService.ts
+++ b/src/services/phraseMemoryService.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { select } from './dbService';
 import { logOperation } from '../stores/operationLogStore';
 import { logger } from '../utils/logger';
 import type { EmbeddingModel, ModelProvider, PhraseMatch } from '../types';
@@ -648,4 +649,18 @@ export async function regenerateAllEmbeddings(
   model: EmbeddingModel,
 ): Promise<number> {
   return invoke<number>('vec_regenerate_all_embeddings', { workspaceId, model });
+}
+
+export async function getChunkPositions(chunkIds: string[]): Promise<Record<string, number>> {
+  if (chunkIds.length === 0) return {};
+  const placeholders = chunkIds.map((_, i) => `$${i + 1}`).join(', ');
+  const rows = await select<{ id: string; position: number | null }>(
+    `SELECT id, position FROM translations WHERE id IN (${placeholders})`,
+    chunkIds,
+  );
+  const map: Record<string, number> = {};
+  rows.forEach((row) => {
+    if (row.position !== null) map[row.id] = row.position;
+  });
+  return map;
 }


### PR DESCRIPTION
## Summary

- **#233** — Refactor `buildBlobContext` in `usePipeline.ts`: rimosso ~25 righe di duplicazione esatta tra `assembleBlobContext` e `assembleTranslationBlobContext`; selector parametrico; test aggiunto per esclusione chunk con testo vuoto
- **#232.2** — `phraseMemoryService`: log `warn` quando alcuni pair vengono scartati per embedding mancante (scarto parziale prima silenzioso)
- **#232.1** — `documents.rs`: tutti gli `.unwrap()` sono in `#[cfg(test)]` → nessun fix necessario in produzione
- **#232.3** — `ARCHITECTURE.md`: corretto riferimento `deepseek.rs` (inesistente) → `openai.rs` fn `deepseek`; rimossa riga blob assembler; aggiornato footer branch/data
- **#232.4** — `ARCHITECTURE.md`: DeepSeek reasoning funzionante → rimosso dalla tabella. Anthropic: nessun parametro thinking inviato. Gemini: `thinkingBudget` inviato ma parsing `parts[0]` prende blocco thinking se attivo → bug documentato
- **#232.5** — `CLAUDE.md`: regola MCP code-review-graph da "ALWAYS BEFORE Grep" a "prefer when available, fall back to Grep if not connected"

## Test plan

- [x] `rtk vitest run src/hooks/usePipeline.test.ts` → 27 pass
- [x] `rtk vitest run src/services/__tests__/phraseMemoryService.test.ts` → 12 pass
- [x] `rtk cargo clippy` → no issues

Closes #232
Closes #233