### PR TITLE
feat: chunk annotations system (#23)

### DIFF
--- a/src-tauri/src/llm/prompts.rs
+++ b/src-tauri/src/llm/prompts.rs
@@ -294,7 +294,10 @@ pub(crate) fn build_coherence_prompts(
          1. Terminology consistency — key terms translated differently than in adjacent segments\n\
          2. Narrative continuity — abrupt breaks in flow at segment boundaries\n\
          3. Glossary adherence — glossary terms used inconsistently with context\n\
-         Do NOT re-evaluate standalone translation quality.";
+         Do NOT re-evaluate standalone translation quality.\n\
+         Be exhaustive: scan ALL dimensions completely before responding. Do not stop after finding \
+         the first issue of each type. Only return an empty issues array if you are fully confident \
+         — after deliberate review of every dimension — that no problems exist.";
 
     let instructions = config
         .coherence_prompt

--- a/src/components/audit/AuditPanel.tsx
+++ b/src/components/audit/AuditPanel.tsx
@@ -323,6 +323,22 @@ function ChunkAuditCard({
                     <p className={`text-sm leading-relaxed text-editorial-ink ${isResolved ? 'line-through' : ''}`}>
                       {issue.description}
                     </p>
+                    {(issue.phrase || chunk.sourceDisplayText) && (
+                      <div className="space-y-2 rounded-xl border border-editorial-border/50 bg-editorial-textbox/20 px-3 py-2">
+                        {issue.phrase && (
+                          <div>
+                            <span className="block text-[9px] font-bold uppercase tracking-widest text-editorial-accent">{t('audit.issuePhraseContext')}</span>
+                            <p className="mt-0.5 text-[11px] leading-relaxed text-editorial-ink">&ldquo;{issue.phrase}&rdquo;</p>
+                          </div>
+                        )}
+                        {chunk.sourceDisplayText && (
+                          <div>
+                            <span className="block text-[9px] font-bold uppercase tracking-widest text-editorial-muted">{t('audit.issueSourceContext')}</span>
+                            <p className="mt-0.5 text-[11px] leading-relaxed text-editorial-muted line-clamp-3">{chunk.sourceDisplayText}</p>
+                          </div>
+                        )}
+                      </div>
+                    )}
                     {issue.suggestedFix && (
                       <div className="rounded-xl border border-editorial-border/70 bg-editorial-bg px-3 py-2 text-[11px] leading-relaxed text-editorial-muted">
                         {t('audit.fix')}: {issue.suggestedFix}

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -24,6 +24,7 @@ import { CopyButton, HighlightedText, MarkdownEditor } from '../common';
 import { IconButton, Tooltip, type IconButtonTone } from '../ui';
 import { usePhraseMemoryAutoSearch } from '../../hooks/usePhraseMemoryAutoSearch';
 import { usePanelScrollSync } from '../../hooks/usePanelScrollSync';
+import { useAnnotationsStore } from '../../stores/annotationsStore';
 import { useDocumentViewState } from './hooks/useDocumentViewState';
 import { StageTraceDialog } from './StageTraceDialog';
 import { PaneSearch } from './PaneSearch';
@@ -144,6 +145,7 @@ export function DocumentView({
   const { config } = usePipelineStore();
   const { currentProjectId, projects } = useProjectStore();
   const activeWorkspace = useWorkspaceStore((state) => state.activeWorkspace);
+  const annotationsByChunkId = useAnnotationsStore((s) => s.annotationsByChunkId);
   const {
     updateChunkDraft,
     updateChunkOriginalText,
@@ -330,6 +332,14 @@ export function DocumentView({
                   const sizeClass = chunk.translationLocked
                     ? (isCurrent ? 'h-4.5 w-4.5' : 'h-4 w-4')
                     : (isCurrent ? 'h-4 w-4' : 'h-3 w-3');
+                  const chunkAnnotations = annotationsByChunkId.get(chunk.id) ?? [];
+                  const annotDotColor = chunkAnnotations.some(a => a.type === 'problem')
+                    ? 'bg-editorial-accent'
+                    : chunkAnnotations.some(a => a.type === 'doubt')
+                      ? 'bg-editorial-warning'
+                      : chunkAnnotations.length > 0
+                        ? 'bg-editorial-charcoal/70'
+                        : null;
                   return (
                     <Tooltip key={chunk.id} label={`${idx + 1}`}>
                       <button
@@ -345,6 +355,9 @@ export function DocumentView({
                         {chunk.translationLocked ? (
                           <span className="absolute left-1/2 top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-editorial-success" />
                         ) : null}
+                        {annotDotColor && (
+                          <span className={`absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ${annotDotColor} ring-1 ring-editorial-bg`} />
+                        )}
                       </button>
                     </Tooltip>
                   );

--- a/src/components/document/hooks/useDocumentViewState.ts
+++ b/src/components/document/hooks/useDocumentViewState.ts
@@ -4,7 +4,8 @@ import { usePipelineStore } from '../../../stores/pipelineStore';
 import { useChunksStore } from '../../../stores/chunksStore';
 import { useUiStore } from '../../../stores/uiStore';
 import { useConfigStore } from '../../../stores/configStore';
-import { useGlossaryHighlight, escapeHtml } from '../../../hooks/useGlossaryHighlight';
+import { useAnnotationsStore } from '../../../stores/annotationsStore';
+import { useGlossaryHighlight, escapeHtml, type AnnotationAnchor } from '../../../hooks/useGlossaryHighlight';
 import { useStageDiff } from '../../../hooks/useStageDiff';
 import { highlightSuperscriptMarkersHtml } from '../../../utils/footnoteExtractor';
 
@@ -118,6 +119,17 @@ export function useDocumentViewState() {
   const sourceEffectiveSearch = sourcePaneSearch.trim() || (highlightsEnabled ? searchQuery.trim() : '');
   const translationEffectiveSearch = translationPaneSearch.trim() || (highlightsEnabled ? searchQuery.trim() : '');
 
+  const annotationsByChunkId = useAnnotationsStore((s) => s.annotationsByChunkId);
+  const currentChunkAnnotations = currentChunk ? (annotationsByChunkId.get(currentChunk.id) ?? []) : [];
+  const annotationAnchors = useMemo<AnnotationAnchor[]>(
+    () => currentChunkAnnotations
+      .filter((a) => !!a.anchorText?.trim())
+      .map((a) => ({ text: a.anchorText!, type: a.type })),
+    // key on serialized text to avoid identity-change noise
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentChunkAnnotations.map((a) => `${a.id}:${a.anchorText ?? ''}`).join('|')],
+  );
+
   const sourceHighlight = useGlossaryHighlight(
     paneFocus !== 'translation' ? deferredSourceText : '',
     showHighlight && paneFocus !== 'translation' ? config.glossary : [],
@@ -130,6 +142,7 @@ export function useDocumentViewState() {
     'translation',
     translationEffectiveSearch,
     focusedIssueQuery ?? '',
+    annotationAnchors,
   );
 
   const activeDiffPair = diffPairs.find((pair) => pair.key === diffPairKey) ?? diffPairs[0] ?? null;

--- a/src/components/document/tabs/AuditTab.tsx
+++ b/src/components/document/tabs/AuditTab.tsx
@@ -72,7 +72,13 @@ export function AuditTab({ panelId, labelledBy, currentChunk, isProcessing, onRe
           </div>
         )}
         {currentChunk.judgeResult.issues.length > 0 && (
-          <IssueList issues={currentChunk.judgeResult.issues} chunkId={currentChunk.id} onSelectChunk={onSelectChunk} onFocusIssue={onFocusIssue} />
+          <IssueList
+            issues={currentChunk.judgeResult.issues}
+            chunkId={currentChunk.id}
+            onSelectChunk={onSelectChunk}
+            onFocusIssue={onFocusIssue}
+            sourceText={currentChunk.sourceDisplayText}
+          />
         )}
       </section>
     </div>

--- a/src/components/document/tabs/CoherenceTab.tsx
+++ b/src/components/document/tabs/CoherenceTab.tsx
@@ -5,7 +5,9 @@ import {
   Loader2,
   ScanLine,
 } from 'lucide-react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useChunksStore } from '../../../stores/chunksStore';
 import { IconButton } from '../../ui';
 import { IssueList } from './IssueList';
 import type { TranslationChunk } from '../../../types';
@@ -25,6 +27,8 @@ export interface CoherenceTabProps {
 
 export function CoherenceTab({ panelId, labelledBy, currentChunk, isProcessing, allChunksTranslated, allChunksLocked, unlockedChunksCount, onSelectChunk, onFocusIssue, onRunCoherenceAudit }: CoherenceTabProps) {
   const { t } = useTranslation();
+  const toggleCoherenceIssueResolved = useChunksStore((s) => s.toggleCoherenceIssueResolved);
+
   const coherence = currentChunk?.coherenceResult;
   const coherenceDisabled = isProcessing || !allChunksTranslated;
   const coherenceTitle = coherenceDisabled && !isProcessing
@@ -32,6 +36,15 @@ export function CoherenceTab({ panelId, labelledBy, currentChunk, isProcessing, 
     : coherence?.status === 'completed' || coherence?.status === 'error'
       ? t('coherence.rerun')
       : t('coherence.runAudit');
+
+  const resolvedKeys = useMemo(
+    () => new Set(coherence?.resolvedIssueKeys ?? []),
+    [coherence?.resolvedIssueKeys],
+  );
+
+  const handleToggleResolved = currentChunk
+    ? (key: string) => toggleCoherenceIssueResolved(currentChunk.id, key)
+    : undefined;
 
   return (
     <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="px-5 py-5">
@@ -76,7 +89,15 @@ export function CoherenceTab({ panelId, labelledBy, currentChunk, isProcessing, 
             <CheckCircle2 size={14} /> {t('coherence.noIssues')}
           </div>
         ) : currentChunk ? (
-          <IssueList issues={coherence.issues} chunkId={currentChunk.id} onSelectChunk={onSelectChunk} onFocusIssue={onFocusIssue} />
+          <IssueList
+            issues={coherence.issues}
+            chunkId={currentChunk.id}
+            onSelectChunk={onSelectChunk}
+            onFocusIssue={onFocusIssue}
+            sourceText={currentChunk.sourceDisplayText}
+            resolvedKeys={resolvedKeys}
+            onToggleResolved={handleToggleResolved}
+          />
         ) : null}
       </section>
     </div>

--- a/src/components/document/tabs/IndexTab.tsx
+++ b/src/components/document/tabs/IndexTab.tsx
@@ -8,11 +8,13 @@ import {
   FlaskConical,
   List,
   Loader2,
+  NotebookText,
 } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useTranslation } from 'react-i18next';
 import { useRef } from 'react';
 import { usePhraseMemoryStore } from '../../../stores/phraseMemoryStore';
+import { useAnnotationsStore } from '../../../stores/annotationsStore';
 import { countWords, indexPad, qualityLabelKey, qualityTone } from '../../../utils';
 import type { TranslationChunk } from '../../../types';
 
@@ -35,6 +37,7 @@ export interface IndexTabProps {
 export function IndexTab({ panelId, labelledBy, chunks, currentChunkId, stuckChunkIds, onSelect, onCancelStuck }: IndexTabProps) {
   const { t } = useTranslation();
   const matchesByChunk = usePhraseMemoryStore((s) => s.matchesByChunk);
+  const annotationsByChunkId = useAnnotationsStore((s) => s.annotationsByChunkId);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const virtualizer = useVirtualizer({
@@ -121,6 +124,22 @@ export function IndexTab({ panelId, labelledBy, chunks, currentChunkId, stuckChu
                       <div className={`mt-1.5 flex items-center gap-1 text-xs font-bold uppercase tracking-[0.18em] ${isActive ? 'text-white/80' : 'text-editorial-accent'}`}>
                         <Brain size={11} />
                         {t('memory.matchBadge', { count: matchCount })}
+                      </div>
+                    );
+                  })()}
+                  {(() => {
+                    const anns = annotationsByChunkId.get(chunk.id) ?? [];
+                    if (anns.length === 0) return null;
+                    const hasProblem = anns.some(a => a.type === 'problem');
+                    const hasDoubt   = anns.some(a => a.type === 'doubt');
+                    const colorClass = isActive ? 'text-white/80'
+                      : hasProblem ? 'text-editorial-accent'
+                      : hasDoubt   ? 'text-editorial-warning'
+                      : 'text-editorial-charcoal';
+                    return (
+                      <div className={`mt-1.5 flex items-center gap-1 text-xs font-bold uppercase tracking-[0.18em] ${colorClass}`}>
+                        <NotebookText size={11} />
+                        {t('annotations.badgeCount', { count: anns.length })}
                       </div>
                     );
                   })()}

--- a/src/components/document/tabs/IssueList.tsx
+++ b/src/components/document/tabs/IssueList.tsx
@@ -2,6 +2,7 @@ import {
   AlertCircle,
   AlertTriangle,
   BookOpen,
+  Check,
   Crosshair,
   Link2,
   MessageCircle,
@@ -16,58 +17,98 @@ export interface IssueListProps {
   chunkId: string;
   onSelectChunk: (id: string) => void;
   onFocusIssue: (chunkId: string, query?: string | null) => void;
+  sourceText?: string;
+  resolvedKeys?: Set<string>;
+  onToggleResolved?: (key: string) => void;
 }
 
-export function IssueList({ issues, chunkId, onSelectChunk, onFocusIssue }: IssueListProps) {
+export function IssueList({ issues, chunkId, onSelectChunk, onFocusIssue, sourceText, resolvedKeys, onToggleResolved }: IssueListProps) {
   const { t } = useTranslation();
   const focusedIssueQuery = useUiStore((s) => s.focusedIssueQuery);
   const clearFocusedIssue = useUiStore((s) => s.clearFocusedIssue);
   return (
     <div className="mt-4 space-y-3">
-      {issues.map((issue, index) => (
-        <article key={`${issue.type}-${index}`} className="rounded-2xl border border-editorial-border bg-editorial-bg/80 p-4 shadow-sm">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <span className={`rounded-full p-1 ${issue.severity === 'high' ? 'bg-editorial-accent text-white' : issue.severity === 'medium' ? 'bg-editorial-warning/80 text-white' : 'bg-editorial-border text-editorial-muted'}`}>
-                {issue.type === 'fluency' ? <MessageCircle size={11} /> :
-                 issue.type === 'accuracy' ? <AlertTriangle size={11} /> :
-                 issue.type === 'grammar' ? <AlertCircle size={11} /> :
-                 issue.type === 'consistency' ? <Link2 size={11} /> :
-                 <BookOpen size={11} />}
-              </span>
-              <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-ink">{issue.type}</span>
+      {issues.map((issue, index) => {
+        const issueKey = `${issue.type}-${index}`;
+        const isResolved = resolvedKeys?.has(issueKey) ?? false;
+        return (
+          <article key={issueKey} className={`rounded-2xl border border-editorial-border bg-editorial-bg/80 p-4 shadow-sm transition-opacity ${isResolved ? 'opacity-40' : ''}`}>
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <span className={`rounded-full p-1 ${issue.severity === 'high' ? 'bg-editorial-accent text-white' : issue.severity === 'medium' ? 'bg-editorial-warning/80 text-white' : 'bg-editorial-border text-editorial-muted'}`}>
+                  {issue.type === 'fluency' ? <MessageCircle size={11} /> :
+                   issue.type === 'accuracy' ? <AlertTriangle size={11} /> :
+                   issue.type === 'grammar' ? <AlertCircle size={11} /> :
+                   issue.type === 'consistency' ? <Link2 size={11} /> :
+                   <BookOpen size={11} />}
+                </span>
+                <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-ink">{issue.type}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                {issue.phrase && (() => {
+                  const isActive = focusedIssueQuery === issue.phrase;
+                  return (
+                    <IconButton
+                      size="sm"
+                      tone={isActive ? 'accent' : 'default'}
+                      onClick={() => {
+                        if (isActive) {
+                          clearFocusedIssue();
+                        } else {
+                          onSelectChunk(chunkId);
+                          onFocusIssue(chunkId, issue.phrase);
+                        }
+                      }}
+                      title={t('audit.locateInTextTooltip')}
+                      ariaPressed={isActive}
+                      tooltipSide="left"
+                    >
+                      <Crosshair size={13} />
+                    </IconButton>
+                  );
+                })()}
+                {onToggleResolved && (
+                  <button
+                    type="button"
+                    onClick={() => onToggleResolved(issueKey)}
+                    title={isResolved ? t('audit.markUnresolved') : t('audit.markResolved')}
+                    aria-label={isResolved ? t('audit.markUnresolved') : t('audit.markResolved')}
+                    className={`rounded-full border p-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+                      isResolved
+                        ? 'border-editorial-success bg-editorial-success/10 text-editorial-success'
+                        : 'border-editorial-border text-editorial-muted hover:border-editorial-success/60 hover:text-editorial-success'
+                    }`}
+                  >
+                    <Check size={10} />
+                  </button>
+                )}
+              </div>
             </div>
-            {issue.phrase && (() => {
-              const isActive = focusedIssueQuery === issue.phrase;
-              return (
-                <IconButton
-                  size="sm"
-                  tone={isActive ? 'accent' : 'default'}
-                  onClick={() => {
-                    if (isActive) {
-                      clearFocusedIssue();
-                    } else {
-                      onSelectChunk(chunkId);
-                      onFocusIssue(chunkId, issue.phrase);
-                    }
-                  }}
-                  title={t('audit.locateInTextTooltip')}
-                  ariaPressed={isActive}
-                  tooltipSide="left"
-                >
-                  <Crosshair size={13} />
-                </IconButton>
-              );
-            })()}
-          </div>
-          <p className="text-sm leading-relaxed text-editorial-ink">{issue.description}</p>
-          {issue.suggestedFix && (
-            <div className="mt-3 rounded-xl border border-editorial-border/70 bg-editorial-bg px-3 py-2 text-sm leading-relaxed text-editorial-muted">
-              <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-accent">{t('audit.fix')}</span>: {issue.suggestedFix}
-            </div>
-          )}
-        </article>
-      ))}
+            <p className={`text-sm leading-relaxed text-editorial-ink ${isResolved ? 'line-through' : ''}`}>{issue.description}</p>
+            {(issue.phrase || sourceText) && (
+              <div className="mt-3 space-y-2 rounded-xl border border-editorial-border/50 bg-editorial-textbox/20 px-3 py-2">
+                {issue.phrase && (
+                  <div>
+                    <span className="block text-[9px] font-bold uppercase tracking-widest text-editorial-accent">{t('audit.issuePhraseContext')}</span>
+                    <p className="mt-0.5 text-[11px] leading-relaxed text-editorial-ink">&ldquo;{issue.phrase}&rdquo;</p>
+                  </div>
+                )}
+                {sourceText && (
+                  <div>
+                    <span className="block text-[9px] font-bold uppercase tracking-widest text-editorial-muted">{t('audit.issueSourceContext')}</span>
+                    <p className="mt-0.5 text-[11px] leading-relaxed text-editorial-muted line-clamp-3">{sourceText}</p>
+                  </div>
+                )}
+              </div>
+            )}
+            {issue.suggestedFix && (
+              <div className="mt-3 rounded-xl border border-editorial-border/70 bg-editorial-bg px-3 py-2 text-sm leading-relaxed text-editorial-muted">
+                <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-editorial-accent">{t('audit.fix')}</span>: {issue.suggestedFix}
+              </div>
+            )}
+          </article>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/document/tabs/NotesTab.tsx
+++ b/src/components/document/tabs/NotesTab.tsx
@@ -1,6 +1,23 @@
-import { NotebookText } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  HelpCircle,
+  MessageSquare,
+  NotebookText,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { TranslationChunk } from '../../../types';
+import { useAnnotationsStore } from '../../../stores/annotationsStore';
+import { useProjectStore } from '../../../stores/projectStore';
+import { MarkdownEditor } from '../../common';
+import type { AnnotationType, TranslationChunk } from '../../../types';
+import type { Annotation } from '../../../types';
 
 export interface NotesTabProps {
   panelId: string;
@@ -8,27 +25,294 @@ export interface NotesTabProps {
   currentChunk: TranslationChunk | null;
 }
 
-export function NotesTab({ panelId, labelledBy, currentChunk }: NotesTabProps) {
-  const { t } = useTranslation();
-  const footnotes = currentChunk?.footnotes ?? [];
+const ANNOTATION_META: Record<AnnotationType, { icon: LucideIcon; colorClass: string; bgClass: string; borderClass: string; labelKey: string }> = {
+  comment:  { icon: MessageSquare, colorClass: 'text-editorial-charcoal', bgClass: 'bg-editorial-charcoal/8', borderClass: 'border-editorial-charcoal/25', labelKey: 'annotations.typeComment' },
+  doubt:    { icon: HelpCircle,    colorClass: 'text-editorial-warning',  bgClass: 'bg-editorial-warning/8',  borderClass: 'border-editorial-warning/30',  labelKey: 'annotations.typeDoubt' },
+  problem:  { icon: AlertTriangle, colorClass: 'text-editorial-accent',   bgClass: 'bg-editorial-accent/8',   borderClass: 'border-editorial-accent/25',   labelKey: 'annotations.typeProblem' },
+  approved: { icon: CheckCircle2,  colorClass: 'text-editorial-success',  bgClass: 'bg-editorial-success/8',  borderClass: 'border-editorial-success/25',  labelKey: 'annotations.typeApproved' },
+};
 
-  if (!currentChunk || footnotes.length === 0) {
+const ANNOTATION_TYPES: AnnotationType[] = ['comment', 'doubt', 'problem', 'approved'];
+
+function AnnotationCard({
+  annotation,
+  isEditing,
+  onEdit,
+  onCancelEdit,
+  onSave,
+  onDelete,
+}: {
+  annotation: Annotation;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancelEdit: () => void;
+  onSave: (updates: Partial<Pick<Annotation, 'type' | 'content' | 'anchorText'>>) => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const meta = ANNOTATION_META[annotation.type];
+  const Icon = meta.icon;
+
+  const [editType, setEditType] = useState<AnnotationType>(annotation.type);
+  const [editContent, setEditContent] = useState(annotation.content);
+  const [editAnchor, setEditAnchor] = useState(annotation.anchorText ?? '');
+
+  if (isEditing) {
     return (
-      <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-        <NotebookText size={28} className="text-editorial-border" />
-        <p className="text-sm font-medium text-editorial-muted">{t('document.insightsNotesEmpty')}</p>
-      </div>
+      <article className={`rounded-2xl border ${meta.borderClass} ${meta.bgClass} px-4 py-3`}>
+        <TypeSelector selected={editType} onSelect={setEditType} />
+        <MarkdownEditor
+          value={editContent}
+          onChange={setEditContent}
+          markdownEnabled={false}
+          minHeightClassName="min-h-[72px]"
+          textClassName="text-sm leading-relaxed"
+          identityKey={`edit-${annotation.id}`}
+        />
+        <input
+          type="text"
+          value={editAnchor}
+          onChange={(e) => setEditAnchor(e.target.value)}
+          placeholder={t('annotations.anchorPlaceholder')}
+          className="mt-2 w-full rounded-xl border border-editorial-border bg-editorial-textbox px-3 py-1.5 text-xs text-editorial-ink placeholder:text-editorial-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+        />
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              onSave({ type: editType, content: editContent, anchorText: editAnchor.trim() || null });
+            }}
+            className="rounded-full border border-editorial-accent/50 bg-editorial-accent/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-editorial-accent transition-colors hover:bg-editorial-accent/20"
+          >
+            {t('annotations.updateButton')}
+          </button>
+          <button
+            type="button"
+            onClick={onCancelEdit}
+            className="rounded-full border border-editorial-border px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-editorial-muted transition-colors hover:text-editorial-ink"
+          >
+            {t('annotations.cancelButton')}
+          </button>
+        </div>
+      </article>
     );
   }
 
   return (
-    <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="space-y-2 px-5 py-5">
-      {footnotes.map((note) => (
-        <article key={note.id} className="rounded-2xl border border-editorial-border bg-editorial-bg px-4 py-3">
-          <div className="mb-1.5 font-display text-sm italic text-editorial-accent">{note.marker}</div>
-          <p className="text-[12px] leading-relaxed text-editorial-ink">{note.text}</p>
-        </article>
+    <article className={`rounded-2xl border ${meta.borderClass} ${meta.bgClass} px-4 py-3`}>
+      <div className="mb-2 flex items-center gap-2">
+        <Icon size={13} className={`shrink-0 ${meta.colorClass}`} />
+        <span className={`text-[10px] font-bold uppercase tracking-[0.25em] ${meta.colorClass}`}>
+          {t(meta.labelKey)}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={t('annotations.editButton')}
+          className="rounded-full p-1 text-editorial-muted transition-colors hover:text-editorial-ink"
+        >
+          <Pencil size={11} />
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label={t('annotations.deleteButton')}
+          className="rounded-full p-1 text-editorial-muted transition-colors hover:text-editorial-accent"
+        >
+          <Trash2 size={11} />
+        </button>
+      </div>
+      <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-editorial-ink">{annotation.content}</p>
+      {annotation.anchorText && (
+        <p className="mt-2 truncate rounded-lg bg-editorial-bg/60 px-2 py-1 text-[11px] italic text-editorial-muted">
+          «{annotation.anchorText}»
+        </p>
+      )}
+    </article>
+  );
+}
+
+function TypeSelector({ selected, onSelect }: { selected: AnnotationType; onSelect: (t: AnnotationType) => void }) {
+  const { t } = useTranslation();
+  return (
+    <div className="mb-3 flex flex-wrap gap-1.5">
+      {ANNOTATION_TYPES.map((type) => {
+        const meta = ANNOTATION_META[type];
+        const Icon = meta.icon;
+        const isActive = selected === type;
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onSelect(type)}
+            className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.2em] transition-colors ${
+              isActive
+                ? `${meta.borderClass} ${meta.bgClass} ${meta.colorClass}`
+                : 'border-editorial-border text-editorial-muted hover:border-editorial-accent/30 hover:text-editorial-ink'
+            }`}
+          >
+            <Icon size={10} />
+            {t(meta.labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function NotesTab({ panelId, labelledBy, currentChunk }: NotesTabProps) {
+  const { t } = useTranslation();
+  const activePipelineId = useProjectStore((s) => s.activePipelineId);
+  const { annotationsByChunkId, addAnnotation, updateAnnotation, deleteAnnotation } = useAnnotationsStore();
+
+  const [showForm, setShowForm] = useState(false);
+  const [formType, setFormType] = useState<AnnotationType>('comment');
+  const [formContent, setFormContent] = useState('');
+  const [formAnchor, setFormAnchor] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const footnotes = currentChunk?.footnotes ?? [];
+  const annotations = currentChunk ? (annotationsByChunkId.get(currentChunk.id) ?? []) : [];
+
+  if (!currentChunk) {
+    return (
+      <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+        <NotebookText size={28} className="text-editorial-border" />
+        <p className="text-sm font-medium text-editorial-muted">{t('annotations.emptyNoChunk')}</p>
+      </div>
+    );
+  }
+
+  const handleAdd = async () => {
+    if (!formContent.trim() || !activePipelineId) return;
+    await addAnnotation({
+      chunkId: currentChunk.id,
+      pipelineId: activePipelineId,
+      type: formType,
+      content: formContent.trim(),
+      anchorText: formAnchor.trim() || null,
+      sequence: annotations.length,
+    });
+    setFormContent('');
+    setFormAnchor('');
+    setFormType('comment');
+    setShowForm(false);
+  };
+
+  const handleSaveEdit = async (id: string, updates: Partial<Pick<Annotation, 'type' | 'content' | 'anchorText'>>) => {
+    await updateAnnotation(id, currentChunk.id, updates);
+    setEditingId(null);
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteAnnotation(id, currentChunk.id);
+    if (editingId === id) setEditingId(null);
+  };
+
+  return (
+    <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="flex flex-col gap-3 px-5 py-5">
+
+      {/* Add annotation button */}
+      {!showForm && (
+        <button
+          type="button"
+          onClick={() => setShowForm(true)}
+          className="flex items-center gap-2 rounded-2xl border border-dashed border-editorial-border px-4 py-2.5 text-sm text-editorial-muted transition-colors hover:border-editorial-accent/40 hover:text-editorial-accent"
+        >
+          <Plus size={14} />
+          {t('annotations.addButton')}
+        </button>
+      )}
+
+      {/* Add form */}
+      {showForm && (
+        <div className="rounded-2xl border border-editorial-border bg-editorial-textbox/40 px-4 py-3">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted">
+              {t('annotations.addButton')}
+            </span>
+            <button
+              type="button"
+              onClick={() => { setShowForm(false); setFormContent(''); setFormAnchor(''); }}
+              className="rounded-full p-1 text-editorial-muted transition-colors hover:text-editorial-ink"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          <TypeSelector selected={formType} onSelect={setFormType} />
+          <MarkdownEditor
+            value={formContent}
+            onChange={setFormContent}
+            markdownEnabled={false}
+            placeholder={t('annotations.placeholder')}
+            minHeightClassName="min-h-[72px]"
+            textClassName="text-sm leading-relaxed"
+            identityKey={`new-annotation-${currentChunk.id}`}
+          />
+          <input
+            type="text"
+            value={formAnchor}
+            onChange={(e) => setFormAnchor(e.target.value)}
+            placeholder={t('annotations.anchorPlaceholder')}
+            className="mt-2 w-full rounded-xl border border-editorial-border bg-editorial-textbox px-3 py-1.5 text-xs text-editorial-ink placeholder:text-editorial-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          />
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={!formContent.trim()}
+              className="rounded-full border border-editorial-accent/50 bg-editorial-accent/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-editorial-accent transition-colors hover:bg-editorial-accent/20 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {t('annotations.saveButton')}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowForm(false); setFormContent(''); setFormAnchor(''); }}
+              className="rounded-full border border-editorial-border px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-editorial-muted transition-colors hover:text-editorial-ink"
+            >
+              {t('annotations.cancelButton')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Annotations list */}
+      {annotations.length === 0 && !showForm && (
+        <p className="px-1 text-xs text-editorial-muted">{t('annotations.emptyNoAnnotations')}</p>
+      )}
+      {annotations.map((ann) => (
+        <AnnotationCard
+          key={ann.id}
+          annotation={ann}
+          isEditing={editingId === ann.id}
+          onEdit={() => setEditingId(ann.id)}
+          onCancelEdit={() => setEditingId(null)}
+          onSave={(updates) => handleSaveEdit(ann.id, updates)}
+          onDelete={() => handleDelete(ann.id)}
+        />
       ))}
+
+      {/* Source footnotes — collapsed, shown only when present */}
+      {footnotes.length > 0 && (
+        <>
+          <div className="mx-0 my-1 h-px bg-editorial-border/40" />
+          <details className="group">
+            <summary className="flex cursor-pointer list-none items-center gap-1.5 py-0.5 text-[10px] font-sans font-bold uppercase tracking-[0.3em] text-editorial-muted/70 transition-colors hover:text-editorial-muted">
+              <ChevronRight size={11} className="shrink-0 text-editorial-accent/60 transition-transform group-open:rotate-90" />
+              {t('annotations.sourceTitle')}
+            </summary>
+            <div className="mt-3 space-y-2">
+              {footnotes.map((note) => (
+                <article key={note.id} className="rounded-2xl border border-editorial-border bg-editorial-bg px-4 py-3">
+                  <div className="mb-1.5 font-display text-sm italic text-editorial-accent">{note.marker}</div>
+                  <p className="text-[12px] leading-relaxed text-editorial-ink">{note.text}</p>
+                </article>
+              ))}
+            </div>
+          </details>
+        </>
+      )}
     </div>
   );
 }

--- a/src/hooks/useGlossaryHighlight.ts
+++ b/src/hooks/useGlossaryHighlight.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
-import type { GlossaryEntry } from '../types';
+import type { AnnotationType, GlossaryEntry } from '../types';
 import { useDebounce } from './useDebounce';
+
+export interface AnnotationAnchor {
+  text: string;
+  type: AnnotationType;
+}
 
 export interface HighlightResult {
   html: string;
@@ -79,7 +84,10 @@ function findSpans(
 
 // Classes that use background-color (mutually exclusive per interval).
 // Classes not in this set use text-decoration and can coexist with a background.
-const BG_CLASSES = new Set(['hl-match', 'hl-mismatch', 'hl-search', 'hl-audit']);
+const BG_CLASSES = new Set([
+  'hl-match', 'hl-mismatch', 'hl-search', 'hl-audit',
+  'hl-annot-comment', 'hl-annot-doubt', 'hl-annot-problem', 'hl-annot-approved',
+]);
 
 // Builds HTML using an interval-breakpoint approach so that non-conflicting
 // highlight properties (e.g. underline + background) can coexist on the same
@@ -122,6 +130,7 @@ export function useGlossaryHighlight(
   mode: 'source' | 'translation',
   searchQuery = '',
   auditQuery = '',
+  annotationAnchors: AnnotationAnchor[] = [],
 ): HighlightResult {
   const debouncedText = useDebounce(text, 300);
   const validEntries = useMemo(
@@ -138,6 +147,8 @@ export function useGlossaryHighlight(
       })),
     [validEntries],
   );
+
+  const anchorsKey = annotationAnchors.map((a) => `${a.type}:${a.text}`).join('|');
 
   return useMemo(() => {
     if (text !== debouncedText) {
@@ -176,10 +187,16 @@ export function useGlossaryHighlight(
       spans.push(...findSpans(debouncedText, auditRe, 'hl-audit', '', 3));
     }
 
+    for (const anchor of annotationAnchors) {
+      if (!anchor.text.trim()) continue;
+      const anchorRe = new RegExp(escapeRegex(anchor.text.trim()), 'gi');
+      spans.push(...findSpans(debouncedText, anchorRe, `hl-annot-${anchor.type}`, anchor.text, 4));
+    }
+
     const matchCount = mode === 'translation'
       ? patterns.filter(({ transRe }) => { transRe.lastIndex = 0; return transRe.test(debouncedText); }).length
       : 0;
 
     return { html: buildHtml(debouncedText, spans), matchCount, totalTerms: validEntries.length };
-  }, [text, debouncedText, patterns, mode, validEntries.length, searchQuery, auditQuery]);
+  }, [text, debouncedText, patterns, mode, validEntries.length, searchQuery, auditQuery, anchorsKey]);
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -382,7 +382,9 @@
     "markResolved": "Mark as resolved",
     "markUnresolved": "Remove resolved mark",
     "markRejected": "Reject suggestion",
-    "markUnrejected": "Remove rejection"
+    "markUnrejected": "Remove rejection",
+    "issuePhraseContext": "In translation",
+    "issueSourceContext": "Source"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1322,5 +1322,25 @@
     "notes": "Notes",
     "selectGlossary": "Select glossary",
     "noGlossarySelected": "— No glossary —"
+  },
+  "annotations": {
+    "typeComment": "Comment",
+    "typeDoubt": "Doubt",
+    "typeProblem": "Problem",
+    "typeApproved": "Approved",
+    "addButton": "Add annotation",
+    "placeholder": "Describe the issue, doubt, or observation...",
+    "anchorLabel": "Anchor to text (optional)",
+    "anchorPlaceholder": "Paste the phrase it refers to...",
+    "saveButton": "Add",
+    "updateButton": "Save",
+    "cancelButton": "Cancel",
+    "deleteButton": "Delete",
+    "editButton": "Edit",
+    "badgeCount_one": "{{count}} note",
+    "badgeCount_other": "{{count}} notes",
+    "emptyNoChunk": "No chunk selected.",
+    "emptyNoAnnotations": "No annotations for this chunk.",
+    "sourceTitle": "Source footnotes"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -382,7 +382,9 @@
     "markResolved": "Segna come risolto",
     "markUnresolved": "Rimuovi marcatura risolto",
     "markRejected": "Rifiuta suggerimento",
-    "markUnrejected": "Rimuovi rifiuto"
+    "markUnrejected": "Rimuovi rifiuto",
+    "issuePhraseContext": "Nella traduzione",
+    "issueSourceContext": "Testo sorgente"
   },
   "settings": {
     "title": "Impostazioni",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1322,5 +1322,25 @@
     "notes": "Note",
     "selectGlossary": "Seleziona glossario",
     "noGlossarySelected": "— Nessun glossario —"
+  },
+  "annotations": {
+    "typeComment": "Commento",
+    "typeDoubt": "Dubbio",
+    "typeProblem": "Problema",
+    "typeApproved": "Approvato",
+    "addButton": "Aggiungi annotazione",
+    "placeholder": "Descrivi il problema, il dubbio o l'osservazione...",
+    "anchorLabel": "Ancora al testo (opzionale)",
+    "anchorPlaceholder": "Incolla la frase a cui si riferisce...",
+    "saveButton": "Aggiungi",
+    "updateButton": "Salva",
+    "cancelButton": "Annulla",
+    "deleteButton": "Elimina",
+    "editButton": "Modifica",
+    "badgeCount_one": "{{count}} nota",
+    "badgeCount_other": "{{count}} note",
+    "emptyNoChunk": "Nessun chunk selezionato.",
+    "emptyNoAnnotations": "Nessuna annotazione per questo chunk.",
+    "sourceTitle": "Note sorgente"
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,10 @@
   --hl-mismatch-bg: rgba(239, 68, 68, 0.15);
   --hl-search-bg: rgba(234, 179, 8, 0.25);
   --hl-audit-bg: rgba(249, 115, 22, 0.25);
+  --hl-annot-comment-bg: rgba(58, 122, 114, 0.18);
+  --hl-annot-doubt-bg: rgba(196, 155, 42, 0.22);
+  --hl-annot-problem-bg: rgba(200, 112, 94, 0.25);
+  --hl-annot-approved-bg: rgba(58, 122, 101, 0.20);
 }
 
 html,
@@ -172,6 +176,38 @@ mark.hl-search {
 
 mark.hl-audit {
   background-color: var(--hl-audit-bg);
+  border-radius: 2px;
+  padding: 0 1px;
+  color: inherit;
+  cursor: help;
+}
+
+mark.hl-annot-comment {
+  background-color: var(--hl-annot-comment-bg);
+  border-radius: 2px;
+  padding: 0 1px;
+  color: inherit;
+  cursor: help;
+}
+
+mark.hl-annot-doubt {
+  background-color: var(--hl-annot-doubt-bg);
+  border-radius: 2px;
+  padding: 0 1px;
+  color: inherit;
+  cursor: help;
+}
+
+mark.hl-annot-problem {
+  background-color: var(--hl-annot-problem-bg);
+  border-radius: 2px;
+  padding: 0 1px;
+  color: inherit;
+  cursor: help;
+}
+
+mark.hl-annot-approved {
+  background-color: var(--hl-annot-approved-bg);
   border-radius: 2px;
   padding: 0 1px;
   color: inherit;

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -17,6 +17,7 @@ const RESETTABLE_OBJECTS = [
   'phrase_memory',
   'phrase_memory_presets',
   'operation_logs',
+  'annotations',
   'translations',
   'macro_blocks',
   'project_glossaries',
@@ -762,6 +763,23 @@ export async function initDatabase(): Promise<void> {
       DEFAULT_MEMORY_EXTRACTOR_PROMPT,
     ],
   );
+
+  await conn.execute(`
+    CREATE TABLE IF NOT EXISTS annotations (
+      id TEXT PRIMARY KEY,
+      chunk_id TEXT NOT NULL,
+      pipeline_id TEXT NOT NULL REFERENCES pipelines(id) ON DELETE CASCADE,
+      type TEXT NOT NULL DEFAULT 'comment',
+      content TEXT NOT NULL DEFAULT '',
+      anchor_text TEXT DEFAULT NULL,
+      sequence INTEGER NOT NULL DEFAULT 0,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await conn.execute(`
+    CREATE INDEX IF NOT EXISTS idx_annotations_chunk
+    ON annotations(pipeline_id, chunk_id)
+  `);
 
   console.log('[Glossa] Database initialized');
 }

--- a/src/stores/annotationsStore.ts
+++ b/src/stores/annotationsStore.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand';
+import { select, execute } from '../services/dbService';
+import type { Annotation, AnnotationType } from '../types';
+
+interface DbAnnotationRow {
+  id: string;
+  chunk_id: string;
+  pipeline_id: string;
+  type: string;
+  content: string;
+  anchor_text: string | null;
+  sequence: number;
+  created_at: string;
+}
+
+function fromRow(row: DbAnnotationRow): Annotation {
+  return {
+    id: row.id,
+    chunkId: row.chunk_id,
+    pipelineId: row.pipeline_id,
+    type: row.type as AnnotationType,
+    content: row.content,
+    anchorText: row.anchor_text ?? undefined,
+    sequence: row.sequence,
+    createdAt: row.created_at,
+  };
+}
+
+interface AnnotationsState {
+  annotationsByChunkId: Map<string, Annotation[]>;
+
+  loadAnnotations: (pipelineId: string) => Promise<void>;
+  addAnnotation: (ann: Omit<Annotation, 'id' | 'createdAt'>) => Promise<void>;
+  updateAnnotation: (id: string, chunkId: string, updates: Partial<Pick<Annotation, 'type' | 'content' | 'anchorText'>>) => Promise<void>;
+  deleteAnnotation: (id: string, chunkId: string) => Promise<void>;
+  clearAll: () => void;
+}
+
+export const useAnnotationsStore = create<AnnotationsState>((set) => ({
+  annotationsByChunkId: new Map(),
+
+  loadAnnotations: async (pipelineId) => {
+    const rows = await select<DbAnnotationRow>(
+      `SELECT * FROM annotations WHERE pipeline_id = $1 ORDER BY chunk_id, sequence`,
+      [pipelineId],
+    );
+    const map = new Map<string, Annotation[]>();
+    for (const row of rows) {
+      const ann = fromRow(row);
+      const existing = map.get(ann.chunkId) ?? [];
+      existing.push(ann);
+      map.set(ann.chunkId, existing);
+    }
+    set({ annotationsByChunkId: map });
+  },
+
+  addAnnotation: async (ann) => {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    await execute(
+      `INSERT INTO annotations (id, chunk_id, pipeline_id, type, content, anchor_text, sequence, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [id, ann.chunkId, ann.pipelineId, ann.type, ann.content, ann.anchorText ?? null, ann.sequence, createdAt],
+    );
+    const full: Annotation = { ...ann, id, createdAt };
+    set((state) => {
+      const next = new Map(state.annotationsByChunkId);
+      const existing = next.get(ann.chunkId) ?? [];
+      next.set(ann.chunkId, [...existing, full]);
+      return { annotationsByChunkId: next };
+    });
+  },
+
+  updateAnnotation: async (id, chunkId, updates) => {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    let i = 1;
+    if (updates.type !== undefined) { sets.push(`type = $${i++}`); params.push(updates.type); }
+    if (updates.content !== undefined) { sets.push(`content = $${i++}`); params.push(updates.content); }
+    if ('anchorText' in updates) { sets.push(`anchor_text = $${i++}`); params.push(updates.anchorText ?? null); }
+    if (sets.length === 0) return;
+    params.push(id);
+    await execute(`UPDATE annotations SET ${sets.join(', ')} WHERE id = $${i}`, params);
+    set((state) => {
+      const next = new Map(state.annotationsByChunkId);
+      const existing = next.get(chunkId) ?? [];
+      next.set(chunkId, existing.map((a) => a.id === id ? { ...a, ...updates } : a));
+      return { annotationsByChunkId: next };
+    });
+  },
+
+  deleteAnnotation: async (id, chunkId) => {
+    await execute(`DELETE FROM annotations WHERE id = $1`, [id]);
+    set((state) => {
+      const next = new Map(state.annotationsByChunkId);
+      const existing = next.get(chunkId) ?? [];
+      const filtered = existing.filter((a) => a.id !== id);
+      if (filtered.length === 0) next.delete(chunkId);
+      else next.set(chunkId, filtered);
+      return { annotationsByChunkId: next };
+    });
+  },
+
+  clearAll: () => set({ annotationsByChunkId: new Map() }),
+}));

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -149,6 +149,7 @@ interface ChunksState {
   restoreChunkSourceText: (chunkId: string) => void;
   toggleChunkSourceEditing: (chunkId: string) => void;
   updateChunkCoherence: (chunkId: string, result: CoherenceResult) => void;
+  toggleCoherenceIssueResolved: (chunkId: string, key: string) => void;
   resetCompletedChunks: () => void;
   resetPreviewChunks: () => void;
   resetAllChunks: () => void;
@@ -357,6 +358,17 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
         ...chunk,
         coherenceResult: result,
       })),
+    })),
+
+  toggleCoherenceIssueResolved: (chunkId, key) =>
+    set((state) => ({
+      chunks: updateSingleChunk(state.chunks, chunkId, (chunk) => {
+        const current = chunk.coherenceResult;
+        if (!current) return chunk;
+        const keys = current.resolvedIssueKeys ?? [];
+        const next = keys.includes(key) ? keys.filter((k) => k !== key) : [...keys, key];
+        return { ...chunk, coherenceResult: { ...current, resolvedIssueKeys: next } };
+      }),
     })),
 
   resetCompletedChunks: () =>

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -28,6 +28,7 @@ import { buildProjectSnapshot } from '../utils/projectSnapshot';
 import { logger } from '../utils/logger';
 import { runInTransaction } from '../services/dbService';
 import { useWorkspaceStore } from './workspaceStore';
+import { useAnnotationsStore } from './annotationsStore';
 import type { Pipeline, PipelineConfig } from '../types';
 
 let saveInFlight: Promise<void> | null = null;
@@ -182,6 +183,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }
 
     useChunksStore.getState().setChunks(restoredChunks);
+
+    if (activePipelineId) {
+      const annStore = useAnnotationsStore.getState();
+      annStore.clearAll();
+      await annStore.loadAnnotations(activePipelineId);
+    }
+
     useUiStore.getState().setViewMode(
       source.viewMode ?? (restoredChunks.length === 0 && source.sourceDisplayText.trim() ? 'sandbox' : 'document'),
     );
@@ -213,6 +221,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     useChunksStore.setState({ chunks: [], isProcessing: false, cancelRequested: false, activeStreamId: null });
     usePipelineStore.getState().resetToDefaults();
     useOperationLogStore.setState({ entries: [], currentProjectId: null });
+    useAnnotationsStore.getState().clearAll();
     set({
       currentProjectId: null,
       pipelines: [],
@@ -355,6 +364,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }));
 
     useChunksStore.getState().setChunks(restoreTranslations(savedTranslations));
+
+    const annStore = useAnnotationsStore.getState();
+    annStore.clearAll();
+    await annStore.loadAnnotations(pipelineId);
+
     useUiStore.getState().setSelectedChunkId(null);
 
     set({

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,7 @@ export interface Issue {
 export interface CoherenceResult {
   status: 'idle' | 'processing' | 'completed' | 'error';
   issues: Issue[];
+  resolvedIssueKeys?: string[];
   error?: string;
   tokenUsage?: TokenUsage;
   promptInfo?: PromptInfo;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,16 @@
 export type ModelProvider = 'gemini' | 'openai' | 'anthropic' | 'deepseek' | 'ollama';
+export type AnnotationType = 'comment' | 'doubt' | 'problem' | 'approved';
+
+export interface Annotation {
+  id: string;
+  chunkId: string;
+  pipelineId: string;
+  type: AnnotationType;
+  content: string;
+  anchorText?: string | null;
+  sequence: number;
+  createdAt: string;
+}
 export type ModelReasoningClass = 'reasoning' | 'non_reasoning' | 'optional';
 export type ModelStatus = 'stable' | 'preview' | 'deprecated';
 export type QualityRating = 'critical' | 'poor' | 'fair' | 'good' | 'excellent';


### PR DESCRIPTION
## Summary

- Introduces a typed, per-chunk annotation system for the review phase
- Users can add multiple annotations per chunk (comment, doubt, problem, approved), each with optional markdown content and an anchor phrase
- Anchor phrases are highlighted in the translation editor with type-specific colors
- Chunk grid dots and index list show colored visual indicators when annotations are present
- Annotations persist in a new \`annotations\` SQLite table and survive pipeline re-runs

**Also fixes (#262 partial):**
- Audit phrase highlight clears when issue is marked resolved/rejected
- Locate-in-text button is now a toggle (click again to deactivate)
- Navigating to a different chunk clears the active audit highlight
- Chunk summary panel shows aggregated translation/audit stats (all stages combined) instead of only the last single stage

## Merge order

~~Must be merged AFTER feat/issue-244-audit-results~~ — resolved: rebased onto main.

## Changes

| Area | What changed |
|---|---|
| DB | New \`annotations\` table (idempotent CREATE IF NOT EXISTS) |
| Types | \`AnnotationType\`, \`Annotation\` in \`types.ts\` |
| Store | New \`annotationsStore.ts\` — CRUD + load/clear lifecycle |
| Project lifecycle | \`openProject\`, \`switchPipeline\`, \`closeProject\` load/clear annotations |
| Highlight | \`useGlossaryHighlight\` extended with \`annotationAnchors\` param |
| CSS | 4 new \`hl-annot-*\` CSS vars + mark classes |
| UI | \`NotesTab\` rewritten — inline add/edit form, typed cards |
| UI | Chunk grid dots get colored badge when chunk has annotations |
| UI | \`IndexTab\` shows note count badge with priority color |
| UI | Audit highlight clears on resolve/reject and chunk navigation |
| Stats | \`ChunkSummaryTab\` shows aggregated per-category stats |
| i18n | \`annotations.*\` keys + updated chunk summary labels |

## Test plan

- [ ] App starts without errors — \`annotations\` table created
- [ ] Add annotation of type Problem → red card, chunk dot red badge
- [ ] Add annotation with anchor → phrase highlighted in translation editor
- [ ] Edit and delete annotation → updates reflected immediately
- [ ] Close and reopen project → annotations persisted
- [ ] Locate-in-text on audit issue → click again → clears highlight
- [ ] Mark audit issue as resolved → highlight disappears
- [ ] Navigate to different chunk → audit highlight clears
- [ ] Chunk summary panel → "Traduzione" card shows totals across all stages