### PR TITLE
chore: rifiniture qualità pre-1.0 (#236)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,4 +353,18 @@ source_phrase_embeddings
 
 ---
 
-*Ultimo aggiornamento: 2026-06-08 — branch chore/hardening-pre-1.0*
+*Ultimo aggiornamento: 2026-06-09 — branch main*
+
+---
+
+## Decisioni spike
+
+### Radix UI per modali/drawer (issue #236 — NO-GO)
+
+**Data:** 2026-06-09
+
+**Proposta:** sostituire il custom `useFocusTrap` hook con `@radix-ui/react-dialog` e `@radix-ui/react-popover` per focus-trap e a11y robusti.
+
+**Decisione: NO-GO pre-1.0.**
+
+Il hook custom copre i casi d'uso attuali (5 componenti: `ImportPreviewDialog`, `ConfigDrawer`, `DashboardSidebar`, `ProjectPanel`, `ExportDialog`). Radix aggiungerebbe ~15 kb di dipendenza e richiederebbe il refactor di tutti e 5 i componenti senza benefici concreti sui bug aperti. Da rivalutare post-1.0 se emergono problemi di focus con stack modale o screen reader.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-build = { version = "2.5.6", features = [] }
 [dependencies]
 bytes = "1"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 log = "0.4"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "json"] }
 tauri = { version = "2.10.3", features = [] }

--- a/src-tauri/src/llm/blobs.rs
+++ b/src-tauri/src/llm/blobs.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +16,7 @@ pub struct BlobAssignment {
     pub chunk_id: String,
     pub blob_id: String,
     pub position: usize,
-    pub reference_chunk_ids: Vec<String>,
+    pub reference_chunk_ids: Arc<[String]>,
 }
 
 /// Rough token estimate: ~1.33 tokens per word (works for Latin-script languages).
@@ -54,10 +56,10 @@ pub fn compute_blob_assignments(
             rand::thread_rng().gen::<u64>(),
             rand::thread_rng().gen::<u64>()
         );
-        let reference_chunk_ids = chunks
+        let reference_chunk_ids: Arc<[String]> = chunks
             .iter()
             .map(|chunk| chunk.id.clone())
-            .collect::<Vec<_>>();
+            .collect();
         return chunks
             .iter()
             .enumerate()
@@ -65,7 +67,7 @@ pub fn compute_blob_assignments(
                 chunk_id: chunk.id.clone(),
                 blob_id: blob_id.clone(),
                 position,
-                reference_chunk_ids: reference_chunk_ids.clone(),
+                reference_chunk_ids: Arc::clone(&reference_chunk_ids),
             })
             .collect();
     }
@@ -110,17 +112,17 @@ pub fn compute_blob_assignments(
             primary_end = (primary_start + 1).min(chunks.len());
         }
 
-        let reference_chunk_ids = chunks[reference_start..reference_end]
+        let reference_chunk_ids: Arc<[String]> = chunks[reference_start..reference_end]
             .iter()
             .map(|chunk| chunk.id.clone())
-            .collect::<Vec<_>>();
+            .collect();
 
         for (position, chunk) in chunks[primary_start..primary_end].iter().enumerate() {
             assignments.push(BlobAssignment {
                 chunk_id: chunk.id.clone(),
                 blob_id: blob_id.clone(),
                 position,
-                reference_chunk_ids: reference_chunk_ids.clone(),
+                reference_chunk_ids: Arc::clone(&reference_chunk_ids),
             });
         }
 
@@ -157,7 +159,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].chunk_id, "c1");
         assert_eq!(result[0].position, 0);
-        assert_eq!(result[0].reference_chunk_ids, vec!["c1"]);
+        assert_eq!(result[0].reference_chunk_ids.as_ref(), &["c1".to_string()] as &[String]);
     }
 
     #[test]
@@ -206,8 +208,10 @@ mod tests {
         assert!(result
             .iter()
             .all(|entry| entry.blob_id == result[0].blob_id));
-        assert!(result.iter().all(|entry| entry.reference_chunk_ids
-            == vec!["c1".to_string(), "c2".to_string(), "c3".to_string()]));
+        let expected_refs: &[String] = &["c1".to_string(), "c2".to_string(), "c3".to_string()];
+        assert!(result
+            .iter()
+            .all(|entry| entry.reference_chunk_ids.as_ref() == expected_refs));
     }
 
     #[test]

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
 use crate::keystore::get_api_key;
@@ -18,7 +19,7 @@ use crate::llm::types::{
 #[derive(serde::Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct PromptEvent {
-    stream_id: String,
+    stream_id: Arc<str>,
     system_prompt: String,
     user_prompt: String,
 }
@@ -26,7 +27,7 @@ struct PromptEvent {
 #[derive(serde::Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct ResponseEvent {
-    stream_id: String,
+    stream_id: Arc<str>,
     kind: String,
     raw_json: String,
 }
@@ -74,6 +75,7 @@ pub async fn run_stage(
     stream_id: String,
     ollama_base_url: Option<String>,
 ) -> Result<StageResult, String> {
+    let stream_id: Arc<str> = stream_id.into();
     let provider = get_provider(&stage.provider, ollama_base_url)?;
     provider.preflight(&stage.model).await?;
     let api_key = get_api_key(&app, &stage.provider)?;
@@ -152,6 +154,7 @@ pub async fn run_stage_stream(
     stream_id: String,
     ollama_base_url: Option<String>,
 ) -> Result<String, String> {
+    let stream_id: Arc<str> = stream_id.into();
     let provider = get_provider(&stage.provider, ollama_base_url)?;
     provider.preflight(&stage.model).await?;
     let api_key = get_api_key(&app, &stage.provider)?;
@@ -227,6 +230,7 @@ pub async fn judge_translation(
     stream_id: String,
     ollama_base_url: Option<String>,
 ) -> Result<JudgeResponse, String> {
+    let stream_id: Arc<str> = stream_id.into();
     let provider = get_provider(&config.judge_provider, ollama_base_url)?;
     provider.preflight(&config.judge_model).await?;
     let api_key = get_api_key(&app, &config.judge_provider)?;
@@ -447,6 +451,7 @@ pub async fn run_coherence_for_chunk(
     stream_id: String,
     ollama_base_url: Option<String>,
 ) -> Result<CoherenceResponse, String> {
+    let stream_id: Arc<str> = stream_id.into();
     let provider = get_provider(&config.judge_provider, ollama_base_url)?;
     provider.preflight(&config.judge_model).await?;
     let api_key = get_api_key(&app, &config.judge_provider)?;

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -152,7 +152,7 @@ impl StreamRegistry {
 /// even if the surrounding future is cancelled or panics.
 pub(crate) struct StreamGuard<'a> {
     pub(crate) registry: &'a StreamRegistry,
-    pub(crate) stream_id: String,
+    pub(crate) stream_id: Arc<str>,
 }
 
 impl Drop for StreamGuard<'_> {

--- a/src-tauri/src/llm/tests.rs
+++ b/src-tauri/src/llm/tests.rs
@@ -824,7 +824,7 @@
         {
             let _guard = StreamGuard {
                 registry: &registry,
-                stream_id: "s-1".to_string(),
+                stream_id: Arc::from("s-1"),
             };
         } // guard drops here
           // After drop, cancelling has no effect on the registered handle

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -545,14 +545,16 @@ export async function initDatabase(): Promise<void> {
     await conn.execute(`
       UPDATE projects
       SET
-        source_display_text    = COALESCE((SELECT source_display_text    FROM pipeline_configs WHERE project_id = projects.id), ''),
-        source_processing_text = COALESCE((SELECT source_processing_text FROM pipeline_configs WHERE project_id = projects.id), ''),
-        source_footnotes       = COALESCE((SELECT source_footnotes       FROM pipeline_configs WHERE project_id = projects.id), '[]'),
-        document_format        = COALESCE((SELECT document_format        FROM pipeline_configs WHERE project_id = projects.id), 'plain'),
-        render_profile         = COALESCE((SELECT render_profile         FROM pipeline_configs WHERE project_id = projects.id), 'plain-text'),
-        markdown_aware         = COALESCE((SELECT markdown_aware         FROM pipeline_configs WHERE project_id = projects.id), 0),
-        experimental_import    =          (SELECT experimental_import    FROM pipeline_configs WHERE project_id = projects.id)
-      WHERE source_display_text IS NULL OR source_display_text = ''
+        source_display_text    = COALESCE(pc.source_display_text, ''),
+        source_processing_text = COALESCE(pc.source_processing_text, ''),
+        source_footnotes       = COALESCE(pc.source_footnotes, '[]'),
+        document_format        = COALESCE(pc.document_format, 'plain'),
+        render_profile         = COALESCE(pc.render_profile, 'plain-text'),
+        markdown_aware         = COALESCE(pc.markdown_aware, 0),
+        experimental_import    = pc.experimental_import
+      FROM pipeline_configs AS pc
+      WHERE pc.project_id = projects.id
+        AND (projects.source_display_text IS NULL OR projects.source_display_text = '')
     `);
   } catch (error) {
     console.warn('[Glossa] Source text migration to projects failed', error);


### PR DESCRIPTION
## Summary

- **Rust `.clone()` ripetuti** — `stream_id` convertito ad `Arc<str>` nelle 4 funzioni Tauri (`run_stage`, `run_stage_stream`, `judge_translation`, `run_coherence_for_chunk`); `BlobAssignment.reference_chunk_ids` cambiato da `Vec<String>` ad `Arc<[String]>` per eliminare le copie nell'inner loop di `compute_blob_assignments`; abilitata feature `rc` di serde
- **SQL COALESCE** — 6 subquery correlate in `dbService.ts` (migration source text) consolidate in un singolo `UPDATE … FROM pipeline_configs AS pc` con join
- **Spike Radix** — decisione NO-GO documentata in `docs/ARCHITECTURE.md`: hook custom copre i casi d'uso attuali, refactor su 5 componenti non giustificato pre-1.0
- **A11y + hex→token** — già completati nel refactor strutturale `ae4acc7`, nessuna modifica necessaria

## Test plan

- [ ] `cargo check` passa senza errori
- [ ] `cargo test` passa (inclusi i test di `blobs.rs` aggiornati per `Arc<[String]>`)
- [ ] Aprire un progetto esistente e verificare che la migration SQL non rompa i dati
- [ ] Avviare la pipeline e controllare che gli eventi `chunk-prompt`/`chunk-response` arrivino correttamente al frontend

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)