### PR TITLE
fix: audit highlight stale, date format EU 24h, embedding regen UX

### DIFF
--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -86,6 +86,7 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
   const selectedChunkId = useUiStore((state) => state.selectedChunkId);
   const setSelectedChunkId = useUiStore((state) => state.setSelectedChunkId);
   const focusIssueInChunk = useUiStore((state) => state.focusIssueInChunk);
+  const clearFocusedIssue = useUiStore((state) => state.clearFocusedIssue);
   const chunks = useChunksStore((state) => state.chunks);
   const isProcessing = useChunksStore((state) => state.isProcessing);
   const allChunksTranslated = chunks.length > 0 && chunks.every((c) => c.currentDraft?.trim());
@@ -104,6 +105,11 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
       setDocumentDrawerTab('index');
     }
   }, [hasGlossary, documentDrawerTab, setDocumentDrawerTab]);
+
+  // Clear audit phrase highlight when switching tabs or chunks.
+  useEffect(() => {
+    clearFocusedIssue();
+  }, [chunkDrawerTab, selectedChunkId, clearFocusedIssue]);
 
   const docTabButtonRefs = useRef<Partial<Record<InsightsDrawerTab, HTMLButtonElement | null>>>({});
   const chunkTabButtonRefs = useRef<Partial<Record<ChunkDrawerTab, HTMLButtonElement | null>>>({});

--- a/src/components/document/tabs/ChunkSummaryTab.tsx
+++ b/src/components/document/tabs/ChunkSummaryTab.tsx
@@ -10,6 +10,7 @@ import {
   summarizeChunkUsage,
   type OperationLogRunSummary,
 } from '../../../utils/operationLogStats';
+import { formatDateTime } from '../../../utils';
 import type { TranslationChunk } from '../../../types';
 
 function StatRow({ label, value }: { label: string; value: string }) {
@@ -25,12 +26,10 @@ function RunSummaryCard({
   title,
   emptyLabel,
   run,
-  locale,
 }: {
   title: string;
   emptyLabel: string;
   run: OperationLogRunSummary | null;
-  locale: string;
 }) {
   const { t } = useTranslation();
 
@@ -43,7 +42,7 @@ function RunSummaryCard({
         <p className="text-[11px] leading-relaxed text-editorial-muted/70">{emptyLabel}</p>
       ) : (
         <dl className="space-y-2">
-          <StatRow label={t('document.summaryWhen')} value={new Date(run.at).toLocaleString(locale)} />
+          <StatRow label={t('document.summaryWhen')} value={formatDateTime(run.at)} />
           {run.stageName ? <StatRow label={t('document.summaryStage')} value={run.stageName} /> : null}
           <StatRow label={t('document.summaryModel')} value={[run.provider, run.model].filter(Boolean).join(' / ') || '—'} />
           <StatRow label={t('document.summaryTokens')} value={(run.stats.totalInput + run.stats.totalOutput).toLocaleString()} />
@@ -64,7 +63,7 @@ export interface ChunkSummaryTabProps {
 }
 
 export function ChunkSummaryTab({ panelId, labelledBy, currentChunk }: ChunkSummaryTabProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const pricingOverrides = usePricingStore((s) => s.overrides);
   const logEntries = useOperationLogStore((s) => s.entries);
   const chunkSummary = useMemo(
@@ -103,14 +102,12 @@ export function ChunkSummaryTab({ panelId, labelledBy, currentChunk }: ChunkSumm
         title={t('document.chunkSummaryLastTranslation')}
         emptyLabel={t('document.chunkSummaryNoTranslation')}
         run={chunkSummary.lastTranslationRun}
-        locale={i18n.language}
       />
 
       <RunSummaryCard
         title={t('document.chunkSummaryLastAudit')}
         emptyLabel={t('document.chunkSummaryNoAudit')}
         run={chunkSummary.lastAuditRun}
-        locale={i18n.language}
       />
     </div>
   );

--- a/src/components/library/MemoriesTab.tsx
+++ b/src/components/library/MemoriesTab.tsx
@@ -486,7 +486,8 @@ function MemoryTextarea({
 function formatDate(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(date.getDate())}/${p(date.getMonth() + 1)}/${date.getFullYear()} ${p(date.getHours())}:${p(date.getMinutes())}`;
 }
 
 function workspaceName(workspaceId: string, workspaces: Workspace[]) {

--- a/src/components/projects/ProjectPanel.tsx
+++ b/src/components/projects/ProjectPanel.tsx
@@ -7,7 +7,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { confirm } from '../../stores/confirmStore';
-import { relativeDateUnit } from '../../utils';
+import { relativeDateUnit, formatDateTime } from '../../utils';
 import { EditorialModalShell } from '../common';
 import { IconButton, PillButton, SectionLabel } from '../ui';
 
@@ -234,7 +234,7 @@ export function ProjectPanel() {
                     </p>
                   ) : null}
                   {projects.map((project) => {
-                    const absoluteDate = new Date(project.updated_at).toLocaleString();
+                    const absoluteDate = formatDateTime(project.updated_at);
                     const relativeLabel = formatRelative(project.updated_at);
                     const isOpening = openingProjectId === project.id;
                     const isDimmed = openingProjectId !== null && !isOpening;

--- a/src/components/workspace/WorkspaceSettingsModal.tsx
+++ b/src/components/workspace/WorkspaceSettingsModal.tsx
@@ -244,31 +244,32 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                         {t('workspace.embeddingModel')}
                       </p>
                     </div>
-                    <select
-                      value={embeddingModel}
-                      onChange={(e) => setEmbeddingModel(e.target.value as EmbeddingModel)}
-                      className="w-full rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-3 py-2 text-xs font-mono text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                    >
-                      <option value="text-embedding-3-small">text-embedding-3-small</option>
-                      <option value="text-embedding-3-large">text-embedding-3-large</option>
-                    </select>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={embeddingModel}
+                        onChange={(e) => setEmbeddingModel(e.target.value as EmbeddingModel)}
+                        className="flex-1 rounded-[12px] border border-editorial-border/60 bg-editorial-textbox/60 px-3 py-2 text-xs font-mono text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                      >
+                        <option value="text-embedding-3-small">text-embedding-3-small</option>
+                        <option value="text-embedding-3-large">text-embedding-3-large</option>
+                      </select>
+                      <IconButton
+                        size="md"
+                        tone={embeddingModel !== activeWorkspace?.embeddingModel ? 'accent' : 'default'}
+                        onClick={() => void handleRegenerateEmbeddings()}
+                        disabled={isRegenerating || !activeWorkspace || embeddingModel === activeWorkspace?.embeddingModel}
+                        title={t('workspace.regenerateEmbeddings')}
+                        tooltipSide="left"
+                      >
+                        {isRegenerating
+                          ? <Loader2 size={13} className="animate-spin" />
+                          : <RefreshCcw size={13} />}
+                      </IconButton>
+                    </div>
                     {embeddingModel !== activeWorkspace?.embeddingModel && (
-                      <div className="flex items-center gap-3 rounded-lg border border-editorial-accent/30 bg-editorial-accent/8 px-3 py-2">
-                        <p className="flex-1 text-sm leading-relaxed text-editorial-accent [text-wrap:pretty]">
-                          {t('workspace.embeddingChangeWarning')}
-                        </p>
-                        <button
-                          type="button"
-                          onClick={() => void handleRegenerateEmbeddings()}
-                          disabled={isRegenerating || !activeWorkspace}
-                          className="flex shrink-0 items-center gap-1.5 rounded-full border border-editorial-accent/50 px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-editorial-accent transition-colors hover:bg-editorial-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                          {isRegenerating
-                            ? <Loader2 size={11} className="animate-spin" />
-                            : <RefreshCcw size={11} />}
-                          {t('workspace.regenerateEmbeddings')}
-                        </button>
-                      </div>
+                      <p className="rounded-lg border border-editorial-accent/30 bg-editorial-accent/8 px-3 py-2 text-sm leading-relaxed text-editorial-accent [text-wrap:pretty]">
+                        {t('workspace.embeddingChangeWarning')}
+                      </p>
                     )}
                   </div>
                   <MemoryExtractorSettings

--- a/src/components/workspace/WorkspaceSettingsModal.tsx
+++ b/src/components/workspace/WorkspaceSettingsModal.tsx
@@ -81,7 +81,7 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
     if (!activeWorkspace) return;
     setIsRegenerating(true);
     try {
-      const count = await regenerateAllEmbeddings(activeWorkspace.id, activeWorkspace.embeddingModel);
+      const count = await regenerateAllEmbeddings(activeWorkspace.id, embeddingModel);
       toast.success(t('workspace.embeddingsRegenerated', { count }));
     } catch (err: unknown) {
       toast.error(t('workspace.embeddingsRegenerateFailed'), {
@@ -253,9 +253,22 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                       <option value="text-embedding-3-large">text-embedding-3-large</option>
                     </select>
                     {embeddingModel !== activeWorkspace?.embeddingModel && (
-                      <p className="rounded-lg border border-editorial-accent/30 bg-editorial-accent/8 px-3 py-2 text-sm leading-relaxed text-editorial-accent [text-wrap:pretty]">
-                        {t('workspace.embeddingChangeWarning')}
-                      </p>
+                      <div className="flex items-center gap-3 rounded-lg border border-editorial-accent/30 bg-editorial-accent/8 px-3 py-2">
+                        <p className="flex-1 text-sm leading-relaxed text-editorial-accent [text-wrap:pretty]">
+                          {t('workspace.embeddingChangeWarning')}
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => void handleRegenerateEmbeddings()}
+                          disabled={isRegenerating || !activeWorkspace}
+                          className="flex shrink-0 items-center gap-1.5 rounded-full border border-editorial-accent/50 px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-editorial-accent transition-colors hover:bg-editorial-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {isRegenerating
+                            ? <Loader2 size={11} className="animate-spin" />
+                            : <RefreshCcw size={11} />}
+                          {t('workspace.regenerateEmbeddings')}
+                        </button>
+                      </div>
                     )}
                   </div>
                   <MemoryExtractorSettings
@@ -270,32 +283,6 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                     onPromptChange={setMemoryExtractorPrompt}
                   />
 
-                  <div className="rounded-[20px] border border-editorial-border bg-editorial-bg/70 px-5 py-4">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="space-y-1">
-                        <div className="flex items-center gap-1.5">
-                          <RefreshCcw size={11} className="shrink-0 text-editorial-accent" />
-                          <p className="text-xs font-sans uppercase tracking-[0.22em] text-editorial-muted">
-                            {t('workspace.regenerateEmbeddings')}
-                          </p>
-                        </div>
-                        <p className="text-xs leading-relaxed text-editorial-muted [text-wrap:pretty]">
-                          {t('workspace.regenerateEmbeddingsHint', { model: activeWorkspace?.embeddingModel })}
-                        </p>
-                      </div>
-                      <IconButton
-                        size="md"
-                        title={t('workspace.regenerateEmbeddings')}
-                        onClick={() => void handleRegenerateEmbeddings()}
-                        disabled={isRegenerating || !activeWorkspace}
-                        tooltipSide="left"
-                      >
-                        {isRegenerating
-                          ? <Loader2 size={13} className="animate-spin" />
-                          : <RefreshCcw size={13} />}
-                      </IconButton>
-                    </div>
-                  </div>
                 </div>
               )}
 

--- a/src/components/workspace/WorkspaceSettingsModal.tsx
+++ b/src/components/workspace/WorkspaceSettingsModal.tsx
@@ -255,7 +255,7 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                       </select>
                       <IconButton
                         size="md"
-                        tone={embeddingModel !== activeWorkspace?.embeddingModel ? 'accent' : 'default'}
+                        tone="default"
                         onClick={() => void handleRegenerateEmbeddings()}
                         disabled={isRegenerating || !activeWorkspace || embeddingModel === activeWorkspace?.embeddingModel}
                         title={t('workspace.regenerateEmbeddings')}

--- a/src/components/workspace/WorkspaceSettingsModal.tsx
+++ b/src/components/workspace/WorkspaceSettingsModal.tsx
@@ -259,7 +259,7 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                         onClick={() => void handleRegenerateEmbeddings()}
                         disabled={isRegenerating || !activeWorkspace || embeddingModel === activeWorkspace?.embeddingModel}
                         title={t('workspace.regenerateEmbeddings')}
-                        tooltipSide="left"
+                        tooltipSide="top"
                       >
                         {isRegenerating
                           ? <Loader2 size={13} className="animate-spin" />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -617,7 +617,7 @@
     "descriptionLabel": "Description",
     "namePlaceholder": "Workspace name",
     "descriptionPlaceholder": "Workspace description",
-    "embeddingChangeWarning": "Changing the embedding model requires regenerating existing memory embeddings. Save only if you really want to change model.",
+    "embeddingChangeWarning": "Model changed. Regenerate embeddings to apply.",
     "regenerateEmbeddings": "Regenerate all embeddings",
     "regenerateEmbeddingsHint": "Re-embeds all memory entries with the current model ({{model}}).",
     "embeddingsRegenerated": "{{count}} entries successfully re-embedded.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -617,7 +617,7 @@
     "descriptionLabel": "Descrizione",
     "namePlaceholder": "Nome workspace",
     "descriptionPlaceholder": "Descrizione del workspace",
-    "embeddingChangeWarning": "Cambiare modello embedding richiede rigenerare gli embedding esistenti della memoria. Salva solo se vuoi davvero cambiare modello.",
+    "embeddingChangeWarning": "Modello cambiato. Rigenera gli embedding per applicare.",
     "regenerateEmbeddings": "Rigenera tutti gli embedding",
     "regenerateEmbeddingsHint": "Ri-embeds tutte le entry della memoria con il modello corrente ({{model}}).",
     "embeddingsRegenerated": "{{count}} entry ri-embedded con successo.",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -531,4 +531,10 @@ export function generateId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
+export function formatDateTime(value: string | number | Date): string {
+  const d = new Date(value);
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getDate())}/${p(d.getMonth() + 1)}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
 export { withRetry, friendlyError, classifyError } from './retry';


### PR DESCRIPTION
## Summary

- Clear `focusedIssueQuery` when switching chunk drawer tabs or chunks (audit phrase highlight no longer stays highlighted after navigating away)
- Add `formatDateTime` utility (dd/MM/yyyy HH:mm) and apply it everywhere dates are displayed
- Move embedding regeneration button into the model-change warning block; remove the separate standalone card. Regen now uses the locally selected model (not yet saved)

Closes #262

## Test plan

- [ ] Open audit tab, click "locate" on an issue → phrase is highlighted in document
- [ ] Switch to a different chunk drawer tab (e.g. Notes) → highlight clears
- [ ] Switch back to audit, click locate again → switch to different chunk → highlight clears
- [ ] Check date displays in ChunkSummaryTab, MemoriesTab, ProjectPanel — format is dd/MM/yyyy HH:mm
- [ ] Open workspace settings → Memory tab → change embedding model → warning + "Rigenera" button appear inline; click Rigenera → toast success; separate standalone card no longer exists