### PR TITLE
security: hardening pre-1.0 — 6 finding da audit (#254)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,15 @@ jobs:
       - name: Run cargo audit
         # RUSTSEC-2023-0071: rsa Marvin Attack via tauri-plugin-sql -> sqlx-mysql, no upstream fix
         run: cd src-tauri && cargo audit --ignore RUSTSEC-2023-0071
+
+  security-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify release CSP has no unsafe-eval
+        run: |
+          if grep -q "unsafe-eval" src-tauri/tauri.release.conf.json; then
+            echo "ERROR: 'unsafe-eval' found in tauri.release.conf.json — remove it before merging"
+            exit 1
+          fi
+          echo "CSP check passed: no unsafe-eval in release config"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -356,4 +356,20 @@ source_phrase_embeddings
 
 ---
 
-*Ultimo aggiornamento: 2026-06-10 — branch feat/issue-244-audit-results*
+---
+
+## Note di Sicurezza (modello di minaccia: desktop single-user)
+
+### Cache in-memoria delle API key
+
+`keystore.rs` mantiene una `HashMap<String, String>` statica (`API_KEY_CACHE`) che contiene le chiavi API in chiaro per la durata del processo, per evitare accessi ripetuti al keyring di sistema. Le chiavi rimangono nella heap del processo fino alla chiusura dell'app.
+
+**Implicazione**: un attaccante con accesso locale al sistema (malware, processo con privilegi equivalenti) può recuperare le chiavi da un memory dump del processo Glossa. Questo è accettabile nel modello di minaccia dichiarato (desktop single-user, nessun attaccante remoto), ma il comportamento va tenuto presente: non estendere la cache a token o credenziali con vita breve senza rivalutare il rischio.
+
+### Logging in release e RUST_LOG
+
+In release (`!debug_assertions`) il livello di log predefinito è `Info`. `RUST_LOG` viene letto a runtime (`lib.rs`) e può sovrascrivere questo default.
+
+**Implicazione**: impostare `RUST_LOG=debug` o `RUST_LOG=trace` su una build release espone log verbosi, inclusi dettagli delle richieste LLM (provider, modello, timing). Non vengono loggati contenuti di prompt o risposte, ma provider e metadati sì. In un contesto di supporto tecnico, chiedere sempre di verificare che `RUST_LOG` non sia impostato prima di condividere i log.
+
+*Ultimo aggiornamento: 2026-06-11 — branch security/issue-254-hardening*

--- a/src-tauri/src/documents/mod.rs
+++ b/src-tauri/src/documents/mod.rs
@@ -1,5 +1,22 @@
 use std::fs;
 
+const MAX_DOCX_BYTES: u64 = 100 * 1024 * 1024;
+const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
+
+fn check_file_size(path: &str, limit: u64) -> Result<(), String> {
+    let size = fs::metadata(path)
+        .map_err(|e| format!("Failed to read file metadata: {e}"))?
+        .len();
+    if size > limit {
+        return Err(format!(
+            "File too large: {} bytes (limit {} MB)",
+            size,
+            limit / 1024 / 1024
+        ));
+    }
+    Ok(())
+}
+
 pub mod docx_export;
 pub mod docx_extract;
 pub mod pdf_extract;
@@ -16,6 +33,7 @@ pub(crate) use pdf_extract::normalize_pdf_text;
 
 #[tauri::command]
 pub async fn extract_docx_text(path: String) -> Result<String, String> {
+    check_file_size(&path, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_text_from_bytes(&bytes)
@@ -26,6 +44,7 @@ pub async fn extract_docx_text(path: String) -> Result<String, String> {
 
 #[tauri::command]
 pub async fn extract_docx_markdown(path: String) -> Result<String, String> {
+    check_file_size(&path, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_markdown_from_bytes(&bytes)
@@ -36,6 +55,7 @@ pub async fn extract_docx_markdown(path: String) -> Result<String, String> {
 
 #[tauri::command]
 pub async fn extract_pdf_text(path: String) -> Result<String, String> {
+    check_file_size(&path, MAX_PDF_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_pdf_text_from_bytes(&bytes)
@@ -85,6 +105,41 @@ mod tests {
             writer.finish().unwrap();
         }
         buffer
+    }
+
+    #[test]
+    fn check_file_size_accepts_file_within_limit() {
+        let path = std::env::temp_dir().join("glossa_test_size_ok.bin");
+        std::fs::write(&path, b"small content").unwrap();
+        assert!(check_file_size(path.to_str().unwrap(), MAX_DOCX_BYTES).is_ok());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn check_file_size_rejects_file_over_limit() {
+        let path = std::env::temp_dir().join("glossa_test_size_over.bin");
+        std::fs::write(&path, b"data").unwrap();
+        let result = check_file_size(path.to_str().unwrap(), 1);
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("File too large"));
+    }
+
+    #[test]
+    fn check_file_size_rejects_missing_file() {
+        let result = check_file_size("/nonexistent_glossa_test_path_xyz.docx", MAX_DOCX_BYTES);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read file metadata"));
+    }
+
+    #[test]
+    fn docx_limit_is_100mb() {
+        assert_eq!(MAX_DOCX_BYTES, 100 * 1024 * 1024);
+    }
+
+    #[test]
+    fn pdf_limit_is_50mb() {
+        assert_eq!(MAX_PDF_BYTES, 50 * 1024 * 1024);
     }
 
     #[test]

--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -44,6 +44,25 @@ fn set_owner_only_permissions(path: &PathBuf) -> Result<(), String> {
             .map_err(|e| format!("Failed to set restrictive file permissions: {e}"))?;
     }
 
+    #[cfg(windows)]
+    {
+        use std::process::Command;
+        let path_str = path.to_string_lossy();
+        let username = std::env::var("USERNAME")
+            .map_err(|_| "Cannot determine current Windows user".to_string())?;
+        let acl_entry = format!("{}:F", username);
+        let output = Command::new("icacls")
+            .args([&*path_str, "/inheritance:r", "/grant:r", &acl_entry])
+            .output()
+            .map_err(|e| format!("icacls execution failed: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "Failed to restrict keystore permissions: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/llm/providers/mod.rs
+++ b/src-tauri/src/llm/providers/mod.rs
@@ -14,7 +14,7 @@ pub fn get_provider(
         "openai" => Ok(Box::new(openai::openai())),
         "deepseek" => Ok(Box::new(openai::deepseek())),
         "anthropic" => Ok(Box::new(anthropic::AnthropicProvider)),
-        "ollama" => Ok(Box::new(ollama::OllamaProvider::new(ollama_base_url))),
+        "ollama" => Ok(Box::new(ollama::OllamaProvider::new(ollama_base_url)?)),
         _ => Err(format!("Unknown provider: {id}")),
     }
 }

--- a/src-tauri/src/llm/providers/ollama.rs
+++ b/src-tauri/src/llm/providers/ollama.rs
@@ -19,6 +19,69 @@ use crate::llm::types::{OllamaConfig, OllamaPreflightStatus};
 const OLLAMA_BASE_URL: &str = "http://localhost:11434";
 const OLLAMA_PREFLIGHT_CACHE_TTL_SECS: u64 = 5;
 
+fn validate_ollama_base_url(url: &str) -> Result<(), String> {
+    // Extract host from "scheme://host:port/path" using basic string parsing.
+    // We don't add a url crate dependency — reqwest is available but Url isn't re-exported.
+    let after_scheme = url
+        .find("://")
+        .map(|i| &url[i + 3..])
+        .ok_or_else(|| format!("Invalid Ollama URL (missing scheme): {url}"))?;
+    let host = if after_scheme.starts_with('[') {
+        // IPv6 bracketed address: [::1]:port/path → extract between brackets
+        after_scheme
+            .strip_prefix('[')
+            .and_then(|s| s.split(']').next())
+            .unwrap_or("")
+    } else {
+        after_scheme
+            .split(['/', ':', '?', '#'])
+            .next()
+            .unwrap_or("")
+    };
+    let is_loopback = matches!(host, "localhost" | "127.0.0.1" | "::1");
+    if !is_loopback {
+        return Err(format!(
+            "Ollama URL must point to localhost or loopback address, got: {host}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod url_validation_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_localhost() {
+        assert!(validate_ollama_base_url("http://localhost:11434").is_ok());
+    }
+
+    #[test]
+    fn accepts_127_0_0_1() {
+        assert!(validate_ollama_base_url("http://127.0.0.1:11434").is_ok());
+    }
+
+    #[test]
+    fn accepts_ipv6_loopback() {
+        assert!(validate_ollama_base_url("http://[::1]:11434").is_ok());
+    }
+
+    #[test]
+    fn rejects_lan_ip() {
+        assert!(validate_ollama_base_url("http://192.168.1.1:11434").is_err());
+    }
+
+    #[test]
+    fn rejects_external_host() {
+        assert!(validate_ollama_base_url("http://internal-server/api").is_err());
+    }
+
+    #[test]
+    fn rejects_url_without_scheme() {
+        assert!(validate_ollama_base_url("localhost:11434").is_err());
+    }
+}
+
 /// Strip userinfo (user:pass@) from a URL before including it in error messages.
 fn sanitize_url_for_display(url: &str) -> &str {
     if let Some(scheme_end) = url.find("://") {
@@ -46,10 +109,10 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: Option<String>) -> Self {
-        OllamaProvider {
-            base_url: base_url.unwrap_or_else(|| OLLAMA_BASE_URL.to_string()),
-        }
+    pub fn new(base_url: Option<String>) -> Result<Self, String> {
+        let url = base_url.unwrap_or_else(|| OLLAMA_BASE_URL.to_string());
+        validate_ollama_base_url(&url)?;
+        Ok(OllamaProvider { base_url: url })
     }
 }
 

--- a/src-tauri/src/vector/mod.rs
+++ b/src-tauri/src/vector/mod.rs
@@ -8,6 +8,10 @@ use tauri::Manager;
 /// Must be called once at startup before opening any connection.
 /// After registration every rusqlite::Connection will have vec_* functions available.
 pub fn register_vec_extension() {
+    // SAFETY: sqlite_vec::sqlite3_vec_init is a valid SQLite auto-extension entry point
+    // whose C signature matches what sqlite3_auto_extension expects. The *const () cast
+    // erases the type at the FFI boundary; transmute restores the concrete function pointer
+    // type required by the API. This follows the documented sqlite-vec integration pattern.
     #[allow(clippy::missing_transmute_annotations)]
     unsafe {
         sqlite3_auto_extension(Some(std::mem::transmute(

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -135,6 +135,48 @@ describe('runInTransaction', () => {
   });
 });
 
+describe('ensureColumn definition validation', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('accepts INTEGER DEFAULT 0', async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition('INTEGER DEFAULT 0')).not.toThrow();
+  });
+
+  it('accepts TEXT DEFAULT NULL', async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition('TEXT DEFAULT NULL')).not.toThrow();
+  });
+
+  it("accepts TEXT DEFAULT ''", async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition("TEXT DEFAULT ''")).not.toThrow();
+  });
+
+  it("accepts TEXT DEFAULT 'value'", async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition("TEXT DEFAULT 'idle'")).not.toThrow();
+  });
+
+  it('rejects SQL injection in definition', async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition("TEXT; DROP TABLE users--")).toThrow('Invalid column definition');
+  });
+
+  it('rejects subquery in definition', async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition("TEXT DEFAULT (SELECT password FROM users)")).toThrow('Invalid column definition');
+  });
+
+  it('accepts INTEGER NOT NULL DEFAULT 0', async () => {
+    const { validateColumnDefinition } = await import('./dbService');
+    expect(() => validateColumnDefinition('INTEGER NOT NULL DEFAULT 0')).not.toThrow();
+  });
+});
+
 describe('ensureColumn whitelist', () => {
   afterEach(() => {
     vi.resetModules();

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -118,10 +118,19 @@ const ALLOWED_MIGRATIONS = new Set([
   'pipelines.phrase_memory_max_results',
 ]);
 
+const VALID_COLUMN_DEFINITION = /^(INTEGER|TEXT|REAL|BLOB|NUMERIC)(\s+NOT\s+NULL)?(\s+DEFAULT\s+('[^']*'|NULL|-?\d+(\.\d+)?))?$/i;
+
+export function validateColumnDefinition(definition: string): void {
+  if (!VALID_COLUMN_DEFINITION.test(definition)) {
+    throw new Error(`[dbService] Invalid column definition: "${definition}"`);
+  }
+}
+
 export async function ensureColumn(table: string, column: string, definition: string): Promise<void> {
   if (!ALLOWED_MIGRATIONS.has(`${table}.${column}`)) {
     throw new Error(`[dbService] ensureColumn: migration not allowed for "${table}.${column}"`);
   }
+  validateColumnDefinition(definition);
   const conn = await getDb();
   const columns = await conn.select<Array<{ name: string }>>(`PRAGMA table_info(${table})`);
   if (columns.some((existing) => existing.name === column)) {

--- a/src/services/markdown.test.ts
+++ b/src/services/markdown.test.ts
@@ -107,4 +107,44 @@ describe('markdown service', () => {
       expect(text).toContain('Alice | 30');
     });
   });
+
+  describe('link protocol sanitization', () => {
+    it('preserves https links', () => {
+      const result = renderMarkdownToHtmlFragment('[click](https://example.com)');
+      expect(result).toContain('href="https://example.com"');
+    });
+
+    it('preserves http links', () => {
+      const result = renderMarkdownToHtmlFragment('[click](http://example.com)');
+      expect(result).toContain('href="http://example.com"');
+    });
+
+    it('preserves anchor links', () => {
+      const result = renderMarkdownToHtmlFragment('[click](#section)');
+      expect(result).toContain('href="#section"');
+    });
+
+    it('blocks javascript: protocol', () => {
+      const result = renderMarkdownToHtmlFragment('[click](javascript:alert(1))');
+      expect(result).toContain('href="#"');
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('blocks data: protocol', () => {
+      const result = renderMarkdownToHtmlFragment('[click](data:text/html,<script>alert(1)</script>)');
+      expect(result).toContain('href="#"');
+      expect(result).not.toContain('data:');
+    });
+
+    it('blocks vbscript: protocol', () => {
+      const result = renderMarkdownToHtmlFragment('[click](vbscript:msgbox(1))');
+      expect(result).toContain('href="#"');
+      expect(result).not.toContain('vbscript:');
+    });
+
+    it('preserves mailto links', () => {
+      const result = renderMarkdownToHtmlFragment('[contact](mailto:info@example.com)');
+      expect(result).toContain('href="mailto:info@example.com"');
+    });
+  });
 });

--- a/src/services/markdown.ts
+++ b/src/services/markdown.ts
@@ -304,7 +304,9 @@ function parseInlineMarkdown(text: string): MarkdownInlineNode[] {
 
     const link = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
     if (link) {
-      nodes.push({ type: 'link', text: link[1], href: link[2] });
+      const rawHref = link[2];
+      const safeHref = /^(https?:\/\/|mailto:|#)/.test(rawHref) ? rawHref : '#';
+      nodes.push({ type: 'link', text: link[1], href: safeHref });
       index += link[0].length;
       continue;
     }


### PR DESCRIPTION
## Summary

Fix dei 6 finding emersi dall'audit di sicurezza pre-1.0 (issue #254). Modello di minaccia: desktop single-user (malware locale, documento malevolo importato, prompt injection).

- **HIGH**: sanitize protocollo link markdown (`javascript:`, `data:`, `vbscript:` → `#`)
- **HIGH**: validazione parametro `definition` in `ensureColumn` contro SQL injection
- **MEDIUM**: limiti dimensione file all'import (100 MB docx, 50 MB pdf) prima di `fs::read`
- **MEDIUM**: permessi file keystore owner-only su Windows via `icacls`
- **MEDIUM**: URL Ollama validato lato Rust — solo localhost/loopback (anti-SSRF)
- **LOW**: CI fallisce se `unsafe-eval` compare nel release config CSP
- **LOW**: commento `// SAFETY:` sul transmute in `vector/mod.rs`
- **LOW**: documentazione cache API key in-memoria e comportamento `RUST_LOG` in release

## Test plan

- [ ] `npx vitest run` — 449 test TS, tutti PASS
- [ ] `cargo test` — 120 test Rust, tutti PASS
- [ ] Test manuale: incollare `[testo](javascript:alert(1))` nel documento → il link non esegue JS
- [ ] Test manuale: importare file >100 MB → messaggio di errore chiaro
- [ ] CI verde su tutti i job incluso `security-checks`

Closes #254