### PR TITLE
feat: multibar UI shell + resizable panels (#243, #252, #258)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,6 +87,12 @@ Glossa 2.0 separa tre livelli:
 
 Il workspace attuale è specifico per l'area **Traduzioni**. Biblioteca e Trascrizioni sono future macro-aree separate; non devono condividere implicitamente la Phrase Memory delle traduzioni.
 
+### Shell UI (multibar)
+
+Home e progetto usano un'unica barra laterale (`ShellNav`). Nel progetto la barra primaria (`PipelineSidebar`) ospita la nav `Run/Pipeline/Document/Insight/Chunk` + back arrow e i pannelli **inline** Run/Pipeline/Document. I pannelli **ricchi** escono in una seconda barra push a sinistra del documento: `ProjectFlyout` (Insight → `InsightDocPanel`, Chunk → `ChunkInspectorPanel`, estratti da `InsightsDrawer.tsx`) e `ConfigDrawer` (config pipeline). Ordine layout editor: `PipelineSidebar → ConfigDrawer → ProjectFlyout → DocumentView`.
+
+`uiStore.activeProjectPanel` (`run|pipeline|document|insight|chunk`) è la source-of-truth del rail. I setter drawer (`setShowDocumentDrawer`/`setShowChunkDrawer`/`setShowConfigDrawer`) sincronizzano `activeProjectPanel`; i flag `show*` restano mutuamente esclusivi e pilotano quale fly-out è aperto. `insight`/`chunk` non sono persistiti come pannello attivo (clamp a `run`).
+
 ---
 
 ## Pipeline di traduzione (flusso end-to-end)

--- a/docs/UI_DESIGN_SYSTEM.md
+++ b/docs/UI_DESIGN_SYSTEM.md
@@ -224,23 +224,38 @@ Regole:
 
 ---
 
-## Sidebar, dashboard e pattern "linguetta"
+## Multibar shell (sidebar home e progetto)
 
-La pipeline sidebar definisce il riferimento visivo per le superfici laterali:
+Le superfici laterali (home e progetto) usano **un'unica barra** (`ShellNav`, `components/layout/ShellNav.tsx`) con sezioni e item navigabili. Niente più colonne multiple né "linguetta" flottante.
 
 ```tsx
-<div className="flex w-52 shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60" />
+<motion.nav className="flex shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60 transition-[width] duration-200 w-60" />
 
-<div className="-mr-px rounded-l-[20px] rounded-r-none border border-r-0 border-editorial-border bg-editorial-paper px-3 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55),6px_10px_20px_rgba(74,50,17,0.04)]" />
+// item attivo = barra accent verticale + tint + testo accent (ShellNavItem)
+<ShellNavItem active icon={<Icon />} label="..." />
 ```
 
 Regole:
 - Sidebar e dashboard usano `editorial-bg/60` o `editorial-bg`, non bianco puro.
-- La superficie selezionata che deve sembrare agganciata alla pagina usa la "linguetta": `rounded-l-[20px] rounded-r-none border-r-0 bg-editorial-paper`.
-- Workspace selezionato: usare il pattern linguetta nella lista, senza ripetere il nome come titolo immediatamente sopra.
-- Dashboard/home: niente card bianche generiche. Usa `editorial-paper`, bordi `editorial-border`, icone tonde e metadati proporzionati.
-- Area nav: usa i testi `workspace.areas.<id>.title` e `workspace.areas.<id>.sidebarHint`. Non mostrare badge tipo "Attiva" sull'area Traduzioni.
-- Le aree future possono essere disabilitate, ma devono mantenere forma e gerarchia visiva coerenti.
+- **Item attivo**: barra accent verticale (`absolute left-0 w-[3px] bg-editorial-accent`) + tint `bg-editorial-accent/10` + testo `text-editorial-accent`. Niente fondo accent pieno, niente linguetta che sfora il bordo colonna.
+- **Collapse**: la barra anima la larghezza (`w-60` ↔ `w-16`), mai render condizionale `return null` (provoca scatti). Collassata = solo icone con tooltip.
+- Sezioni con `ShellNavSection` (header `SectionLabel`, tracking calmo `0.1em`). Un solo `border-r`, nessun divider duplicato.
+- Workspace/area attivi: usare `ShellNavItem active` (no titolo ripetuto sopra). Area label `labelFont="display"`.
+- **Azioni di riga**: comandi contestuali (es. modifica/elimina del workspace attivo) vanno nel `trailing` di `ShellNavItem` (wrapper div + button interno + trailing fratelli — mai button annidati), non in barre d'azione separate nel canvas.
+- Dashboard/home: niente card bianche generiche. Usa `editorial-paper`, bordi `editorial-border`, icone tonde, metadati proporzionati.
+- Area nav: testi `workspace.areas.<id>.title` e `workspace.areas.<id>.sidebarHint`. Niente badge "Attiva".
+- Le aree future possono essere disabilitate ma mantengono forma e gerarchia.
+
+### Seconda barra (fly-out progetto)
+
+Nel progetto la barra primaria contiene la nav (`Run/Pipeline/Document/Insight/Chunk`) + back arrow in cima. I pannelli **inline** (Run, Pipeline, Document) vivono dentro la barra; i pannelli **ricchi** (Insight, Chunk, Config pipeline) escono in una **seconda barra push** (`ProjectFlyout`, `ConfigDrawer`) ancorata al bordo destro della barra, che spinge il documento (niente overlay, niente backdrop). La larghezza è animata (`width 0 → N`), così l'apertura/chiusura è fluida e parte sempre dal bordo della barra.
+
+### Resize (drag) — `useEdgeResize` + `ResizeHandle`
+
+Tutte le superfici laterali sono ridimensionabili dal bordo destro (`components/layout/useEdgeResize.tsx`). Le larghezze e lo stato collapse sono persistiti in `uiStore`.
+- **Barre primarie** (home, progetto): mode `collapse` — trascinando sotto soglia collassano a icone in tempo reale (reversibile nel drag).
+- **Fly-out** (Insight, Chunk, ConfigDrawer): mode `dismiss` — trascinando sotto soglia il pannello **scompare** al rilascio (non collassa a icona).
+- Durante il drag la transizione di larghezza è disattivata (movimento 1:1); allo snap/chiusura riprende l'animazione. Niente larghezze hard-coded nei consumer: leggere da `uiStore`.
 
 ---
 

--- a/docs/UI_DESIGN_SYSTEM.md
+++ b/docs/UI_DESIGN_SYSTEM.md
@@ -238,7 +238,8 @@ Le superfici laterali (home e progetto) usano **un'unica barra** (`ShellNav`, `c
 Regole:
 - Sidebar e dashboard usano `editorial-bg/60` o `editorial-bg`, non bianco puro.
 - **Item attivo**: barra accent verticale (`absolute left-0 w-[3px] bg-editorial-accent`) + tint `bg-editorial-accent/10` + testo `text-editorial-accent`. Niente fondo accent pieno, niente linguetta che sfora il bordo colonna.
-- **Collapse**: la barra anima la larghezza (`w-60` ↔ `w-16`), mai render condizionale `return null` (provoca scatti). Collassata = solo icone con tooltip.
+- **Collapse**: la barra anima la larghezza, mai render condizionale `return null` (provoca scatti). Collassata = solo icone con tooltip. **Niente bottone comprimi dedicato**: il collapse segue il pattern activity-bar — click sull'item **attivo** comprime/espande; da collassata, click su qualunque item espande e seleziona. Si può anche trascinare il bordo destro (vedi Resize).
+- **Back progetto**: la barra progetto ha una freccia indietro **slim** in cima (striscia bassa, `IconButton size="sm"`), non una riga piena; il ritorno alla home resta anche dal breadcrumb dell'header.
 - Sezioni con `ShellNavSection` (header `SectionLabel`, tracking calmo `0.1em`). Un solo `border-r`, nessun divider duplicato.
 - Workspace/area attivi: usare `ShellNavItem active` (no titolo ripetuto sopra). Area label `labelFont="display"`.
 - **Azioni di riga**: comandi contestuali (es. modifica/elimina del workspace attivo) vanno nel `trailing` di `ShellNavItem` (wrapper div + button interno + trailing fratelli — mai button annidati), non in barre d'azione separate nel canvas.

--- a/docs/UI_DESIGN_SYSTEM.md
+++ b/docs/UI_DESIGN_SYSTEM.md
@@ -238,8 +238,10 @@ Le superfici laterali (home e progetto) usano **un'unica barra** (`ShellNav`, `c
 Regole:
 - Sidebar e dashboard usano `editorial-bg/60` o `editorial-bg`, non bianco puro.
 - **Item attivo**: barra accent verticale (`absolute left-0 w-[3px] bg-editorial-accent`) + tint `bg-editorial-accent/10` + testo `text-editorial-accent`. Niente fondo accent pieno, niente linguetta che sfora il bordo colonna.
-- **Collapse**: la barra anima la larghezza, mai render condizionale `return null` (provoca scatti). Collassata = solo icone con tooltip. **Niente bottone comprimi dedicato**: il collapse segue il pattern activity-bar — click sull'item **attivo** comprime/espande; da collassata, click su qualunque item espande e seleziona. Si può anche trascinare il bordo destro (vedi Resize).
+- **Collapse**: la barra anima la larghezza, mai render condizionale `return null` (provoca scatti). Collassata = solo icone con `Tooltip` (mai `title` nativo), contenuto ancorato alla larghezza collassata (niente slide). **Niente bottone comprimi dedicato** (pattern activity-bar): click sull'item **attivo** comprime/espande; cambiare sezione **conserva** lo stato collassato/espanso (non riapre la barra). Anche il drag del bordo destro collassa/ridimensiona.
+- **Footer barra** (`ShellNavFooter`): azioni app-level (Impostazioni, Aiuto) ancorate in fondo alla barra (home e progetto), non nell'header. L'header tiene solo Salva / Libreria / Lingua.
 - **Back progetto**: la barra progetto ha una freccia indietro **slim** in cima (striscia bassa, `IconButton size="sm"`), non una riga piena; il ritorno alla home resta anche dal breadcrumb dell'header.
+- **Pannelli inline collassati**: icone uniformi (`h-9 w-9`), con icona di sezione in cima; le label testuali (es. modalità Test/Prod del Run) compaiono **solo da collassato**.
 - Sezioni con `ShellNavSection` (header `SectionLabel`, tracking calmo `0.1em`). Un solo `border-r`, nessun divider duplicato.
 - Workspace/area attivi: usare `ShellNavItem active` (no titolo ripetuto sopra). Area label `labelFont="display"`.
 - **Azioni di riga**: comandi contestuali (es. modifica/elimina del workspace attivo) vanno nel `trailing` di `ShellNavItem` (wrapper div + button interno + trailing fratelli — mai button annidati), non in barre d'azione separate nel canvas.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,8 +102,8 @@ const ConfigDrawer = lazy(() =>
 const DocumentView = lazy(() =>
   import('./components/document').then((m) => ({ default: m.DocumentView })),
 );
-const InsightsDrawer = lazy(() =>
-  import('./components/document').then((m) => ({ default: m.InsightsDrawer })),
+const ProjectFlyout = lazy(() =>
+  import('./components/layout').then((m) => ({ default: m.ProjectFlyout })),
 );
 const SettingsModal = lazy(() =>
   import('./components/settings/SettingsModal').then((m) => ({ default: m.SettingsModal })),
@@ -136,6 +136,7 @@ interface PendingImport {
  * nella shell gating di App.
  */
 function EditorView() {
+  const { t } = useTranslation();
   const {
     runPipeline,
     runAuditOnly,
@@ -197,12 +198,12 @@ function EditorView() {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg === 'pdf_no_text_layer') {
-        toast.error('PDF has no selectable text layer.');
+        toast.error(t('files.pdfScannedError'));
       } else {
-        toast.error('Import failed.', { description: msg });
+        toast.error(t('files.importError'), { description: msg });
       }
     }
-  }, [chunkPresetMedium, config]);
+  }, [chunkPresetMedium, config, t]);
 
   const handleConfirmImport = useCallback(async (
     manualChunks?: string[],
@@ -270,12 +271,12 @@ function EditorView() {
         logger.error('savePipelineConfig after import failed', {
           error: err instanceof Error ? err.message : String(err),
         });
-        toast.warning('Pipeline settings could not be fully persisted after import.');
+        toast.warning(t('files.pipelineSaveAfterImportFailed'));
       }
     }
     setPendingImport(null);
     setShowConfigDrawer(false);
-    toast.success('File imported successfully.');
+    toast.success(t('files.imported'));
   }, [
     activePipelineId,
     chunkPresetLong,
@@ -286,6 +287,7 @@ function EditorView() {
     pendingImport,
     setConfig,
     setShowConfigDrawer,
+    t,
   ]);
 
   return (
@@ -295,23 +297,24 @@ function EditorView() {
           <main className="relative flex flex-1 min-h-0 overflow-hidden">
             <PipelineSidebar
               onRunPipeline={runPipeline}
+              onRunAuditOnly={runAuditOnly}
               onCancelPipeline={cancelPipeline}
               onDryRun={runDryRun}
               onRetranslateChunk={handleRetranslateChunk}
               onImportDocument={handleImportDocument}
               onOpenWorkspaceSettings={() => setShowWorkspaceSettings(true)}
             />
+            <ConfigDrawer
+              onRunPipeline={runPipeline}
+              onRunAuditOnly={runAuditOnly}
+              onCancelPipeline={cancelPipeline}
+            />
+            <ProjectFlyout onReauditChunk={auditSingleChunk} onRunCoherenceAudit={runCoherenceAudit} />
             <div className="relative flex min-w-0 flex-1">
-              <ConfigDrawer
-                onRunPipeline={runPipeline}
-                onRunAuditOnly={runAuditOnly}
-                onCancelPipeline={cancelPipeline}
-              />
               <DocumentView
                 onRetranslateChunk={handleRetranslateChunk}
                 onImportDocument={handleImportDocument}
               />
-              <InsightsDrawer onReauditChunk={auditSingleChunk} onRunCoherenceAudit={runCoherenceAudit} />
               <PanelTransitionVeil panelKey={editorContentKey} tone="paper" variant="project" />
             </div>
           </main>

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X, LibraryBig, Save, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { AnimatePresence, motion } from 'motion/react';
-import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { IconButton, PillButton } from '../ui';
+import { ResizeHandle, useEdgeResize } from '../layout/useEdgeResize';
 import { PipelineConfig } from '../pipeline/PipelineConfig';
+
+const CONFIG_MIN = 420;
+const CONFIG_MAX = 760;
+const CONFIG_DISMISS_AT = 380;
 import { useUiStore } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
 import { usePipelineStore } from '../../stores/pipelineStore';
@@ -30,7 +35,32 @@ export function ConfigDrawer({
   const { t } = useTranslation();
   const showConfigDrawer = useUiStore((state) => state.showConfigDrawer);
   const setShowConfigDrawer = useUiStore((state) => state.setShowConfigDrawer);
-  const drawerRef = useFocusTrap(showConfigDrawer, () => setShowConfigDrawer(false));
+  const width = useUiStore((state) => state.configFlyoutWidth);
+  const setWidth = useUiStore((state) => state.setConfigFlyoutWidth);
+  const { dragging, startDrag } = useEdgeResize();
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleResizeStart = (event: React.PointerEvent) => {
+    startDrag(event, {
+      startWidth: width,
+      min: CONFIG_MIN,
+      max: CONFIG_MAX,
+      threshold: CONFIG_DISMISS_AT,
+      mode: 'dismiss',
+      onWidth: setWidth,
+      onDismiss: () => setShowConfigDrawer(false),
+    });
+  };
+
+  // Pannello push (non modale): chiusura via Esc, nessun focus trap sul documento.
+  useEffect(() => {
+    if (!showConfigDrawer) return;
+    const onKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') setShowConfigDrawer(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [showConfigDrawer, setShowConfigDrawer]);
   const setPipelineMode = useConfigStore((state) => state.setPipelineMode);
   const [glossaryDirty, setGlossaryDirty] = useState(false);
   const [isSavingGlossary, setIsSavingGlossary] = useState(false);
@@ -102,18 +132,18 @@ export function ConfigDrawer({
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5">
           <LibraryBig size={11} className="text-editorial-accent shrink-0" />
-          <span className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+          <span className="text-[11px] font-sans uppercase tracking-[0.1em] text-editorial-muted">
             {t('library.assignedDictionary')}
           </span>
         </div>
-        <button
+        <IconButton
+          size="md"
           onClick={() => setShowLibraryPanel(true, 'dictionaries')}
           title={t('library.openLibrary')}
-          aria-label={t('library.openLibrary')}
-          className="shrink-0 text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+          className="shrink-0"
         >
           <LibraryBig size={16} />
-        </button>
+        </IconButton>
       </div>
       <select
         value={config.assignedGlossaryId ?? ''}
@@ -136,48 +166,39 @@ export function ConfigDrawer({
       )}
       {glossaryDirty && config.assignedGlossaryId && (
         <div className="flex justify-end">
-          <button
+          <PillButton
+            variant="accent"
             onClick={handleSaveGlossary}
             disabled={isSavingGlossary}
-            className="flex items-center gap-1.5 rounded-full border border-editorial-ink px-4 py-2 text-xs font-bold uppercase tracking-widest text-editorial-ink hover:bg-editorial-ink hover:text-white disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            className="inline-flex items-center gap-1.5"
           >
             <Save size={13} />
             {t('common.save')}
-          </button>
+          </PillButton>
         </div>
       )}
     </div>
   );
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {showConfigDrawer && (
-        <>
-          <motion.div
-            key="backdrop"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="absolute top-0 bottom-0 left-0 right-0 z-30 bg-editorial-ink/20 backdrop-blur-sm"
-            onClick={() => setShowConfigDrawer(false)}
-          />
-          <motion.div
-            key="drawer"
-            ref={drawerRef}
-            initial={{ x: -680, opacity: 0 }}
-            animate={{ x: 0, opacity: 1 }}
-            exit={{ x: -680, opacity: 0 }}
-            transition={{ type: 'spring', damping: 28, stiffness: 280 }}
-            role="dialog"
-            aria-modal="true"
-            className="absolute top-0 bottom-0 left-0 z-40 flex w-[680px] flex-col overflow-hidden border-r border-editorial-border bg-editorial-bg shadow-xl"
-            aria-labelledby="config-drawer-title"
-          >
+        <motion.aside
+          key="config-flyout"
+          ref={drawerRef}
+          initial={{ width: 0, opacity: 0 }}
+          animate={{ width, opacity: 1 }}
+          exit={{ width: 0, opacity: 0 }}
+          transition={dragging ? { duration: 0 } : { type: 'spring', damping: 30, stiffness: 280 }}
+          role="dialog"
+          aria-labelledby="config-drawer-title"
+          className="relative flex h-full shrink-0 overflow-hidden border-r border-editorial-border bg-editorial-bg"
+        >
+          <div className="flex h-full flex-col overflow-hidden" style={{ width }}>
           {/* Header */}
           <div className="flex items-start justify-between gap-3 border-b border-editorial-border px-6 pt-4 pb-4">
             <div className="min-w-0">
-              <div className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+              <div className="text-[11px] font-sans uppercase tracking-[0.1em] text-editorial-muted">
                 {t('document.configDrawerTitle')}
               </div>
               <input
@@ -198,14 +219,15 @@ export function ConfigDrawer({
                 className="mt-1 w-full bg-transparent font-display text-2xl italic tracking-tight text-editorial-ink outline-none placeholder:text-editorial-muted/40 transition-colors focus:text-editorial-accent"
               />
             </div>
-            <button
-              type="button"
+            <IconButton
+              size="md"
               onClick={() => setShowConfigDrawer(false)}
-              className="mt-1 shrink-0 rounded-full border border-editorial-border p-2.5 text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('header.closeDrawer')}
+              title={t('header.closeDrawer')}
+              tooltipSide="left"
+              className="mt-1 shrink-0"
             >
               <X size={16} />
-            </button>
+            </IconButton>
           </div>
 
           <PipelineConfig
@@ -219,20 +241,21 @@ export function ConfigDrawer({
           />
 
           {completedCount > 0 && (
-            <div className="shrink-0 border-t border-editorial-border/40 px-6 py-4">
-              <button
-                type="button"
+            <div className="flex shrink-0 justify-center border-t border-editorial-border/40 px-6 py-4">
+              <PillButton
+                variant="secondary"
                 onClick={handleResetAll}
                 disabled={isProcessing}
-                className="flex w-full items-center justify-center gap-2 rounded-full border border-editorial-accent/40 px-4 py-2 text-xs font-bold uppercase tracking-widest text-editorial-accent/70 transition-colors hover:border-editorial-accent hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center gap-2 border-editorial-accent/40 text-editorial-accent/80 hover:border-editorial-accent hover:text-editorial-accent"
               >
                 <Trash2 size={12} />
                 {t('pipeline.resetAll')}
-              </button>
+              </PillButton>
             </div>
           )}
-          </motion.div>
-        </>
+          </div>
+          <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizePanel')} />
+        </motion.aside>
       )}
     </AnimatePresence>
   );

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -191,7 +191,7 @@ export function DocumentView({
   const [annotationMenu, setAnnotationMenu] = useState<{ x: number; y: number; text: string; chunkId: string } | null>(null);
 
   const {
-    resolvedLayout,
+    documentLayout,
     paneFocus,
     syncScrollEnabled,
     chunks,
@@ -291,7 +291,17 @@ export function DocumentView({
     );
   }
 
-  const isBook = resolvedLayout === 'book';
+  // Colonne in modalità "entrambi": la scelta layout comanda (book = affiancate,
+  // standard = impilate); 'auto' affianca solo quando lo spazio REALE del documento
+  // lo consente (container query, non viewport — la barra/fly-out riducono lo spazio).
+  const bothColumnsClass =
+    paneFocus !== 'both'
+      ? 'grid-cols-1'
+      : documentLayout === 'standard'
+        ? 'grid-cols-1'
+        : documentLayout === 'book'
+          ? 'grid-cols-2'
+          : '@[820px]:grid-cols-2';
   const prevChunk = chunks[currentIndex - 1];
   const nextChunk = chunks[currentIndex + 1];
   const sourceReadOnly =
@@ -301,7 +311,7 @@ export function DocumentView({
 
   return (
     <section className="w-full bg-editorial-paper overflow-y-auto min-h-0 h-full custom-scrollbar flex flex-col">
-      <div className="mx-auto w-full max-w-[1720px] px-5 py-3 md:px-6 md:py-4 flex flex-col flex-1 min-h-0 gap-5">
+      <div className="@container mx-auto w-full max-w-[1720px] px-5 py-3 md:px-6 md:py-4 flex flex-col flex-1 min-h-0 gap-5">
         <div className="shrink-0">
           {/* Navigation bar */}
           <div className="w-full rounded-[20px] border border-editorial-border bg-editorial-bg/90 px-4 py-3 shadow-[0_16px_50px_rgba(26,26,26,0.05)]">
@@ -426,7 +436,7 @@ export function DocumentView({
           </div>
         </div>
 
-        <div className={`grid gap-5 flex-1 min-h-0 auto-rows-fr ${paneFocus === 'both' ? (isBook ? '2xl:grid-cols-2' : 'grid-cols-1') : 'grid-cols-1'}`}>
+        <div className={`grid gap-5 flex-1 min-h-0 auto-rows-fr ${bothColumnsClass}`}>
           {paneFocus !== 'translation' && (
             <DocumentPage
               label={t('pipeline.originalSource')}

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   RotateCcw,
   ScanLine,
+  Search,
   Wand2,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -104,6 +105,12 @@ function DocumentPage({
   scrollRef,
   children,
 }: DocumentPageProps) {
+  const { t } = useTranslation();
+  const searchable = Boolean(onSearchChange && searchLabel);
+  const [searchOpen, setSearchOpen] = useState(false);
+  // Il campo resta aperto finché c'è una query attiva.
+  const showSearch = searchable && (searchOpen || Boolean(searchValue));
+
   return (
     <section className={`relative rounded-[24px] bg-editorial-page px-6 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.85),0_18px_45px_rgba(74,50,17,0.08)] flex flex-col min-h-0 ${
       highlighted ? 'border border-editorial-accent ring-2 ring-editorial-accent/30' : 'border border-editorial-divider'
@@ -121,6 +128,18 @@ function DocumentPage({
             <h3 className="font-display text-[1.7rem] italic tracking-tight text-editorial-ink">
               {label}
             </h3>
+            {searchable ? (
+              <IconButton
+                size="sm"
+                tone={showSearch ? 'accent' : 'default'}
+                onClick={() => setSearchOpen((open) => !open)}
+                title={t('document.searchInPane')}
+                ariaLabel={t('document.searchInPane')}
+                ariaPressed={showSearch}
+              >
+                <Search size={13} />
+              </IconButton>
+            ) : null}
             {statusBadge}
           </div>
           {subtitle && (
@@ -141,11 +160,12 @@ function DocumentPage({
         </div>
       </div>
       <div ref={scrollRef} className={`flex flex-col flex-1 min-h-0 ${readOnly ? 'opacity-90' : ''}`}>
-        {onSearchChange && searchLabel ? (
+        {showSearch && onSearchChange && searchLabel ? (
           <PaneSearch
             value={searchValue ?? ''}
             onChange={onSearchChange}
             label={searchLabel}
+            autoFocus
           />
         ) : null}
         {children}

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -5,13 +5,11 @@ import {
   Link2,
   List,
   NotebookText,
-  PanelRight,
   Search,
   ShieldCheck,
   TerminalSquare,
   X,
 } from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { type KeyboardEvent, useEffect, useRef } from 'react';
 import { useUiStore, type InsightsDrawerTab, type ChunkDrawerTab } from '../../stores/uiStore';
@@ -21,7 +19,7 @@ import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunkWatchdog } from '../../hooks/useChunkWatchdog';
 import { OperationsTab } from './OperationsTab';
 import { SearchTab } from './SearchTab';
-import { IconButton, Tooltip } from '../ui';
+import { IconButton } from '../ui';
 import { TabButton } from './tabs/TabButton';
 import { IndexTab } from './tabs/IndexTab';
 import { StatsTab } from './tabs/StatsTab';
@@ -30,13 +28,6 @@ import { CoherenceTab } from './tabs/CoherenceTab';
 import { AuditTab } from './tabs/AuditTab';
 import { NotesTab } from './tabs/NotesTab';
 import { GlossaryTab } from './tabs/GlossaryTab';
-
-interface InsightsDrawerProps {
-  onReauditChunk: (chunkId: string) => void;
-  onRunCoherenceAudit: () => void;
-}
-
-const PANEL_WIDTH = 430;
 
 const DOC_TAB_ORDER: InsightsDrawerTab[] = ['index', 'search', 'stats', 'coherence', 'glossary'];
 const CHUNK_TAB_ORDER: ChunkDrawerTab[] = ['audit', 'notes', 'operations', 'memory', 'summary'];
@@ -73,61 +64,61 @@ const CHUNK_TAB_PANEL_IDS: Record<ChunkDrawerTab, string> = {
   memory: 'chunk-tab-panel-memory',
 };
 
-export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: InsightsDrawerProps) {
-  const { t } = useTranslation();
-  const showDocumentDrawer = useUiStore((state) => state.showDocumentDrawer);
-  const documentDrawerTab = useUiStore((state) => state.documentDrawerTab);
-  const showChunkDrawer = useUiStore((state) => state.showChunkDrawer);
-  const chunkDrawerTab = useUiStore((state) => state.chunkDrawerTab);
-  const setShowDocumentDrawer = useUiStore((state) => state.setShowDocumentDrawer);
-  const setDocumentDrawerTab = useUiStore((state) => state.setDocumentDrawerTab);
-  const setShowChunkDrawer = useUiStore((state) => state.setShowChunkDrawer);
-  const setChunkDrawerTab = useUiStore((state) => state.setChunkDrawerTab);
+/** Stato condiviso letto da entrambi i pannelli del fly-out. */
+function useInsightData() {
+  const chunks = useChunksStore((state) => state.chunks);
+  const isProcessing = useChunksStore((state) => state.isProcessing);
   const selectedChunkId = useUiStore((state) => state.selectedChunkId);
+  const currentChunk = chunks.find((c) => c.id === selectedChunkId) ?? chunks[0] ?? null;
+  const currentChunkIndex = currentChunk ? chunks.findIndex((c) => c.id === currentChunk.id) : -1;
+  return { chunks, isProcessing, currentChunk, currentChunkIndex };
+}
+
+interface FlyoutHeaderProps {
+  title: string;
+  onClose: () => void;
+}
+
+function FlyoutHeader({ title, onClose }: FlyoutHeaderProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-editorial-border px-5 py-4">
+      <div className="text-xs font-sans uppercase tracking-[0.12em] text-editorial-muted">{title}</div>
+      <IconButton
+        size="md"
+        onClick={onClose}
+        title={t('header.closeDrawer')}
+        tooltipSide="left"
+        className="shrink-0"
+      >
+        <X size={16} />
+      </IconButton>
+    </div>
+  );
+}
+
+// ── Chunk inspector ────────────────────────────────────────────────────
+
+interface ChunkInspectorPanelProps {
+  onReauditChunk: (chunkId: string) => void;
+  onClose: () => void;
+}
+
+export function ChunkInspectorPanel({ onReauditChunk, onClose }: ChunkInspectorPanelProps) {
+  const { t } = useTranslation();
+  const chunkDrawerTab = useUiStore((state) => state.chunkDrawerTab);
+  const setChunkDrawerTab = useUiStore((state) => state.setChunkDrawerTab);
   const setSelectedChunkId = useUiStore((state) => state.setSelectedChunkId);
   const focusIssueInChunk = useUiStore((state) => state.focusIssueInChunk);
   const clearFocusedIssue = useUiStore((state) => state.clearFocusedIssue);
-  const chunks = useChunksStore((state) => state.chunks);
-  const isProcessing = useChunksStore((state) => state.isProcessing);
-  const allChunksTranslated = chunks.length > 0 && chunks.every((c) => c.currentDraft?.trim());
-  const allChunksLocked = chunks.length > 0 && chunks.every((c) => c.translationLocked);
-  const unlockedChunksCount = chunks.filter((c) => c.currentDraft?.trim() && !c.translationLocked).length;
-  const currentChunk = chunks.find((c) => c.id === selectedChunkId) ?? chunks[0] ?? null;
-  const currentChunkIndex = currentChunk ? chunks.findIndex((c) => c.id === currentChunk.id) : -1;
+  const { chunks, isProcessing, currentChunk, currentChunkIndex } = useInsightData();
 
-  const { stuckChunkIds, cancelStuckChunk } = useChunkWatchdog();
-  const { config } = usePipelineStore();
-  const hasGlossary = !!config.assignedGlossaryId && config.glossary.length > 0;
+  const tabButtonRefs = useRef<Partial<Record<ChunkDrawerTab, HTMLButtonElement | null>>>({});
 
-  // Redirect away from the glossary tab if the glossary is removed.
-  useEffect(() => {
-    if (!hasGlossary && documentDrawerTab === 'glossary') {
-      setDocumentDrawerTab('index');
-    }
-  }, [hasGlossary, documentDrawerTab, setDocumentDrawerTab]);
-
-  // Clear audit phrase highlight when switching tabs or chunks.
   useEffect(() => {
     clearFocusedIssue();
-  }, [chunkDrawerTab, selectedChunkId, clearFocusedIssue]);
+  }, [chunkDrawerTab, currentChunk?.id, clearFocusedIssue]);
 
-  const docTabButtonRefs = useRef<Partial<Record<InsightsDrawerTab, HTMLButtonElement | null>>>({});
-  const chunkTabButtonRefs = useRef<Partial<Record<ChunkDrawerTab, HTMLButtonElement | null>>>({});
-
-  const DOC_TAB_ICON: Record<InsightsDrawerTab, React.ReactNode> = {
-    index: <List size={16} />,
-    search: <Search size={16} />,
-    stats: <BarChart2 size={16} />,
-    coherence: <Link2 size={16} />,
-    glossary: <BookText size={16} />,
-  };
-  const DOC_TAB_LABEL: Record<InsightsDrawerTab, string> = {
-    index: t('document.insightsTabIndex'),
-    search: t('document.insightsTabSearch'),
-    stats: t('document.insightsTabStats'),
-    coherence: t('document.insightsTabCoherence'),
-    glossary: t('document.insightsTabGlossary'),
-  };
   const CHUNK_TAB_ICON: Record<ChunkDrawerTab, React.ReactNode> = {
     summary: <BarChart2 size={16} />,
     audit: <ShieldCheck size={16} />,
@@ -143,29 +134,11 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
     memory: t('document.insightsTabMemory'),
   };
 
-  const enabledDocTabOrder = DOC_TAB_ORDER.filter((tab) => tab !== 'glossary' || hasGlossary);
-
-  const activateDocTab = (tab: InsightsDrawerTab) => {
-    setDocumentDrawerTab(tab);
-    docTabButtonRefs.current[tab]?.focus();
-  };
-  const activateChunkTab = (tab: ChunkDrawerTab) => {
+  const activateTab = (tab: ChunkDrawerTab) => {
     setChunkDrawerTab(tab);
-    chunkTabButtonRefs.current[tab]?.focus();
+    tabButtonRefs.current[tab]?.focus();
   };
-
-  const handleDocTabKeyDown = (tab: InsightsDrawerTab, event: KeyboardEvent<HTMLButtonElement>) => {
-    const idx = enabledDocTabOrder.indexOf(tab);
-    let next: InsightsDrawerTab | null = null;
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp')
-      next = enabledDocTabOrder[(idx - 1 + enabledDocTabOrder.length) % enabledDocTabOrder.length];
-    else if (event.key === 'ArrowRight' || event.key === 'ArrowDown')
-      next = enabledDocTabOrder[(idx + 1) % enabledDocTabOrder.length];
-    else if (event.key === 'Home') next = enabledDocTabOrder[0];
-    else if (event.key === 'End') next = enabledDocTabOrder[enabledDocTabOrder.length - 1];
-    if (next) { event.preventDefault(); activateDocTab(next); }
-  };
-  const handleChunkTabKeyDown = (tab: ChunkDrawerTab, event: KeyboardEvent<HTMLButtonElement>) => {
+  const handleTabKeyDown = (tab: ChunkDrawerTab, event: KeyboardEvent<HTMLButtonElement>) => {
     const idx = CHUNK_TAB_ORDER.indexOf(tab);
     let next: ChunkDrawerTab | null = null;
     if (event.key === 'ArrowLeft' || event.key === 'ArrowUp')
@@ -174,7 +147,7 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
       next = CHUNK_TAB_ORDER[(idx + 1) % CHUNK_TAB_ORDER.length];
     else if (event.key === 'Home') next = CHUNK_TAB_ORDER[0];
     else if (event.key === 'End') next = CHUNK_TAB_ORDER[CHUNK_TAB_ORDER.length - 1];
-    if (next) { event.preventDefault(); activateChunkTab(next); }
+    if (next) { event.preventDefault(); activateTab(next); }
   };
 
   const chunkLabel = currentChunk && currentChunkIndex >= 0
@@ -182,252 +155,207 @@ export function InsightsDrawer({ onReauditChunk, onRunCoherenceAudit }: Insights
     : t('document.chunkPanelTitle');
 
   return (
-    <div className="flex h-full shrink-0">
+    <div className="flex h-full flex-col" role="region" aria-label={chunkLabel}>
+      <FlyoutHeader title={chunkLabel} onClose={onClose} />
 
-      {/* ── Chunk panel ─────────────────────────────────────── */}
-      <AnimatePresence initial={false}>
-        {!showChunkDrawer && (
-          <motion.button
-            key="chunk-strip"
-            type="button"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            onClick={() => setShowChunkDrawer(true)}
-            className="flex w-8 shrink-0 flex-col items-center justify-center gap-3 self-stretch border-l border-editorial-border bg-editorial-bg/80 text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-editorial-accent"
-            aria-label={t('document.openChunkPanel')}
-          >
-            <Tooltip label={t('document.openChunkPanel')} side="left" className="h-full w-full">
-              <span className="flex h-full w-full flex-col items-center justify-center gap-3">
-                <ShieldCheck size={14} />
-                <span className="[writing-mode:vertical-lr] rotate-180 text-[10px] font-bold uppercase tracking-[0.16em]">
-                  {t('document.chunkPanelTitle')}
-                </span>
-              </span>
-            </Tooltip>
-          </motion.button>
+      <div className="flex items-center gap-2 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2">
+        <div role="tablist" aria-orientation="horizontal" aria-label={chunkLabel} className="flex gap-1">
+          {CHUNK_TAB_ORDER.map((tab) => (
+            <TabButton
+              key={tab}
+              buttonId={CHUNK_TAB_BUTTON_IDS[tab]}
+              active={chunkDrawerTab === tab}
+              onClick={() => activateTab(tab)}
+              onKeyDown={(e) => handleTabKeyDown(tab, e)}
+              label={CHUNK_TAB_LABEL[tab]}
+              icon={CHUNK_TAB_ICON[tab]}
+              controls={CHUNK_TAB_PANEL_IDS[tab]}
+              buttonRef={(el) => { tabButtonRefs.current[tab] = el; }}
+            />
+          ))}
+        </div>
+        <span className="mx-1 h-4 w-px bg-editorial-border/70" aria-hidden="true" />
+        <span className="font-display text-sm italic text-editorial-ink">{CHUNK_TAB_LABEL[chunkDrawerTab]}</span>
+      </div>
+
+      <div className={`flex flex-1 flex-col overflow-y-auto custom-scrollbar ${chunkDrawerTab === 'operations' ? 'bg-black' : 'bg-editorial-bg/40'}`}>
+        {chunkDrawerTab === 'audit' ? (
+          <AuditTab
+            panelId={CHUNK_TAB_PANEL_IDS.audit}
+            labelledBy={CHUNK_TAB_BUTTON_IDS.audit}
+            currentChunk={currentChunk}
+            isProcessing={isProcessing}
+            onReauditChunk={onReauditChunk}
+            onSelectChunk={setSelectedChunkId}
+            onFocusIssue={focusIssueInChunk}
+          />
+        ) : chunkDrawerTab === 'notes' ? (
+          <NotesTab
+            panelId={CHUNK_TAB_PANEL_IDS.notes}
+            labelledBy={CHUNK_TAB_BUTTON_IDS.notes}
+            currentChunk={currentChunk}
+          />
+        ) : chunkDrawerTab === 'memory' ? (
+          <MemoryTab
+            panelId={CHUNK_TAB_PANEL_IDS.memory}
+            labelledBy={CHUNK_TAB_BUTTON_IDS.memory}
+            currentChunkId={currentChunk?.id ?? null}
+          />
+        ) : chunkDrawerTab === 'summary' ? (
+          <ChunkSummaryTab
+            panelId={CHUNK_TAB_PANEL_IDS.summary}
+            labelledBy={CHUNK_TAB_BUTTON_IDS.summary}
+            currentChunk={currentChunk}
+          />
+        ) : (
+          <OperationsTab
+            panelId={CHUNK_TAB_PANEL_IDS.operations}
+            labelledBy={CHUNK_TAB_BUTTON_IDS.operations}
+            currentChunkId={currentChunk?.id ?? null}
+            chunks={chunks}
+            onSelectChunk={setSelectedChunkId}
+          />
         )}
-      </AnimatePresence>
+      </div>
+    </div>
+  );
+}
 
-      <AnimatePresence initial={false}>
-        {showChunkDrawer && (
-          <motion.aside
-            key="chunk-panel"
-            initial={{ width: 0, opacity: 0 }}
-            animate={{ width: PANEL_WIDTH, opacity: 1 }}
-            exit={{ width: 0, opacity: 0 }}
-            transition={{ type: 'spring', damping: 28, stiffness: 280 }}
-            className={`flex h-full overflow-hidden border-l bg-editorial-bg/95 ${chunkDrawerTab === 'operations' ? 'border-terminal-border' : 'border-editorial-border'}`}
-            role="region"
-            aria-label={chunkLabel}
-          >
-            <div className="flex h-full flex-col" style={{ width: PANEL_WIDTH }}>
-              <div className="flex items-center justify-between gap-3 border-b border-editorial-border px-5 py-4">
-                <div className="text-xs font-sans uppercase tracking-[0.12em] text-editorial-muted">
-                  {chunkLabel}
-                </div>
-                <IconButton
-                  size="md"
-                  onClick={() => setShowChunkDrawer(false)}
-                  title={t('header.closeDrawer')}
-                  tooltipSide="left"
-                  className="shrink-0"
-                >
-                  <X size={16} />
-                </IconButton>
-              </div>
+// ── Insight / documento ────────────────────────────────────────────────
 
-              <div className="flex items-center gap-2 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2">
-                <div role="tablist" aria-orientation="horizontal" aria-label={chunkLabel} className="flex gap-1">
-                  {CHUNK_TAB_ORDER.map((tab) => (
-                    <TabButton
-                      key={tab}
-                      buttonId={CHUNK_TAB_BUTTON_IDS[tab]}
-                      active={chunkDrawerTab === tab}
-                      onClick={() => activateChunkTab(tab)}
-                      onKeyDown={(e) => handleChunkTabKeyDown(tab, e)}
-                      label={CHUNK_TAB_LABEL[tab]}
-                      icon={CHUNK_TAB_ICON[tab]}
-                      controls={CHUNK_TAB_PANEL_IDS[tab]}
-                      buttonRef={(el) => { chunkTabButtonRefs.current[tab] = el; }}
-                    />
-                  ))}
-                </div>
-                <span className="mx-1 h-4 w-px bg-editorial-border/70" aria-hidden="true" />
-                <span className="font-display italic text-sm text-editorial-ink">{CHUNK_TAB_LABEL[chunkDrawerTab]}</span>
-              </div>
+interface InsightDocPanelProps {
+  onRunCoherenceAudit: () => void;
+  onClose: () => void;
+}
 
-              <div className={`flex flex-1 flex-col overflow-y-auto custom-scrollbar ${chunkDrawerTab === 'operations' ? 'bg-black' : 'bg-editorial-bg/40'}`}>
-                {chunkDrawerTab === 'audit' ? (
-                  <AuditTab
-                    panelId={CHUNK_TAB_PANEL_IDS.audit}
-                    labelledBy={CHUNK_TAB_BUTTON_IDS.audit}
-                    currentChunk={currentChunk}
-                    isProcessing={isProcessing}
-                    onReauditChunk={onReauditChunk}
-                    onSelectChunk={setSelectedChunkId}
-                    onFocusIssue={focusIssueInChunk}
-                  />
-                ) : chunkDrawerTab === 'notes' ? (
-                  <NotesTab
-                    panelId={CHUNK_TAB_PANEL_IDS.notes}
-                    labelledBy={CHUNK_TAB_BUTTON_IDS.notes}
-                    currentChunk={currentChunk}
-                  />
-                ) : chunkDrawerTab === 'memory' ? (
-                  <MemoryTab
-                    panelId={CHUNK_TAB_PANEL_IDS.memory}
-                    labelledBy={CHUNK_TAB_BUTTON_IDS.memory}
-                    currentChunkId={currentChunk?.id ?? null}
-                  />
-                ) : chunkDrawerTab === 'summary' ? (
-                  <ChunkSummaryTab
-                    panelId={CHUNK_TAB_PANEL_IDS.summary}
-                    labelledBy={CHUNK_TAB_BUTTON_IDS.summary}
-                    currentChunk={currentChunk}
-                  />
-                ) : (
-                  <OperationsTab
-                    panelId={CHUNK_TAB_PANEL_IDS.operations}
-                    labelledBy={CHUNK_TAB_BUTTON_IDS.operations}
-                    currentChunkId={currentChunk?.id ?? null}
-                    chunks={chunks}
-                    onSelectChunk={setSelectedChunkId}
-                  />
-                )}
-              </div>
-            </div>
-          </motion.aside>
+export function InsightDocPanel({ onRunCoherenceAudit, onClose }: InsightDocPanelProps) {
+  const { t } = useTranslation();
+  const documentDrawerTab = useUiStore((state) => state.documentDrawerTab);
+  const setDocumentDrawerTab = useUiStore((state) => state.setDocumentDrawerTab);
+  const setSelectedChunkId = useUiStore((state) => state.setSelectedChunkId);
+  const focusIssueInChunk = useUiStore((state) => state.focusIssueInChunk);
+  const { chunks, isProcessing, currentChunk } = useInsightData();
+  const allChunksTranslated = chunks.length > 0 && chunks.every((c) => c.currentDraft?.trim());
+  const allChunksLocked = chunks.length > 0 && chunks.every((c) => c.translationLocked);
+  const unlockedChunksCount = chunks.filter((c) => c.currentDraft?.trim() && !c.translationLocked).length;
+
+  const { stuckChunkIds, cancelStuckChunk } = useChunkWatchdog();
+  const { config } = usePipelineStore();
+  const hasGlossary = !!config.assignedGlossaryId && config.glossary.length > 0;
+
+  const tabButtonRefs = useRef<Partial<Record<InsightsDrawerTab, HTMLButtonElement | null>>>({});
+
+  // Esci dal tab glossario se il glossario viene rimosso.
+  useEffect(() => {
+    if (!hasGlossary && documentDrawerTab === 'glossary') {
+      setDocumentDrawerTab('index');
+    }
+  }, [hasGlossary, documentDrawerTab, setDocumentDrawerTab]);
+
+  const DOC_TAB_ICON: Record<InsightsDrawerTab, React.ReactNode> = {
+    index: <List size={16} />,
+    search: <Search size={16} />,
+    stats: <BarChart2 size={16} />,
+    coherence: <Link2 size={16} />,
+    glossary: <BookText size={16} />,
+  };
+  const DOC_TAB_LABEL: Record<InsightsDrawerTab, string> = {
+    index: t('document.insightsTabIndex'),
+    search: t('document.insightsTabSearch'),
+    stats: t('document.insightsTabStats'),
+    coherence: t('document.insightsTabCoherence'),
+    glossary: t('document.insightsTabGlossary'),
+  };
+
+  const enabledTabOrder = DOC_TAB_ORDER.filter((tab) => tab !== 'glossary' || hasGlossary);
+
+  const activateTab = (tab: InsightsDrawerTab) => {
+    setDocumentDrawerTab(tab);
+    tabButtonRefs.current[tab]?.focus();
+  };
+  const handleTabKeyDown = (tab: InsightsDrawerTab, event: KeyboardEvent<HTMLButtonElement>) => {
+    const idx = enabledTabOrder.indexOf(tab);
+    let next: InsightsDrawerTab | null = null;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp')
+      next = enabledTabOrder[(idx - 1 + enabledTabOrder.length) % enabledTabOrder.length];
+    else if (event.key === 'ArrowRight' || event.key === 'ArrowDown')
+      next = enabledTabOrder[(idx + 1) % enabledTabOrder.length];
+    else if (event.key === 'Home') next = enabledTabOrder[0];
+    else if (event.key === 'End') next = enabledTabOrder[enabledTabOrder.length - 1];
+    if (next) { event.preventDefault(); activateTab(next); }
+  };
+
+  return (
+    <div className="flex h-full flex-col" role="region" aria-label={t('document.insightsDrawerTitle')}>
+      <FlyoutHeader title={t('document.insightsDrawerTitle')} onClose={onClose} />
+
+      <div className="flex items-center gap-2 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2">
+        <div role="tablist" aria-orientation="horizontal" aria-label={t('document.insightsDrawerTitle')} className="flex gap-1">
+          {DOC_TAB_ORDER.map((tab) => (
+            <TabButton
+              key={tab}
+              buttonId={DOC_TAB_BUTTON_IDS[tab]}
+              active={documentDrawerTab === tab}
+              disabled={tab === 'glossary' && !hasGlossary}
+              onClick={() => activateTab(tab)}
+              onKeyDown={(e) => handleTabKeyDown(tab, e)}
+              label={tab === 'glossary' && !hasGlossary ? t('document.insightsGlossaryEmpty') : DOC_TAB_LABEL[tab]}
+              icon={DOC_TAB_ICON[tab]}
+              controls={DOC_TAB_PANEL_IDS[tab]}
+              buttonRef={(el) => { tabButtonRefs.current[tab] = el; }}
+            />
+          ))}
+        </div>
+        <span className="mx-1 h-4 w-px bg-editorial-border/70" aria-hidden="true" />
+        <span className="font-display text-sm italic text-editorial-ink">{DOC_TAB_LABEL[documentDrawerTab]}</span>
+      </div>
+
+      <div className="flex flex-1 flex-col overflow-y-auto bg-editorial-bg/40 custom-scrollbar">
+        {documentDrawerTab === 'index' ? (
+          <IndexTab
+            panelId={DOC_TAB_PANEL_IDS.index}
+            labelledBy={DOC_TAB_BUTTON_IDS.index}
+            chunks={chunks}
+            currentChunkId={currentChunk?.id ?? null}
+            stuckChunkIds={stuckChunkIds}
+            onSelect={(id) => setSelectedChunkId(id)}
+            onCancelStuck={cancelStuckChunk}
+          />
+        ) : documentDrawerTab === 'search' ? (
+          <SearchTab
+            panelId={DOC_TAB_PANEL_IDS.search}
+            labelledBy={DOC_TAB_BUTTON_IDS.search}
+            chunks={chunks}
+            currentChunkId={currentChunk?.id ?? null}
+            onSelectChunk={setSelectedChunkId}
+          />
+        ) : documentDrawerTab === 'stats' ? (
+          <StatsTab
+            panelId={DOC_TAB_PANEL_IDS.stats}
+            labelledBy={DOC_TAB_BUTTON_IDS.stats}
+            chunks={chunks}
+          />
+        ) : documentDrawerTab === 'glossary' ? (
+          <GlossaryTab
+            panelId={DOC_TAB_PANEL_IDS.glossary}
+            labelledBy={DOC_TAB_BUTTON_IDS.glossary}
+            glossary={config.glossary}
+          />
+        ) : (
+          <CoherenceTab
+            panelId={DOC_TAB_PANEL_IDS.coherence}
+            labelledBy={DOC_TAB_BUTTON_IDS.coherence}
+            currentChunk={currentChunk}
+            isProcessing={isProcessing}
+            allChunksTranslated={allChunksTranslated}
+            allChunksLocked={allChunksLocked}
+            unlockedChunksCount={unlockedChunksCount}
+            onSelectChunk={setSelectedChunkId}
+            onFocusIssue={focusIssueInChunk}
+            onRunCoherenceAudit={onRunCoherenceAudit}
+          />
         )}
-      </AnimatePresence>
-
-      {/* ── Document panel ──────────────────────────────────── */}
-      <AnimatePresence initial={false}>
-        {!showDocumentDrawer && (
-          <motion.button
-            key="doc-strip"
-            type="button"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            onClick={() => setShowDocumentDrawer(true)}
-            className="flex w-8 shrink-0 flex-col items-center justify-center gap-3 self-stretch border-l border-editorial-border bg-editorial-bg/80 text-editorial-muted transition-colors hover:bg-editorial-textbox/50 hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-editorial-accent"
-            aria-label={t('header.openInsights')}
-          >
-            <Tooltip label={t('header.openInsights')} side="left" className="h-full w-full">
-              <span className="flex h-full w-full flex-col items-center justify-center gap-3">
-                <PanelRight size={14} />
-                <span className="[writing-mode:vertical-lr] rotate-180 text-[10px] font-bold uppercase tracking-[0.16em]">
-                  {t('document.insightsDrawerTitle')}
-                </span>
-              </span>
-            </Tooltip>
-          </motion.button>
-        )}
-      </AnimatePresence>
-
-      <AnimatePresence initial={false}>
-        {showDocumentDrawer && (
-          <motion.aside
-            key="doc-panel"
-            initial={{ width: 0, opacity: 0 }}
-            animate={{ width: PANEL_WIDTH, opacity: 1 }}
-            exit={{ width: 0, opacity: 0 }}
-            transition={{ type: 'spring', damping: 28, stiffness: 280 }}
-            className="flex h-full overflow-hidden border-l border-editorial-border bg-editorial-bg/95"
-            role="region"
-            aria-label={t('document.insightsDrawerTitle')}
-          >
-            <div className="flex h-full flex-col" style={{ width: PANEL_WIDTH }}>
-              <div className="flex items-center justify-between gap-3 border-b border-editorial-border px-5 py-4">
-                <div className="text-xs font-sans uppercase tracking-[0.12em] text-editorial-muted">
-                  {t('document.insightsDrawerTitle')}
-                </div>
-                <IconButton
-                  size="md"
-                  onClick={() => setShowDocumentDrawer(false)}
-                  title={t('header.closeDrawer')}
-                  tooltipSide="left"
-                  className="shrink-0"
-                >
-                  <X size={16} />
-                </IconButton>
-              </div>
-
-              <div className="flex items-center gap-2 border-b border-editorial-border bg-editorial-bg/60 px-4 py-2">
-                <div role="tablist" aria-orientation="horizontal" aria-label={t('document.insightsDrawerTitle')} className="flex gap-1">
-                  {DOC_TAB_ORDER.map((tab) => (
-                    <TabButton
-                      key={tab}
-                      buttonId={DOC_TAB_BUTTON_IDS[tab]}
-                      active={documentDrawerTab === tab}
-                      disabled={tab === 'glossary' && !hasGlossary}
-                      onClick={() => activateDocTab(tab)}
-                      onKeyDown={(e) => handleDocTabKeyDown(tab, e)}
-                      label={tab === 'glossary' && !hasGlossary ? t('document.insightsGlossaryEmpty') : DOC_TAB_LABEL[tab]}
-                      icon={DOC_TAB_ICON[tab]}
-                      controls={DOC_TAB_PANEL_IDS[tab]}
-                      buttonRef={(el) => { docTabButtonRefs.current[tab] = el; }}
-                    />
-                  ))}
-                </div>
-                <span className="mx-1 h-4 w-px bg-editorial-border/70" aria-hidden="true" />
-                <span className="font-display italic text-sm text-editorial-ink">{DOC_TAB_LABEL[documentDrawerTab]}</span>
-              </div>
-
-              <div className="flex flex-1 flex-col overflow-y-auto bg-editorial-bg/40 custom-scrollbar">
-                {documentDrawerTab === 'index' ? (
-                  <IndexTab
-                    panelId={DOC_TAB_PANEL_IDS.index}
-                    labelledBy={DOC_TAB_BUTTON_IDS.index}
-                    chunks={chunks}
-                    currentChunkId={currentChunk?.id ?? null}
-                    stuckChunkIds={stuckChunkIds}
-                    onSelect={(id) => setSelectedChunkId(id)}
-                    onCancelStuck={cancelStuckChunk}
-                  />
-                ) : documentDrawerTab === 'search' ? (
-                  <SearchTab
-                    panelId={DOC_TAB_PANEL_IDS.search}
-                    labelledBy={DOC_TAB_BUTTON_IDS.search}
-                    chunks={chunks}
-                    currentChunkId={currentChunk?.id ?? null}
-                    onSelectChunk={setSelectedChunkId}
-                  />
-                ) : documentDrawerTab === 'stats' ? (
-                  <StatsTab
-                    panelId={DOC_TAB_PANEL_IDS.stats}
-                    labelledBy={DOC_TAB_BUTTON_IDS.stats}
-                    chunks={chunks}
-                  />
-                ) : documentDrawerTab === 'glossary' ? (
-                  <GlossaryTab
-                    panelId={DOC_TAB_PANEL_IDS.glossary}
-                    labelledBy={DOC_TAB_BUTTON_IDS.glossary}
-                    glossary={config.glossary}
-                  />
-                ) : (
-                  <CoherenceTab
-                    panelId={DOC_TAB_PANEL_IDS.coherence}
-                    labelledBy={DOC_TAB_BUTTON_IDS.coherence}
-                    currentChunk={currentChunk}
-                    isProcessing={isProcessing}
-                    allChunksTranslated={allChunksTranslated}
-                    allChunksLocked={allChunksLocked}
-                    unlockedChunksCount={unlockedChunksCount}
-                    onSelectChunk={setSelectedChunkId}
-                    onFocusIssue={focusIssueInChunk}
-                    onRunCoherenceAudit={onRunCoherenceAudit}
-                  />
-                )}
-              </div>
-            </div>
-          </motion.aside>
-        )}
-      </AnimatePresence>
-
+      </div>
     </div>
   );
 }

--- a/src/components/document/PaneSearch.tsx
+++ b/src/components/document/PaneSearch.tsx
@@ -6,9 +6,10 @@ interface PaneSearchProps {
   value: string;
   onChange: (value: string) => void;
   label: string;
+  autoFocus?: boolean;
 }
 
-export function PaneSearch({ value, onChange, label }: PaneSearchProps) {
+export function PaneSearch({ value, onChange, label, autoFocus = false }: PaneSearchProps) {
   const { t } = useTranslation();
 
   return (
@@ -26,6 +27,7 @@ export function PaneSearch({ value, onChange, label }: PaneSearchProps) {
           onChange={(event) => onChange(event.target.value)}
           placeholder={t('document.searchChunkPlaceholder')}
           aria-label={label}
+          autoFocus={autoFocus}
           className="min-w-0 flex-1 bg-transparent text-xs text-editorial-ink placeholder:text-editorial-muted/55 focus:outline-none"
         />
         {value ? (

--- a/src/components/document/hooks/useDocumentViewState.ts
+++ b/src/components/document/hooks/useDocumentViewState.ts
@@ -204,6 +204,7 @@ export function useDocumentViewState() {
   return {
     // Layout
     resolvedLayout,
+    documentLayout,
     paneFocus,
     syncScrollEnabled,
     // Chunks

--- a/src/components/document/index.ts
+++ b/src/components/document/index.ts
@@ -1,6 +1,6 @@
 export { DocumentView } from './DocumentView';
 export { ImportPreviewDialog } from './ImportPreviewDialog';
 export { ConfigDrawer } from './ConfigDrawer';
-export { InsightsDrawer } from './InsightsDrawer';
+export { ChunkInspectorPanel, InsightDocPanel } from './InsightsDrawer';
 export { ExportDialog } from './ExportDialog';
 export type { ExportFormat } from './ExportDialog';

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -203,6 +203,7 @@ function OverviewSection() {
       </div>
 
       <P>{t('help.overview.p3')}</P>
+      <P>{t('help.overview.nav')}</P>
       <VersionWidget />
     </>
   );

--- a/src/components/layout/DashboardSidebar.test.tsx
+++ b/src/components/layout/DashboardSidebar.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../stores/projectStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { DashboardSidebar } from './DashboardSidebar';
+
+const originalProjectState = useProjectStore.getState();
+const originalWorkspaceState = useWorkspaceStore.getState();
+
+describe('DashboardSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.setState({
+      ...originalProjectState,
+      closeProject: vi.fn(),
+      loadProjects: vi.fn().mockResolvedValue(undefined),
+    });
+    useWorkspaceStore.setState({
+      ...originalWorkspaceState,
+      activeWorkspace: { id: 'workspace-1', name: 'Editorial' } as never,
+      workspaces: [
+        { id: 'workspace-1', name: 'Editorial' } as never,
+        { id: 'workspace-2', name: 'Archive' } as never,
+      ],
+      createAndActivate: vi.fn().mockResolvedValue({ id: 'workspace-3', name: 'New' }),
+      setActive: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('shows translations as the only enabled macroarea', () => {
+    render(<DashboardSidebar />);
+
+    expect(screen.getByRole('button', { name: /workspace\.areas\.translations\.title/ })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('button', { name: /workspace\.areas\.library\.title/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /workspace\.areas\.transcriptions\.title/ })).toBeDisabled();
+  });
+
+  it('exposes configure and delete actions on the active workspace row', () => {
+    render(<DashboardSidebar />);
+
+    expect(screen.getByRole('button', { name: 'workspace.configure' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'workspace.delete' })).toBeInTheDocument();
+  });
+
+  it('creates a workspace with the default embedding model from the quick form', async () => {
+    const createAndActivate = vi.fn().mockResolvedValue({ id: 'workspace-3', name: 'New' });
+    useWorkspaceStore.setState({ createAndActivate });
+
+    render(<DashboardSidebar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'workspace.create' }));
+    expect(screen.queryByText('workspace.embeddingModel')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('workspace.namePlaceholder'), {
+      target: { value: 'New workspace' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+
+    await waitFor(() => {
+      expect(createAndActivate).toHaveBeenCalledWith({
+        name: 'New workspace',
+        description: undefined,
+        embeddingModel: 'text-embedding-3-small',
+      });
+    });
+  });
+});

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Archive, BookOpenText, ChevronLeft, ChevronRight, FilePen, LibraryBig, Plus, Settings2, Trash2 } from 'lucide-react';
+import { Archive, BookOpenText, FilePen, LibraryBig, Plus, Settings2, Trash2 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -54,6 +54,21 @@ export function DashboardSidebar() {
     closeProject();
     await setActive(ws);
     await loadProjects();
+  };
+
+  // Pattern activity-bar: click sul workspace attivo fa da toggle della barra.
+  const handleWorkspaceClick = (ws: Workspace) => {
+    const isActive = ws.id === activeWorkspace?.id;
+    if (collapsed) {
+      setCollapsed(false);
+      if (!isActive) void handleSwitchWorkspace(ws);
+      return;
+    }
+    if (isActive) {
+      setCollapsed(true);
+      return;
+    }
+    void handleSwitchWorkspace(ws);
   };
 
   const handleCreateWorkspace = async () => {
@@ -129,21 +144,7 @@ export function DashboardSidebar() {
         dragging ? '' : 'transition-[width] duration-200'
       }`}
     >
-      <div className="flex items-center justify-end px-3 pt-3">
-        <IconButton
-          size="sm"
-          tone="muted"
-          onClick={() => setCollapsed(!collapsed)}
-          title={collapsed ? t('sidebar.expandAreas') : t('sidebar.collapseAreas')}
-          ariaPressed={collapsed}
-          tooltipSide="right"
-          className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
-        >
-          {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}
-        </IconButton>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto custom-scrollbar pb-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto custom-scrollbar pb-4 pt-2">
         <ShellNavSection icon={BookOpenText} label={t('sidebar.areaLabel')} collapsed={collapsed}>
           {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => (
             <ShellNavItem
@@ -152,6 +153,7 @@ export function DashboardSidebar() {
               disabled={!enabled}
               collapsed={collapsed}
               labelFont="display"
+              onClick={enabled ? () => setCollapsed(!collapsed) : undefined}
               ariaCurrent={enabled ? 'page' : undefined}
               icon={(
                 <span
@@ -194,7 +196,7 @@ export function DashboardSidebar() {
                 key={ws.id}
                 active={isActive}
                 collapsed={collapsed}
-                onClick={() => void handleSwitchWorkspace(ws)}
+                onClick={() => handleWorkspaceClick(ws)}
                 ariaCurrent={isActive ? 'page' : undefined}
                 icon={(
                   <span

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -144,7 +144,10 @@ export function DashboardSidebar() {
         dragging ? '' : 'transition-[width] duration-200'
       }`}
     >
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto custom-scrollbar pb-4 pt-2">
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden custom-scrollbar pb-4 pt-2"
+        style={{ width: collapsed ? SIDEBAR_COLLAPSED : undefined }}
+      >
         <ShellNavSection icon={BookOpenText} label={t('sidebar.areaLabel')} collapsed={collapsed}>
           {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => (
             <ShellNavItem

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -1,15 +1,19 @@
 import { useState } from 'react';
-import type { ReactNode } from 'react';
-import { Archive, BookOpenText, FilePen, LibraryBig, Plus } from 'lucide-react';
+import { Archive, BookOpenText, ChevronLeft, ChevronRight, FilePen, LibraryBig, Plus, Settings2, Trash2 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useProjectStore } from '../../stores/projectStore';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
-import type { EmbeddingModel, Workspace } from '../../types';
+import { useUiStore } from '../../stores/uiStore';
+import { confirm } from '../../stores/confirmStore';
+import type { Workspace } from '../../types';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { EditorialModalShell } from '../common';
-import { IconButton, PillButton, SectionLabel } from '../ui';
+import { IconButton, PillButton } from '../ui';
+import { WorkspaceSettingsModal } from '../workspace/WorkspaceSettingsModal';
+import { ShellNavItem, ShellNavSection } from './ShellNav';
+import { ResizeHandle, useEdgeResize } from './useEdgeResize';
 
 const AREA_ITEMS = [
   { id: 'translations', icon: BookOpenText, enabled: true },
@@ -17,29 +21,31 @@ const AREA_ITEMS = [
   { id: 'transcriptions', icon: FilePen, enabled: false },
 ] as const;
 
-const ATTACHED_TAB_TRANSITION = {
-  type: 'spring',
-  stiffness: 360,
-  damping: 40,
-  mass: 0.8,
-} as const;
+const SIDEBAR_MIN = 180;
+const SIDEBAR_MAX = 320;
+const SIDEBAR_COLLAPSE_AT = 150;
+const SIDEBAR_COLLAPSED = 64;
 
 export function DashboardSidebar() {
   const { t } = useTranslation();
-  const { workspaces, activeWorkspace, createAndActivate, setActive } = useWorkspaceStore();
-  const { closeProject, loadProjects } = useProjectStore();
+  const { workspaces, activeWorkspace, createAndActivate, setActive, removeWorkspace } = useWorkspaceStore();
+  const { projects, closeProject, loadProjects } = useProjectStore();
+  const collapsed = useUiStore((state) => state.dashboardSidebarCollapsed);
+  const setCollapsed = useUiStore((state) => state.setDashboardSidebarCollapsed);
+  const width = useUiStore((state) => state.dashboardSidebarWidth);
+  const setWidth = useUiStore((state) => state.setDashboardSidebarWidth);
+  const { dragging, startDrag } = useEdgeResize();
 
+  const [showWorkspaceSettings, setShowWorkspaceSettings] = useState(false);
   const [showCreateWsForm, setShowCreateWsForm] = useState(false);
   const [newWsName, setNewWsName] = useState('');
   const [newWsDesc, setNewWsDesc] = useState('');
-  const [newWsModel, setNewWsModel] = useState<EmbeddingModel>('text-embedding-3-small');
   const [savingWs, setSavingWs] = useState(false);
 
   const closeCreateWorkspaceForm = () => {
     setShowCreateWsForm(false);
     setNewWsName('');
     setNewWsDesc('');
-    setNewWsModel('text-embedding-3-small');
   };
   const createDialogRef = useFocusTrap(showCreateWsForm, closeCreateWorkspaceForm);
 
@@ -58,7 +64,7 @@ export function DashboardSidebar() {
       await createAndActivate({
         name: newWsName.trim(),
         description: newWsDesc.trim() || undefined,
-        embeddingModel: newWsModel,
+        embeddingModel: 'text-embedding-3-small',
       });
       await loadProjects();
       toast.success(t('workspace.created'));
@@ -72,87 +78,167 @@ export function DashboardSidebar() {
     }
   };
 
+  const handleDeleteWorkspace = async () => {
+    if (!activeWorkspace) return;
+    if (projects.length > 0) {
+      await confirm({
+        title: t('workspace.deleteBlockedTitle'),
+        message: t('workspace.deleteBlockedMessage', { count: projects.length }),
+        confirmLabel: t('common.confirm'),
+        danger: true,
+      });
+      return;
+    }
+    const ok = await confirm({
+      title: t('workspace.deleteTitle'),
+      message: t('workspace.deleteMessage', { name: activeWorkspace.name }),
+      confirmLabel: t('common.delete'),
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await removeWorkspace(activeWorkspace.id);
+      toast.success(t('workspace.deleted'));
+    } catch (err: unknown) {
+      toast.error(t('workspace.deleteFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const handleResizeStart = (event: React.PointerEvent) => {
+    startDrag(event, {
+      startWidth: collapsed ? SIDEBAR_COLLAPSED : width,
+      min: SIDEBAR_MIN,
+      max: SIDEBAR_MAX,
+      threshold: SIDEBAR_COLLAPSE_AT,
+      mode: 'collapse',
+      onWidth: setWidth,
+      onCollapsedChange: setCollapsed,
+    });
+  };
+
   return (
-    <motion.div
+    <motion.nav
       initial={{ opacity: 0, x: -18 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-      className="relative isolate flex w-48 shrink-0 flex-col bg-editorial-bg/60 after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:z-0 after:w-px after:bg-editorial-border after:content-['']"
+      aria-label={t('sidebar.areaLabel')}
+      style={{ width: collapsed ? SIDEBAR_COLLAPSED : width }}
+      className={`relative flex shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60 ${
+        dragging ? '' : 'transition-[width] duration-200'
+      }`}
     >
-      <nav className="pt-3.5" aria-label={t('sidebar.areaLabel')}>
-        <div className="px-3">
-          <SectionLabel icon={BookOpenText} label={t('sidebar.areaLabel')} />
-        </div>
-        <div className="space-y-1.5 pb-3 pt-2.5">
-          {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => {
-            const isActive = enabled;
-            return (
-              <AttachedSidebarTab
-                key={id}
-                active={isActive}
-                disabled={!enabled}
-                layoutId="dashboard-active-area-tab"
-                ariaCurrent={isActive ? 'page' : undefined}
-                size="area"
-                icon={(
-                  <span className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition-colors duration-200 ${
-                    isActive
+      <div className="flex items-center justify-end px-3 pt-3">
+        <IconButton
+          size="sm"
+          tone="muted"
+          onClick={() => setCollapsed(!collapsed)}
+          title={collapsed ? t('sidebar.expandAreas') : t('sidebar.collapseAreas')}
+          ariaPressed={collapsed}
+          tooltipSide="right"
+          className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
+        >
+          {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}
+        </IconButton>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto custom-scrollbar pb-4">
+        <ShellNavSection icon={BookOpenText} label={t('sidebar.areaLabel')} collapsed={collapsed}>
+          {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => (
+            <ShellNavItem
+              key={id}
+              active={enabled}
+              disabled={!enabled}
+              collapsed={collapsed}
+              labelFont="display"
+              ariaCurrent={enabled ? 'page' : undefined}
+              icon={(
+                <span
+                  className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition-colors duration-200 ${
+                    enabled
                       ? 'border-editorial-accent/45 bg-editorial-accent/10 text-editorial-accent'
                       : 'border-editorial-border bg-editorial-textbox/30 text-editorial-muted'
-                  }`}>
-                    <Icon size={12} />
-                  </span>
-                )}
-                label={t(`workspace.areas.${id}.title`)}
-              />
-            );
-          })}
-        </div>
-      </nav>
+                  }`}
+                >
+                  <Icon size={12} />
+                </span>
+              )}
+              label={t(`workspace.areas.${id}.title`)}
+              hint={t(`workspace.areas.${id}.sidebarHint`)}
+            />
+          ))}
+        </ShellNavSection>
 
-      <div className="mx-3 mb-3 mt-1 h-px bg-editorial-border/60" aria-hidden="true" />
-
-      <section className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="px-3 flex items-center justify-between gap-2">
-          <SectionLabel icon={Archive} label={t('sidebar.workspaceSection')} />
-          <IconButton
-            size="sm"
-            tone="muted"
-            onClick={() => setShowCreateWsForm(true)}
-            title={t('workspace.create')}
-            tooltipSide="right"
-            className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
-          >
-            <Plus size={11} />
-          </IconButton>
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto custom-scrollbar space-y-1.5 pb-4 pt-2.5">
+        <ShellNavSection
+          icon={Archive}
+          label={t('sidebar.workspaceSection')}
+          collapsed={collapsed}
+          action={(
+            <IconButton
+              size="sm"
+              tone="muted"
+              onClick={() => setShowCreateWsForm(true)}
+              title={t('workspace.create')}
+              tooltipSide="right"
+              className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
+            >
+              <Plus size={11} />
+            </IconButton>
+          )}
+        >
           {workspaces.map((ws) => {
             const isActive = ws.id === activeWorkspace?.id;
             return (
-              <AttachedSidebarTab
+              <ShellNavItem
                 key={ws.id}
                 active={isActive}
-                layoutId="dashboard-active-workspace-tab"
+                collapsed={collapsed}
                 onClick={() => void handleSwitchWorkspace(ws)}
                 ariaCurrent={isActive ? 'page' : undefined}
                 icon={(
                   <span
                     className={`h-2 w-2 shrink-0 rounded-full transition-colors duration-200 ${
-                      isActive
-                        ? 'bg-editorial-accent'
-                        : 'border border-editorial-border bg-transparent'
+                      isActive ? 'bg-editorial-accent' : 'border border-editorial-border bg-transparent'
                     }`}
                     aria-hidden="true"
                   />
                 )}
                 label={ws.name}
+                trailing={isActive ? (
+                  <>
+                    <IconButton
+                      size="sm"
+                      tone="muted"
+                      onClick={() => setShowWorkspaceSettings(true)}
+                      title={t('workspace.configure')}
+                      tooltipSide="right"
+                    >
+                      <Settings2 size={12} />
+                    </IconButton>
+                    <IconButton
+                      size="sm"
+                      tone="muted"
+                      onClick={() => void handleDeleteWorkspace()}
+                      title={t('workspace.delete')}
+                      tooltipSide="right"
+                    >
+                      <Trash2 size={12} />
+                    </IconButton>
+                  </>
+                ) : undefined}
               />
             );
           })}
-        </div>
-      </section>
+        </ShellNavSection>
+      </div>
+
+      <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('sidebar.resize')} />
+
+      <WorkspaceSettingsModal
+        open={showWorkspaceSettings}
+        onClose={() => setShowWorkspaceSettings(false)}
+      />
 
       {showCreateWsForm && (
         <div
@@ -186,7 +272,7 @@ export function DashboardSidebar() {
           >
             <div className="space-y-4">
               <label className="block space-y-1.5">
-                <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-muted">
+                <span className="text-[11px] font-bold uppercase tracking-[0.1em] text-editorial-muted">
                   {t('workspace.nameLabel')}
                 </span>
                 <input
@@ -199,7 +285,7 @@ export function DashboardSidebar() {
                 />
               </label>
               <label className="block space-y-1.5">
-                <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-muted">
+                <span className="text-[11px] font-bold uppercase tracking-[0.1em] text-editorial-muted">
                   {t('workspace.descriptionLabel')}
                 </span>
                 <textarea
@@ -209,81 +295,10 @@ export function DashboardSidebar() {
                   className="min-h-16 w-full rounded-[14px] border border-editorial-border bg-editorial-textbox/30 px-3 py-2.5 text-sm text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                 />
               </label>
-              <label className="block space-y-1.5">
-                <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-muted">
-                  {t('workspace.embeddingModel')}
-                </span>
-                <select
-                  value={newWsModel}
-                  onChange={(e) => setNewWsModel(e.target.value as EmbeddingModel)}
-                  className="w-full rounded-[14px] border border-editorial-border bg-editorial-textbox/30 px-3 py-2.5 text-sm text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                >
-                  <option value="text-embedding-3-small">text-embedding-3-small</option>
-                  <option value="text-embedding-3-large">text-embedding-3-large</option>
-                </select>
-              </label>
             </div>
           </EditorialModalShell>
         </div>
       )}
-    </motion.div>
-  );
-}
-
-interface AttachedSidebarTabProps {
-  active: boolean;
-  ariaCurrent?: 'page';
-  disabled?: boolean;
-  icon: ReactNode;
-  label: string;
-  layoutId: string;
-  onClick?: () => void;
-  size?: 'area' | 'workspace';
-}
-
-function AttachedSidebarTab({
-  active,
-  ariaCurrent,
-  disabled = false,
-  icon,
-  label,
-  layoutId,
-  onClick,
-  size = 'workspace',
-}: AttachedSidebarTabProps) {
-  const labelClassName = size === 'area'
-    ? 'font-display text-sm italic'
-    : 'font-sans text-sm';
-  const minHeightClassName = size === 'area' ? 'min-h-16' : 'min-h-[3.25rem]';
-  const sharedButtonClassName = `relative z-10 flex w-full items-center gap-2 rounded-l-[20px] rounded-r-none px-3.5 py-2.5 text-left transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${minHeightClassName}`;
-
-  return (
-    <div className={`relative pl-3 pr-0 ${active ? 'z-20' : 'z-10'}`}>
-      {active ? (
-        <motion.div
-          layoutId={layoutId}
-          transition={ATTACHED_TAB_TRANSITION}
-          className="dashboard-sidebar-tab-surface absolute inset-y-0 left-2 right-0 z-0"
-        />
-      ) : null}
-      <button
-        type="button"
-        onClick={onClick}
-        disabled={disabled}
-        aria-current={ariaCurrent}
-        className={`${sharedButtonClassName} ${
-          active
-            ? 'text-editorial-ink'
-            : disabled
-              ? 'cursor-not-allowed text-editorial-muted opacity-55'
-              : 'text-editorial-muted hover:text-editorial-accent'
-        }`}
-      >
-        {icon}
-        <span className={`min-w-0 flex-1 truncate ${labelClassName} ${active ? 'text-editorial-ink' : ''}`}>
-          {label}
-        </span>
-      </button>
-    </div>
+    </motion.nav>
   );
 }

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -12,7 +12,7 @@ import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { EditorialModalShell } from '../common';
 import { IconButton, PillButton } from '../ui';
 import { WorkspaceSettingsModal } from '../workspace/WorkspaceSettingsModal';
-import { ShellNavItem, ShellNavSection } from './ShellNav';
+import { ShellNavFooter, ShellNavItem, ShellNavSection } from './ShellNav';
 import { ResizeHandle, useEdgeResize } from './useEdgeResize';
 
 const AREA_ITEMS = [
@@ -145,9 +145,10 @@ export function DashboardSidebar() {
       }`}
     >
       <div
-        className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden custom-scrollbar pb-4 pt-2"
+        className="flex min-h-0 flex-1 flex-col"
         style={{ width: collapsed ? SIDEBAR_COLLAPSED : undefined }}
       >
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden custom-scrollbar pb-4 pt-2">
         <ShellNavSection icon={BookOpenText} label={t('sidebar.areaLabel')} collapsed={collapsed}>
           {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => (
             <ShellNavItem
@@ -236,6 +237,9 @@ export function DashboardSidebar() {
             );
           })}
         </ShellNavSection>
+        </div>
+
+        <ShellNavFooter collapsed={collapsed} />
       </div>
 
       <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('sidebar.resize')} />

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -4,6 +4,7 @@ import { Header } from './Header';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useLibraryStore } from '../../stores/libraryStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 
 const toastMocks = vi.hoisted(() => ({
   success: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock('sonner', () => ({
 }));
 
 const originalProjectSave = useProjectStore.getState().saveCurrentProject;
+const originalCloseProject = useProjectStore.getState().closeProject;
 const originalLibrarySave = useLibraryStore.getState().saveAllDirty;
 
 describe('Header global save', () => {
@@ -26,6 +28,11 @@ describe('Header global save', () => {
       currentProjectId: null,
       projects: [],
       saveCurrentProject: originalProjectSave,
+      closeProject: originalCloseProject,
+    });
+    useWorkspaceStore.setState({
+      activeWorkspace: null,
+      workspaces: [],
     });
     useLibraryStore.setState({
       dirtyIds: [],
@@ -87,5 +94,25 @@ describe('Header global save', () => {
     await waitFor(() => expect(saveAllDirty).toHaveBeenCalledTimes(1));
     expect(saveCurrentProject).not.toHaveBeenCalled();
     expect(toastMocks.warning).toHaveBeenCalledWith('header.savedLibraryProjectDeferred');
+  });
+
+  it('renders the project breadcrumb and returns to the workspace dashboard', () => {
+    const closeProject = vi.fn();
+    useWorkspaceStore.setState({
+      activeWorkspace: { id: 'workspace-1', name: 'Scholars' } as never,
+      workspaces: [{ id: 'workspace-1', name: 'Scholars' } as never],
+    });
+    useProjectStore.setState({
+      currentProjectId: 'project-1',
+      projects: [{ id: 'project-1', name: 'Draft' } as never],
+      closeProject,
+    });
+
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scholars' }));
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(closeProject).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { HelpCircle, LibraryBig, Save, Settings } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { lazy, Suspense, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -7,6 +8,7 @@ import { useUiStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useLibraryStore } from '../../stores/libraryStore';
 import { useChunksStore } from '../../stores/chunksStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { IconButton, Tooltip } from '../ui';
 
 const HelpGuide = lazy(() =>
@@ -21,13 +23,15 @@ export function Header() {
       showHelp: state.showHelp,
     })),
   );
-  const { currentProjectId, currentProjectName, saveCurrentProject } = useProjectStore(
+  const { currentProjectId, currentProjectName, saveCurrentProject, closeProject } = useProjectStore(
     useShallow((state) => ({
       currentProjectId: state.currentProjectId,
       currentProjectName: state.projects.find((project) => project.id === state.currentProjectId)?.name ?? null,
       saveCurrentProject: state.saveCurrentProject,
+      closeProject: state.closeProject,
     })),
   );
+  const activeWorkspace = useWorkspaceStore((state) => state.activeWorkspace);
   const { dirtyIdsLength, saveAllDirty, setShowLibraryPanel } = useLibraryStore(
     useShallow((state) => ({
       dirtyIdsLength: state.dirtyIds.length,
@@ -42,9 +46,7 @@ export function Header() {
   const helpLoaded = useRef(false);
   if (showHelp) helpLoaded.current = true;
 
-  const brandCtx = currentProjectId && currentProjectName
-    ? currentProjectName
-    : t('header.brandArea');
+  const workspaceLabel = activeWorkspace?.name ?? t('header.brandArea');
 
   const toggleLang = () => {
     i18n.changeLanguage(i18n.language === 'en' ? 'it' : 'en');
@@ -103,15 +105,46 @@ export function Header() {
       <div className="flex items-center justify-between gap-4">
         <div className="min-w-0">
           <div className="flex min-w-0 items-baseline gap-2.5">
-            <span className="shrink-0 font-display text-4xl italic tracking-tight text-editorial-ink md:text-5xl">
+            <span className="shrink-0 font-display text-4xl italic text-editorial-ink md:text-5xl">
               {t('app.brand')}
             </span>
             <span className="shrink-0 font-display text-lg italic text-editorial-muted md:text-xl">
               //
             </span>
-            <span className="min-w-0 truncate font-display text-lg italic text-editorial-muted md:text-xl">
-              {brandCtx}
-            </span>
+            {currentProjectId ? (
+              <button
+                type="button"
+                onClick={closeProject}
+                disabled={isProcessing}
+                className="min-w-0 truncate font-display text-lg italic text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-55 md:text-xl"
+                title={t('sidebar.backToWorkspace')}
+              >
+                {workspaceLabel}
+              </button>
+            ) : (
+              <span className="min-w-0 truncate font-display text-lg italic text-editorial-muted md:text-xl">
+                {workspaceLabel}
+              </span>
+            )}
+            <AnimatePresence mode="popLayout">
+              {currentProjectId && currentProjectName ? (
+                <motion.span
+                  key="project-segment"
+                  initial={{ opacity: 0, x: -12 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -12 }}
+                  transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+                  className="flex min-w-0 items-baseline gap-2.5"
+                >
+                  <span className="shrink-0 font-display text-lg italic text-editorial-muted md:text-xl">
+                    //
+                  </span>
+                  <span className="min-w-0 truncate font-display text-lg italic text-editorial-muted md:text-xl">
+                    {currentProjectName}
+                  </span>
+                </motion.span>
+              ) : null}
+            </AnimatePresence>
           </div>
         </div>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, LibraryBig, Save, Settings } from 'lucide-react';
+import { LibraryBig, Save } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { lazy, Suspense, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,9 +16,8 @@ const HelpGuide = lazy(() =>
 );
 
 export function Header() {
-  const { setShowSettings, setShowHelp, showHelp } = useUiStore(
+  const { setShowHelp, showHelp } = useUiStore(
     useShallow((state) => ({
-      setShowSettings: state.setShowSettings,
       setShowHelp: state.setShowHelp,
       showHelp: state.showHelp,
     })),
@@ -167,13 +166,6 @@ export function Header() {
           >
             <LibraryBig size={16} />
           </IconButton>
-          <IconButton
-            onClick={() => setShowSettings(true)}
-            title={t('header.settings')}
-            tooltipSide="bottom"
-          >
-            <Settings size={16} />
-          </IconButton>
           <Tooltip
             label={`${t('language.label')} (${i18n.language === 'it' ? 'IT -> EN' : 'EN -> IT'})`}
             side="bottom"
@@ -189,14 +181,6 @@ export function Header() {
               </span>
             </button>
           </Tooltip>
-          <IconButton
-            onClick={() => setShowHelp(true)}
-            title={`${t('help.title')} (Ctrl+H)`}
-            ariaLabel={t('help.title')}
-            tooltipSide="bottom"
-          >
-            <HelpCircle size={16} />
-          </IconButton>
         </div>
       </div>
 

--- a/src/components/layout/PipelineSidebar.test.tsx
+++ b/src/components/layout/PipelineSidebar.test.tsx
@@ -28,10 +28,11 @@ describe('PipelineSidebar project shell', () => {
     expect(screen.getByText('projectShell.noDocumentHint')).toBeInTheDocument();
   });
 
-  it('collapses the contextual column without changing the selected tab', () => {
+  it('collapses the contextual column when the active tab is clicked again', () => {
     render(<PipelineSidebar />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'projectShell.collapseContext' }));
+    // Run è il tab attivo di default: ri-cliccarlo comprime la barra.
+    fireEvent.click(screen.getByRole('tab', { name: 'projectShell.runTab' }));
 
     expect(useUiStore.getState().projectContextCollapsed).toBe(true);
     expect(useUiStore.getState().activeProjectPanel).toBe('run');

--- a/src/components/layout/PipelineSidebar.test.tsx
+++ b/src/components/layout/PipelineSidebar.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChunksStore } from '../../stores/chunksStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUiStore } from '../../stores/uiStore';
+import { PipelineSidebar } from './PipelineSidebar';
+
+const initialUiState = useUiStore.getState();
+
+describe('PipelineSidebar project shell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState(initialUiState, true);
+    useChunksStore.setState({
+      chunks: [],
+      isProcessing: false,
+      cancelRequested: false,
+    });
+    useProjectStore.setState({ closeProject: vi.fn() });
+  });
+
+  it('switches the contextual column from Run to Document', () => {
+    render(<PipelineSidebar />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'projectShell.documentTab' }));
+
+    expect(useUiStore.getState().activeProjectPanel).toBe('document');
+    expect(screen.getByText('projectShell.noDocumentHint')).toBeInTheDocument();
+  });
+
+  it('collapses the contextual column without changing the selected tab', () => {
+    render(<PipelineSidebar />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'projectShell.collapseContext' }));
+
+    expect(useUiStore.getState().projectContextCollapsed).toBe(true);
+    expect(useUiStore.getState().activeProjectPanel).toBe('run');
+    expect(screen.queryByText('pipeline.modeLabel')).not.toBeInTheDocument();
+  });
+
+  it('keeps Run Audit Only reachable from document mode', () => {
+    const onRunAuditOnly = vi.fn();
+    useChunksStore.setState({
+      chunks: [
+        {
+          id: 'chunk-1',
+          originalText: 'Source',
+          currentDraft: 'Translation',
+          status: 'completed',
+        } as never,
+      ],
+      isProcessing: false,
+    });
+
+    render(<PipelineSidebar onRunAuditOnly={onRunAuditOnly} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'pipeline.runAuditOnly' }));
+
+    expect(onRunAuditOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the insight fly-out and collapses the primary bar when insight is selected', () => {
+    render(<PipelineSidebar />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'projectShell.insightTab' }));
+
+    expect(useUiStore.getState().activeProjectPanel).toBe('insight');
+    expect(useUiStore.getState().showDocumentDrawer).toBe(true);
+    expect(useUiStore.getState().projectContextCollapsed).toBe(true);
+  });
+});

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -166,7 +166,7 @@ export function PipelineSidebar({
           id="project-context-panel"
           role="tabpanel"
           aria-labelledby={`project-rail-tab-${activeProjectPanel}`}
-          className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-hidden border-t border-editorial-border/50 py-3"
+          className="mt-3 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-hidden border-t border-editorial-border/50 pb-3 pt-5"
         >
           {activeProjectPanel === 'run' ? (
             <PipelineSidebarRunSection

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -10,7 +10,7 @@ import {
 import { motion } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { DashboardSidebar } from './DashboardSidebar';
-import { ShellNavItem } from './ShellNav';
+import { ShellNavFooter, ShellNavItem } from './ShellNav';
 import { ResizeHandle, useEdgeResize } from './useEdgeResize';
 import {
   PipelineSidebarDocumentSection,
@@ -88,12 +88,10 @@ export function PipelineSidebar({
       }
       return;
     }
-    // Pannelli inline (run/pipeline/document)
-    if (collapsed) {
-      setProjectContextCollapsed(false);
-      setActiveProjectPanel(panel);
-    } else if (panel === activeProjectPanel) {
-      setProjectContextCollapsed(true);
+    // Pannelli inline (run/pipeline/document): cambiare sezione conserva lo stato
+    // collassato/espanso; solo il click sulla sezione già attiva fa da toggle.
+    if (panel === activeProjectPanel) {
+      setProjectContextCollapsed(!collapsed);
     } else {
       setActiveProjectPanel(panel);
     }
@@ -187,6 +185,8 @@ export function PipelineSidebar({
             />
           ) : null}
         </div>
+
+        <ShellNavFooter collapsed={collapsed} />
       </div>
 
       <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizeRail')} />

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
 import {
+  ArrowLeft,
   BarChart2,
-  ChevronLeft,
-  ChevronRight,
   FileText,
   Layers,
   Play,
@@ -20,6 +19,8 @@ import {
 } from './PipelineSidebarSections';
 import { useUiStore } from '../../stores/uiStore';
 import type { ProjectPanelTab } from '../../stores/uiStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useChunksStore } from '../../stores/chunksStore';
 import { IconButton } from '../ui';
 
 interface PipelineSidebarProps {
@@ -65,23 +66,38 @@ export function PipelineSidebar({
   const setProjectContextCollapsed = useUiStore((state) => state.setProjectContextCollapsed);
   const width = useUiStore((state) => state.projectSidebarWidth);
   const setWidth = useUiStore((state) => state.setProjectSidebarWidth);
+  const closeProject = useProjectStore((state) => state.closeProject);
+  const isProcessing = useChunksStore((state) => state.isProcessing);
   const { dragging, startDrag } = useEdgeResize();
 
   if (mode === 'dashboard') {
     return <DashboardSidebar />;
   }
 
+  const collapsed = projectContextCollapsed;
+
+  // Pattern activity-bar: l'item attivo fa da toggle del pannello.
   const handleSelect = (panel: ProjectPanelTab) => {
     const isFlyout = panel === 'insight' || panel === 'chunk';
-    const flyoutOpen = showDocumentDrawer || showChunkDrawer;
-    if (isFlyout && activeProjectPanel === panel && flyoutOpen) {
-      setActiveProjectPanel('document');
+    if (isFlyout) {
+      const flyoutOpen = showDocumentDrawer || showChunkDrawer;
+      if (activeProjectPanel === panel && flyoutOpen) {
+        setActiveProjectPanel('document');
+      } else {
+        setActiveProjectPanel(panel);
+      }
       return;
     }
-    setActiveProjectPanel(panel);
+    // Pannelli inline (run/pipeline/document)
+    if (collapsed) {
+      setProjectContextCollapsed(false);
+      setActiveProjectPanel(panel);
+    } else if (panel === activeProjectPanel) {
+      setProjectContextCollapsed(true);
+    } else {
+      setActiveProjectPanel(panel);
+    }
   };
-
-  const collapsed = projectContextCollapsed;
 
   const handleResizeStart = (event: React.PointerEvent) => {
     startDrag(event, {
@@ -106,24 +122,24 @@ export function PipelineSidebar({
         dragging ? '' : 'transition-[width] duration-200'
       }`}
     >
-      <div className={`flex items-center pt-3 ${collapsed ? 'justify-center px-0' : 'justify-end px-3'}`}>
+      <div className={`flex items-center pt-2 ${collapsed ? 'justify-center px-0' : 'px-3'}`}>
         <IconButton
           size="sm"
           tone="muted"
-          onClick={() => setProjectContextCollapsed(!collapsed)}
-          title={collapsed ? t('projectShell.expandContext') : t('projectShell.collapseContext')}
-          ariaPressed={collapsed}
+          onClick={() => closeProject()}
+          disabled={isProcessing}
+          title={t('sidebar.backToWorkspace')}
           tooltipSide="right"
           className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
         >
-          {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}
+          <ArrowLeft size={12} />
         </IconButton>
       </div>
 
       <div
         role="tablist"
         aria-label={t('projectShell.railLabel')}
-        className="space-y-0.5 px-2.5 pt-3"
+        className="space-y-0.5 px-2.5 pt-2"
       >
         {PROJECT_PANEL_TABS.map((tab) => (
           <ShellNavItem

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -122,65 +122,71 @@ export function PipelineSidebar({
         dragging ? '' : 'transition-[width] duration-200'
       }`}
     >
-      <div className={`flex items-center pt-2 ${collapsed ? 'justify-center px-0' : 'px-3'}`}>
-        <IconButton
-          size="sm"
-          tone="muted"
-          onClick={() => closeProject()}
-          disabled={isProcessing}
-          title={t('sidebar.backToWorkspace')}
-          tooltipSide="right"
-          className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
+      {/* Contenuto ancorato alla larghezza collassata: niente slide orizzontale durante l'animazione. */}
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        style={{ width: collapsed ? SIDEBAR_COLLAPSED : undefined }}
+      >
+        <div className={`flex items-center pt-2 ${collapsed ? 'justify-center px-0' : 'px-3'}`}>
+          <IconButton
+            size="sm"
+            tone="muted"
+            onClick={() => closeProject()}
+            disabled={isProcessing}
+            title={t('sidebar.backToWorkspace')}
+            tooltipSide="right"
+            className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
+          >
+            <ArrowLeft size={12} />
+          </IconButton>
+        </div>
+
+        <div
+          role="tablist"
+          aria-label={t('projectShell.railLabel')}
+          className="space-y-0.5 px-2.5 pt-2"
         >
-          <ArrowLeft size={12} />
-        </IconButton>
-      </div>
+          {PROJECT_PANEL_TABS.map((tab) => (
+            <ShellNavItem
+              key={tab.id}
+              id={`project-rail-tab-${tab.id}`}
+              role="tab"
+              ariaSelected={activeProjectPanel === tab.id}
+              ariaControls="project-context-panel"
+              active={activeProjectPanel === tab.id}
+              collapsed={collapsed}
+              onClick={() => handleSelect(tab.id)}
+              icon={tab.icon}
+              label={t(tab.labelKey)}
+            />
+          ))}
+        </div>
 
-      <div
-        role="tablist"
-        aria-label={t('projectShell.railLabel')}
-        className="space-y-0.5 px-2.5 pt-2"
-      >
-        {PROJECT_PANEL_TABS.map((tab) => (
-          <ShellNavItem
-            key={tab.id}
-            id={`project-rail-tab-${tab.id}`}
-            role="tab"
-            ariaSelected={activeProjectPanel === tab.id}
-            ariaControls="project-context-panel"
-            active={activeProjectPanel === tab.id}
-            collapsed={collapsed}
-            onClick={() => handleSelect(tab.id)}
-            icon={tab.icon}
-            label={t(tab.labelKey)}
-          />
-        ))}
-      </div>
-
-      <div
-        id="project-context-panel"
-        role="tabpanel"
-        aria-labelledby={`project-rail-tab-${activeProjectPanel}`}
-        className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-hidden border-t border-editorial-border/50 py-3"
-      >
-        {activeProjectPanel === 'run' ? (
-          <PipelineSidebarRunSection
-            collapsed={collapsed}
-            onRunPipeline={onRunPipeline}
-            onRunAuditOnly={onRunAuditOnly}
-            onCancelPipeline={onCancelPipeline}
-            onDryRun={onDryRun}
-            onRetranslateChunk={onRetranslateChunk}
-          />
-        ) : activeProjectPanel === 'pipeline' ? (
-          <PipelineSidebarPipelinesSection collapsed={collapsed} />
-        ) : activeProjectPanel === 'document' ? (
-          <PipelineSidebarDocumentSection
-            collapsed={collapsed}
-            onImportDocument={onImportDocument}
-            onOpenWorkspaceSettings={onOpenWorkspaceSettings}
-          />
-        ) : null}
+        <div
+          id="project-context-panel"
+          role="tabpanel"
+          aria-labelledby={`project-rail-tab-${activeProjectPanel}`}
+          className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-hidden border-t border-editorial-border/50 py-3"
+        >
+          {activeProjectPanel === 'run' ? (
+            <PipelineSidebarRunSection
+              collapsed={collapsed}
+              onRunPipeline={onRunPipeline}
+              onRunAuditOnly={onRunAuditOnly}
+              onCancelPipeline={onCancelPipeline}
+              onDryRun={onDryRun}
+              onRetranslateChunk={onRetranslateChunk}
+            />
+          ) : activeProjectPanel === 'pipeline' ? (
+            <PipelineSidebarPipelinesSection collapsed={collapsed} />
+          ) : activeProjectPanel === 'document' ? (
+            <PipelineSidebarDocumentSection
+              collapsed={collapsed}
+              onImportDocument={onImportDocument}
+              onOpenWorkspaceSettings={onOpenWorkspaceSettings}
+            />
+          ) : null}
+        </div>
       </div>
 
       <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizeRail')} />

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -1,15 +1,31 @@
+import type { ReactNode } from 'react';
+import {
+  BarChart2,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Layers,
+  Play,
+  Zap,
+} from 'lucide-react';
 import { motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
 import { DashboardSidebar } from './DashboardSidebar';
+import { ShellNavItem } from './ShellNav';
+import { ResizeHandle, useEdgeResize } from './useEdgeResize';
 import {
   PipelineSidebarDocumentSection,
   PipelineSidebarPipelinesSection,
   PipelineSidebarRunSection,
-  PipelineSidebarWorkspaceSection,
 } from './PipelineSidebarSections';
+import { useUiStore } from '../../stores/uiStore';
+import type { ProjectPanelTab } from '../../stores/uiStore';
+import { IconButton } from '../ui';
 
 interface PipelineSidebarProps {
   mode?: 'dashboard' | 'editor';
   onRunPipeline?: () => void;
+  onRunAuditOnly?: () => void;
   onCancelPipeline?: () => void;
   onDryRun?: () => void;
   onRetranslateChunk?: (chunkId: string) => void;
@@ -17,47 +33,141 @@ interface PipelineSidebarProps {
   onOpenWorkspaceSettings?: () => void;
 }
 
+const PROJECT_PANEL_TABS: Array<{ id: ProjectPanelTab; icon: ReactNode; labelKey: string }> = [
+  { id: 'run', icon: <Play size={15} fill="currentColor" />, labelKey: 'projectShell.runTab' },
+  { id: 'pipeline', icon: <Zap size={15} />, labelKey: 'projectShell.pipelineTab' },
+  { id: 'document', icon: <FileText size={15} />, labelKey: 'projectShell.documentTab' },
+  { id: 'insight', icon: <BarChart2 size={15} />, labelKey: 'projectShell.insightTab' },
+  { id: 'chunk', icon: <Layers size={15} />, labelKey: 'projectShell.chunkTab' },
+];
+
+const SIDEBAR_MIN = 180;
+const SIDEBAR_MAX = 320;
+const SIDEBAR_COLLAPSE_AT = 150;
+const SIDEBAR_COLLAPSED = 64;
+
 export function PipelineSidebar({
   mode = 'editor',
   onRunPipeline,
+  onRunAuditOnly,
   onCancelPipeline,
   onDryRun,
   onRetranslateChunk,
   onImportDocument,
   onOpenWorkspaceSettings,
 }: PipelineSidebarProps) {
+  const { t } = useTranslation();
+  const activeProjectPanel = useUiStore((state) => state.activeProjectPanel);
+  const projectContextCollapsed = useUiStore((state) => state.projectContextCollapsed);
+  const showDocumentDrawer = useUiStore((state) => state.showDocumentDrawer);
+  const showChunkDrawer = useUiStore((state) => state.showChunkDrawer);
+  const setActiveProjectPanel = useUiStore((state) => state.setActiveProjectPanel);
+  const setProjectContextCollapsed = useUiStore((state) => state.setProjectContextCollapsed);
+  const width = useUiStore((state) => state.projectSidebarWidth);
+  const setWidth = useUiStore((state) => state.setProjectSidebarWidth);
+  const { dragging, startDrag } = useEdgeResize();
+
   if (mode === 'dashboard') {
     return <DashboardSidebar />;
   }
 
+  const handleSelect = (panel: ProjectPanelTab) => {
+    const isFlyout = panel === 'insight' || panel === 'chunk';
+    const flyoutOpen = showDocumentDrawer || showChunkDrawer;
+    if (isFlyout && activeProjectPanel === panel && flyoutOpen) {
+      setActiveProjectPanel('document');
+      return;
+    }
+    setActiveProjectPanel(panel);
+  };
+
+  const collapsed = projectContextCollapsed;
+
+  const handleResizeStart = (event: React.PointerEvent) => {
+    startDrag(event, {
+      startWidth: collapsed ? SIDEBAR_COLLAPSED : width,
+      min: SIDEBAR_MIN,
+      max: SIDEBAR_MAX,
+      threshold: SIDEBAR_COLLAPSE_AT,
+      mode: 'collapse',
+      onWidth: setWidth,
+      onCollapsedChange: setProjectContextCollapsed,
+    });
+  };
+
   return (
-    <motion.div
+    <motion.nav
       initial={{ opacity: 0, x: -22 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.42, ease: [0.22, 1, 0.36, 1] }}
-      className="relative isolate flex w-52 shrink-0 flex-col bg-editorial-bg/60 after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:z-0 after:w-px after:bg-editorial-border after:content-['']"
+      aria-label={t('projectShell.railLabel')}
+      style={{ width: collapsed ? SIDEBAR_COLLAPSED : width }}
+      className={`relative flex shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60 ${
+        dragging ? '' : 'transition-[width] duration-200'
+      }`}
     >
-      <PipelineSidebarWorkspaceSection
-        onImportDocument={onImportDocument}
-        onOpenWorkspaceSettings={onOpenWorkspaceSettings}
-      />
-
-      <div className="mx-3 my-4 h-px bg-editorial-border/60" />
-
-      <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pb-4 scrollbar-hidden">
-        <PipelineSidebarRunSection
-          onRunPipeline={onRunPipeline}
-          onCancelPipeline={onCancelPipeline}
-          onDryRun={onDryRun}
-          onRetranslateChunk={onRetranslateChunk}
-        />
-
-        <div className="my-4 h-px bg-editorial-border/60" />
-
-        <PipelineSidebarPipelinesSection />
+      <div className={`flex items-center pt-3 ${collapsed ? 'justify-center px-0' : 'justify-end px-3'}`}>
+        <IconButton
+          size="sm"
+          tone="muted"
+          onClick={() => setProjectContextCollapsed(!collapsed)}
+          title={collapsed ? t('projectShell.expandContext') : t('projectShell.collapseContext')}
+          ariaPressed={collapsed}
+          tooltipSide="right"
+          className="bg-editorial-textbox/25 hover:bg-editorial-textbox/45"
+        >
+          {collapsed ? <ChevronRight size={11} /> : <ChevronLeft size={11} />}
+        </IconButton>
       </div>
 
-      <PipelineSidebarDocumentSection />
-    </motion.div>
+      <div
+        role="tablist"
+        aria-label={t('projectShell.railLabel')}
+        className="space-y-0.5 px-2.5 pt-3"
+      >
+        {PROJECT_PANEL_TABS.map((tab) => (
+          <ShellNavItem
+            key={tab.id}
+            id={`project-rail-tab-${tab.id}`}
+            role="tab"
+            ariaSelected={activeProjectPanel === tab.id}
+            ariaControls="project-context-panel"
+            active={activeProjectPanel === tab.id}
+            collapsed={collapsed}
+            onClick={() => handleSelect(tab.id)}
+            icon={tab.icon}
+            label={t(tab.labelKey)}
+          />
+        ))}
+      </div>
+
+      <div
+        id="project-context-panel"
+        role="tabpanel"
+        aria-labelledby={`project-rail-tab-${activeProjectPanel}`}
+        className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-hidden border-t border-editorial-border/50 py-3"
+      >
+        {activeProjectPanel === 'run' ? (
+          <PipelineSidebarRunSection
+            collapsed={collapsed}
+            onRunPipeline={onRunPipeline}
+            onRunAuditOnly={onRunAuditOnly}
+            onCancelPipeline={onCancelPipeline}
+            onDryRun={onDryRun}
+            onRetranslateChunk={onRetranslateChunk}
+          />
+        ) : activeProjectPanel === 'pipeline' ? (
+          <PipelineSidebarPipelinesSection collapsed={collapsed} />
+        ) : activeProjectPanel === 'document' ? (
+          <PipelineSidebarDocumentSection
+            collapsed={collapsed}
+            onImportDocument={onImportDocument}
+            onOpenWorkspaceSettings={onOpenWorkspaceSettings}
+          />
+        ) : null}
+      </div>
+
+      <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizeRail')} />
+    </motion.nav>
   );
 }

--- a/src/components/layout/PipelineSidebarSections.tsx
+++ b/src/components/layout/PipelineSidebarSections.tsx
@@ -1,12 +1,9 @@
 import {
-  ChevronLeft,
   Columns2,
   FileOutput,
   FlaskConical,
-  FolderOpen,
   Highlighter,
   Info,
-  LibraryBig,
   Link2,
   Link2Off,
   Loader2,
@@ -45,7 +42,6 @@ import { usePricingStore } from '../../stores/pricingStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUiStore } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
-import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { estimatePipelineCost } from '../../utils/costEstimate';
 import { CostBreakdownPanel } from '../pipeline/CostBadge';
 import { IconButton, SectionLabel, Tooltip } from '../ui';
@@ -66,11 +62,7 @@ function clamp(value: number, min: number, max: number) {
 }
 
 function SidebarSectionShell({ children }: { children: ReactNode }) {
-  return (
-    <div className="-mr-px rounded-l-[20px] rounded-r-none border border-r-0 border-editorial-border bg-editorial-paper px-3 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55),6px_10px_20px_rgba(74,50,17,0.04)]">
-      {children}
-    </div>
-  );
+  return <div className="px-1">{children}</div>;
 }
 
 function SidebarCostPanel({
@@ -141,90 +133,17 @@ function SidebarCostPanel({
   );
 }
 
-export function PipelineSidebarWorkspaceSection({
-  onImportDocument,
-  onOpenWorkspaceSettings,
-}: {
-  onImportDocument?: () => void;
-  onOpenWorkspaceSettings?: () => void;
-}) {
-  const { t } = useTranslation();
-  const { activeWorkspace } = useWorkspaceStore(useShallow((state) => ({ activeWorkspace: state.activeWorkspace })));
-  const { setShowProjectPanel, closeProject } = useProjectStore(
-    useShallow((state) => ({
-      setShowProjectPanel: state.setShowProjectPanel,
-      closeProject: state.closeProject,
-    })),
-  );
-  const isProcessing = useChunksStore((state) => state.isProcessing);
-  const hasDocument = useChunksStore((state) => state.chunks.length > 0);
-
-  return (
-    <div className="relative z-10 pl-3 pr-0 pt-3">
-      <SidebarSectionShell>
-        <div className="flex justify-center pb-2">
-          <SectionLabel icon={LibraryBig} label={t('sidebar.workspaceSection')} />
-        </div>
-        <div className="flex items-center gap-2">
-          <IconButton
-            size="sm"
-            onClick={closeProject}
-            title={t('sidebar.backToWorkspace')}
-            disabled={isProcessing}
-            tooltipSide="right"
-            className="shrink-0"
-          >
-            <ChevronLeft size={15} />
-          </IconButton>
-          <div className="min-w-0 flex-1">
-            <span className="block truncate font-display text-base italic leading-none text-editorial-ink">
-              {activeWorkspace?.name ?? '—'}
-            </span>
-          </div>
-        </div>
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          <IconButton
-            size="md"
-            onClick={() => setShowProjectPanel(true)}
-            title={t('projects.title')}
-            tooltipSide="right"
-          >
-            <FolderOpen size={15} />
-          </IconButton>
-          <IconButton
-            size="md"
-            onClick={onOpenWorkspaceSettings}
-            title={t('workspace.configure')}
-            tooltipSide="right"
-          >
-            <Settings2 size={15} />
-          </IconButton>
-        </div>
-        {!hasDocument && (
-          <div className="mt-2 flex justify-center">
-            <IconButton
-              size="md"
-              onClick={onImportDocument}
-              title={t('files.import')}
-              tooltipSide="right"
-              className="shrink-0"
-            >
-              <Upload size={15} />
-            </IconButton>
-          </div>
-        )}
-      </SidebarSectionShell>
-    </div>
-  );
-}
-
 export function PipelineSidebarRunSection({
+  collapsed = false,
   onRunPipeline,
+  onRunAuditOnly,
   onCancelPipeline,
   onDryRun,
   onRetranslateChunk,
 }: {
+  collapsed?: boolean;
   onRunPipeline?: () => void;
+  onRunAuditOnly?: () => void;
   onCancelPipeline?: () => void;
   onDryRun?: () => void;
   onRetranslateChunk?: (chunkId: string) => void;
@@ -297,8 +216,43 @@ export function PipelineSidebarRunSection({
     };
   }, []);
 
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center gap-2 px-1">
+        {isProcessing ? (
+          cancelRequested ? (
+            <IconButton size="lg" tone="muted" disabled title={t('pipeline.stopping')} tooltipSide="right" className="h-11 w-11 bg-editorial-bg opacity-50">
+              <Loader2 size={18} className="animate-spin" />
+            </IconButton>
+          ) : (
+            <IconButton size="lg" tone="default" onClick={onCancelPipeline} title={t('pipeline.stopPipeline')} tooltipSide="right" className="h-11 w-11 border-editorial-accent bg-editorial-bg text-editorial-accent hover:bg-editorial-accent/10">
+              <Square size={16} fill="currentColor" />
+            </IconButton>
+          )
+        ) : (
+          <IconButton size="lg" tone="charcoal" onClick={pipelineMode === 'test' ? onDryRun : onRunPipeline} disabled={isProcessing || !hasDocument} title={`${t('pipeline.beginPipeline')} (Ctrl+↵)`} ariaLabel={t('pipeline.beginPipeline')} tooltipSide="right" className="h-11 w-11 border-editorial-charcoal bg-editorial-charcoal text-white hover:bg-editorial-charcoal/85">
+            <Play size={18} fill="currentColor" />
+          </IconButton>
+        )}
+        {hasDocument ? (
+          <span className="text-[11px] font-bold tabular-nums tracking-[0.1em] text-editorial-muted">
+            {completedCount}/{pipelineMode === 'test' ? runChunkCount : totalChunks}
+          </span>
+        ) : null}
+        <IconButton size="md" onClick={onRunAuditOnly} disabled={isProcessing || !hasDocument} title={t('pipeline.runAuditOnly')} ariaLabel={t('pipeline.runAuditOnly')} tooltipSide="right" className="bg-editorial-bg">
+          <Highlighter size={14} />
+        </IconButton>
+        {currentChunk ? (
+          <IconButton size="md" tone="charcoal" onClick={() => currentChunk && onRetranslateChunk?.(currentChunk.id)} disabled={isProcessing || !currentChunk.hasOriginalText} title={pipelineMode === 'test' ? t('pipeline.retestChunk') : t('pipeline.retranslateChunk')} tooltipSide="right" className="h-10 w-10 bg-editorial-bg">
+            <RotateCcw size={13} />
+          </IconButton>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
-    <div className="relative z-10 pl-3 pr-0">
+    <div className="px-2.5">
       <SidebarSectionShell>
         <div className="flex flex-col gap-4">
           <div className="flex flex-col items-center gap-2">
@@ -407,6 +361,18 @@ export function PipelineSidebarRunSection({
                 {completedCount} / {pipelineMode === 'test' ? runChunkCount : totalChunks}
               </span>
             )}
+            <IconButton
+              size="md"
+              tone="default"
+              onClick={onRunAuditOnly}
+              disabled={isProcessing || !hasDocument}
+              title={t('pipeline.runAuditOnly')}
+              ariaLabel={t('pipeline.runAuditOnly')}
+              tooltipSide="right"
+              className="mt-1 bg-editorial-bg"
+            >
+              <Highlighter size={14} />
+            </IconButton>
           </div>
 
           <div className="flex flex-col items-center gap-1.5">
@@ -459,7 +425,7 @@ export function PipelineSidebarRunSection({
   );
 }
 
-export function PipelineSidebarPipelinesSection() {
+export function PipelineSidebarPipelinesSection({ collapsed = false }: { collapsed?: boolean }) {
   const { t } = useTranslation();
   const runStatus = usePipelineStore((state) => state.runStatus);
   const {
@@ -503,8 +469,63 @@ export function PipelineSidebarPipelinesSection() {
     await deletePipeline(pipelineId);
   }, [deletePipeline, t]);
 
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center gap-2 px-1">
+        {pipelines.length === 0 ? (
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-editorial-accent text-xs font-black text-white opacity-55">1</span>
+        ) : (
+          pipelines.map((pipeline, index) => {
+            const isActive = pipeline.id === activePipelineId;
+            const isPipelineRunning = isActive && isRunning;
+            return (
+              <IconButton
+                key={pipeline.id}
+                size="lg"
+                tone={isActive ? 'accent' : 'default'}
+                onClick={() => switchPipeline(pipeline.id)}
+                title={pipeline.name}
+                tooltipSide="right"
+                className="h-11 w-11 text-sm font-black"
+              >
+                {isPipelineRunning ? (
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-transparent border-t-current" />
+                ) : (
+                  index + 1
+                )}
+              </IconButton>
+            );
+          })
+        )}
+        {hasProject && pipelines.length < maxPipelines ? (
+          <IconButton
+            size="md"
+            onClick={() => createNewPipeline(t('pipeline.pipelineNumber', { number: pipelines.length + 1 }))}
+            title={t('pipeline.newPipeline')}
+            tooltipSide="right"
+            className="border-dashed bg-editorial-bg"
+          >
+            <Plus size={14} />
+          </IconButton>
+        ) : null}
+        <IconButton
+          size="md"
+          tone={showConfigDrawer ? 'accent' : 'default'}
+          onClick={() => setShowConfigDrawer(!showConfigDrawer)}
+          title={`${t('pipeline.configurePipeline')} (Ctrl+,)`}
+          ariaLabel={t('pipeline.configurePipeline')}
+          ariaPressed={showConfigDrawer}
+          tooltipSide="right"
+          className={showConfigDrawer ? '' : 'bg-editorial-textbox'}
+        >
+          <Settings2 size={15} />
+        </IconButton>
+      </div>
+    );
+  }
+
   return (
-    <div className="relative z-10 pl-3 pr-0">
+    <div className="px-2.5">
       <SidebarSectionShell>
         <div className="flex flex-col gap-3">
           <div className="flex flex-col items-center gap-1">
@@ -597,7 +618,15 @@ export function PipelineSidebarPipelinesSection() {
   );
 }
 
-export function PipelineSidebarDocumentSection() {
+export function PipelineSidebarDocumentSection({
+  collapsed = false,
+  onImportDocument,
+  onOpenWorkspaceSettings,
+}: {
+  collapsed?: boolean;
+  onImportDocument?: () => void;
+  onOpenWorkspaceSettings?: () => void;
+}) {
   const { t } = useTranslation();
   const hasDocument = useChunksStore((state) => state.chunks.length > 0);
   const {
@@ -622,72 +651,133 @@ export function PipelineSidebarDocumentSection() {
     })),
   );
 
-  if (!hasDocument) return null;
-
   const syncScrollDisabled = documentPaneFocus !== 'both';
 
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center gap-2 px-1">
+        {hasDocument ? (
+          <>
+            <IconButton size="md" tone={documentPaneFocus === 'both' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('both')} title={t('document.focusBoth')} ariaPressed={documentPaneFocus === 'both'} tooltipSide="right">
+              <Columns2 size={14} />
+            </IconButton>
+            <IconButton size="md" tone={documentPaneFocus === 'source' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('source')} title={t('document.focusSource')} ariaPressed={documentPaneFocus === 'source'} tooltipSide="right">
+              <PanelLeft size={14} />
+            </IconButton>
+            <IconButton size="md" tone={documentPaneFocus === 'translation' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('translation')} title={t('document.focusTranslation')} ariaPressed={documentPaneFocus === 'translation'} tooltipSide="right">
+              <PanelRight size={14} />
+            </IconButton>
+            <IconButton size="md" tone={syncScrollEnabled && !syncScrollDisabled ? 'accent' : 'default'} onClick={() => setSyncScrollEnabled(!syncScrollEnabled)} title={syncScrollEnabled ? t('document.scrollSyncDisable') : t('document.scrollSyncEnable')} disabled={syncScrollDisabled} ariaPressed={syncScrollEnabled && !syncScrollDisabled} tooltipSide="right">
+              {syncScrollEnabled && !syncScrollDisabled ? <Link2 size={14} /> : <Link2Off size={14} />}
+            </IconButton>
+            <IconButton size="md" tone={highlightsEnabled ? 'accent' : 'default'} onClick={() => setHighlightsEnabled(!highlightsEnabled)} title={t('document.highlightsToggle')} ariaPressed={highlightsEnabled} tooltipSide="right">
+              <Highlighter size={14} />
+            </IconButton>
+            <IconButton size="md" onClick={() => setShowExportDialog(true)} title={`${t('header.exportLabel')} (Ctrl+E)`} ariaLabel={t('header.exportLabel')} tooltipSide="right">
+              <FileOutput size={14} />
+            </IconButton>
+          </>
+        ) : null}
+        <IconButton size="md" onClick={onImportDocument} title={t('files.import')} disabled={!onImportDocument} tooltipSide="right">
+          <Upload size={14} />
+        </IconButton>
+        <IconButton size="md" tone="muted" onClick={onOpenWorkspaceSettings} title={t('workspace.configure')} disabled={!onOpenWorkspaceSettings} tooltipSide="right">
+          <Settings2 size={14} />
+        </IconButton>
+        <PipelineSidebarExportDialogHost open={showExportDialog} onOpenChange={setShowExportDialog} />
+      </div>
+    );
+  }
+
   return (
-    <div className="relative z-10 pl-3 pr-0 pb-4 pt-3">
+    <div className="px-2.5">
       <SidebarSectionShell>
         <div className="flex justify-center pb-2">
           <SectionLabel icon={Columns2} label={t('document.panelsTitle')} />
         </div>
-        <div className="flex items-center justify-center gap-2">
+        {hasDocument ? (
+          <>
+            <div className="flex items-center justify-center gap-2">
+              <IconButton
+                size="md"
+                tone={documentPaneFocus === 'both' ? 'accent' : 'default'}
+                onClick={() => setDocumentPaneFocus('both')}
+                title={t('document.focusBoth')}
+                ariaPressed={documentPaneFocus === 'both'}
+              >
+                <Columns2 size={14} />
+              </IconButton>
+              <IconButton
+                size="md"
+                tone={documentPaneFocus === 'source' ? 'accent' : 'default'}
+                onClick={() => setDocumentPaneFocus('source')}
+                title={t('document.focusSource')}
+                ariaPressed={documentPaneFocus === 'source'}
+              >
+                <PanelLeft size={14} />
+              </IconButton>
+              <IconButton
+                size="md"
+                tone={documentPaneFocus === 'translation' ? 'accent' : 'default'}
+                onClick={() => setDocumentPaneFocus('translation')}
+                title={t('document.focusTranslation')}
+                ariaPressed={documentPaneFocus === 'translation'}
+              >
+                <PanelRight size={14} />
+              </IconButton>
+            </div>
+            <div className="mt-3 flex items-center justify-center gap-2 border-t border-editorial-border/40 pt-3">
+              <IconButton
+                size="md"
+                tone={syncScrollEnabled && !syncScrollDisabled ? 'accent' : 'default'}
+                onClick={() => setSyncScrollEnabled(!syncScrollEnabled)}
+                title={syncScrollEnabled ? t('document.scrollSyncDisable') : t('document.scrollSyncEnable')}
+                disabled={syncScrollDisabled}
+                ariaPressed={syncScrollEnabled && !syncScrollDisabled}
+              >
+                {syncScrollEnabled && !syncScrollDisabled ? <Link2 size={14} /> : <Link2Off size={14} />}
+              </IconButton>
+              <IconButton
+                size="md"
+                tone={highlightsEnabled ? 'accent' : 'default'}
+                onClick={() => setHighlightsEnabled(!highlightsEnabled)}
+                title={t('document.highlightsToggle')}
+                ariaPressed={highlightsEnabled}
+              >
+                <Highlighter size={14} />
+              </IconButton>
+              <IconButton
+                size="md"
+                onClick={() => setShowExportDialog(true)}
+                title={`${t('header.exportLabel')} (Ctrl+E)`}
+                ariaLabel={t('header.exportLabel')}
+              >
+                <FileOutput size={14} />
+              </IconButton>
+            </div>
+          </>
+        ) : (
+          <p className="px-1 text-center text-xs leading-relaxed text-editorial-muted [text-wrap:pretty]">
+            {t('projectShell.noDocumentHint')}
+          </p>
+        )}
+        <div className="mt-3 flex items-center justify-center gap-2 border-t border-editorial-border/50 pt-3">
           <IconButton
             size="md"
-            tone={documentPaneFocus === 'both' ? 'accent' : 'default'}
-            onClick={() => setDocumentPaneFocus('both')}
-            title={t('document.focusBoth')}
-            ariaPressed={documentPaneFocus === 'both'}
+            onClick={onImportDocument}
+            title={t('files.import')}
+            disabled={!onImportDocument}
           >
-            <Columns2 size={14} />
+            <Upload size={14} />
           </IconButton>
           <IconButton
             size="md"
-            tone={documentPaneFocus === 'source' ? 'accent' : 'default'}
-            onClick={() => setDocumentPaneFocus('source')}
-            title={t('document.focusSource')}
-            ariaPressed={documentPaneFocus === 'source'}
+            tone="muted"
+            onClick={onOpenWorkspaceSettings}
+            title={t('workspace.configure')}
+            disabled={!onOpenWorkspaceSettings}
           >
-            <PanelLeft size={14} />
-          </IconButton>
-          <IconButton
-            size="md"
-            tone={documentPaneFocus === 'translation' ? 'accent' : 'default'}
-            onClick={() => setDocumentPaneFocus('translation')}
-            title={t('document.focusTranslation')}
-            ariaPressed={documentPaneFocus === 'translation'}
-          >
-            <PanelRight size={14} />
-          </IconButton>
-        </div>
-        <div className="mt-2 flex items-center justify-center gap-2">
-          <IconButton
-            size="md"
-            tone={syncScrollEnabled && !syncScrollDisabled ? 'accent' : 'default'}
-            onClick={() => setSyncScrollEnabled(!syncScrollEnabled)}
-            title={syncScrollEnabled ? t('document.scrollSyncDisable') : t('document.scrollSyncEnable')}
-            disabled={syncScrollDisabled}
-            ariaPressed={syncScrollEnabled && !syncScrollDisabled}
-          >
-            {syncScrollEnabled && !syncScrollDisabled ? <Link2 size={14} /> : <Link2Off size={14} />}
-          </IconButton>
-          <IconButton
-            size="md"
-            tone={highlightsEnabled ? 'accent' : 'default'}
-            onClick={() => setHighlightsEnabled(!highlightsEnabled)}
-            title={t('document.highlightsToggle')}
-            ariaPressed={highlightsEnabled}
-          >
-            <Highlighter size={14} />
-          </IconButton>
-          <IconButton
-            size="md"
-            onClick={() => setShowExportDialog(true)}
-            title={`${t('header.exportLabel')} (Ctrl+E)`}
-            ariaLabel={t('header.exportLabel')}
-          >
-            <FileOutput size={14} />
+            <Settings2 size={14} />
           </IconButton>
         </div>
       </SidebarSectionShell>

--- a/src/components/layout/PipelineSidebarSections.tsx
+++ b/src/components/layout/PipelineSidebarSections.tsx
@@ -218,33 +218,42 @@ export function PipelineSidebarRunSection({
 
   if (collapsed) {
     return (
-      <div className="flex flex-col items-center gap-2 px-1">
-        <FlaskConical size={13} className="text-editorial-muted/70" aria-hidden="true" />
+      <div className="flex flex-col items-center gap-3 px-1 pt-1">
+        <div className="flex flex-col items-center gap-1">
+          {pipelineMode === 'test' ? (
+            <FlaskConical size={14} className="text-editorial-accent" aria-hidden="true" />
+          ) : (
+            <Zap size={14} className="text-editorial-accent" aria-hidden="true" />
+          )}
+          <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-editorial-accent">
+            {pipelineMode === 'test' ? t('pipeline.modeTest') : t('pipeline.modeProduction')}
+          </span>
+        </div>
         {isProcessing ? (
           cancelRequested ? (
-            <IconButton size="lg" tone="muted" disabled title={t('pipeline.stopping')} tooltipSide="right" className="h-11 w-11 bg-editorial-bg opacity-50">
-              <Loader2 size={18} className="animate-spin" />
+            <IconButton size="md" tone="muted" disabled title={t('pipeline.stopping')} tooltipSide="right" className="h-9 w-9 bg-editorial-bg opacity-50">
+              <Loader2 size={15} className="animate-spin" />
             </IconButton>
           ) : (
-            <IconButton size="lg" tone="default" onClick={onCancelPipeline} title={t('pipeline.stopPipeline')} tooltipSide="right" className="h-11 w-11 border-editorial-accent bg-editorial-bg text-editorial-accent hover:bg-editorial-accent/10">
-              <Square size={16} fill="currentColor" />
+            <IconButton size="md" tone="default" onClick={onCancelPipeline} title={t('pipeline.stopPipeline')} tooltipSide="right" className="h-9 w-9 border-editorial-accent bg-editorial-bg text-editorial-accent hover:bg-editorial-accent/10">
+              <Square size={14} fill="currentColor" />
             </IconButton>
           )
         ) : (
-          <IconButton size="lg" tone="charcoal" onClick={pipelineMode === 'test' ? onDryRun : onRunPipeline} disabled={isProcessing || !hasDocument} title={`${t('pipeline.beginPipeline')} (Ctrl+↵)`} ariaLabel={t('pipeline.beginPipeline')} tooltipSide="right" className="h-11 w-11 border-editorial-charcoal bg-editorial-charcoal text-white hover:bg-editorial-charcoal/85">
-            <Play size={18} fill="currentColor" />
+          <IconButton size="md" tone="charcoal" onClick={pipelineMode === 'test' ? onDryRun : onRunPipeline} disabled={isProcessing || !hasDocument} title={`${t('pipeline.beginPipeline')} (Ctrl+↵)`} ariaLabel={t('pipeline.beginPipeline')} tooltipSide="right" className="h-9 w-9 border-editorial-charcoal bg-editorial-charcoal text-white hover:bg-editorial-charcoal/85">
+            <Play size={15} fill="currentColor" />
           </IconButton>
         )}
         {hasDocument ? (
-          <span className="text-[11px] font-bold tabular-nums tracking-[0.1em] text-editorial-muted">
+          <span className="text-[10px] font-bold tabular-nums tracking-[0.1em] text-editorial-muted">
             {completedCount}/{pipelineMode === 'test' ? runChunkCount : totalChunks}
           </span>
         ) : null}
-        <IconButton size="md" onClick={onRunAuditOnly} disabled={isProcessing || !hasDocument} title={t('pipeline.runAuditOnly')} ariaLabel={t('pipeline.runAuditOnly')} tooltipSide="right" className="bg-editorial-bg">
+        <IconButton size="md" onClick={onRunAuditOnly} disabled={isProcessing || !hasDocument} title={t('pipeline.runAuditOnly')} ariaLabel={t('pipeline.runAuditOnly')} tooltipSide="right" className="h-9 w-9 bg-editorial-bg">
           <Highlighter size={14} />
         </IconButton>
         {currentChunk ? (
-          <IconButton size="md" tone="charcoal" onClick={() => currentChunk && onRetranslateChunk?.(currentChunk.id)} disabled={isProcessing || !currentChunk.hasOriginalText} title={pipelineMode === 'test' ? t('pipeline.retestChunk') : t('pipeline.retranslateChunk')} tooltipSide="right" className="h-10 w-10 bg-editorial-bg">
+          <IconButton size="md" tone="charcoal" onClick={() => currentChunk && onRetranslateChunk?.(currentChunk.id)} disabled={isProcessing || !currentChunk.hasOriginalText} title={pipelineMode === 'test' ? t('pipeline.retestChunk') : t('pipeline.retranslateChunk')} tooltipSide="right" className="h-9 w-9 bg-editorial-bg">
             <RotateCcw size={13} />
           </IconButton>
         ) : null}
@@ -286,6 +295,9 @@ export function PipelineSidebarRunSection({
                 <Zap size={14} />
               </IconButton>
             </div>
+            <span className="font-display text-sm italic text-editorial-accent">
+              {pipelineMode === 'test' ? t('pipeline.modeTest') : t('pipeline.modeProduction')}
+            </span>
           </div>
 
           <div className="flex flex-col items-center gap-2.5">
@@ -472,10 +484,10 @@ export function PipelineSidebarPipelinesSection({ collapsed = false }: { collaps
 
   if (collapsed) {
     return (
-      <div className="flex flex-col items-center gap-2 px-1">
+      <div className="flex flex-col items-center gap-3 px-1 pt-1">
         <Zap size={13} className="text-editorial-muted/70" aria-hidden="true" />
         {pipelines.length === 0 ? (
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-editorial-accent text-xs font-black text-white opacity-55">1</span>
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-editorial-accent text-xs font-black text-white opacity-55">1</span>
         ) : (
           pipelines.map((pipeline, index) => {
             const isActive = pipeline.id === activePipelineId;
@@ -483,12 +495,12 @@ export function PipelineSidebarPipelinesSection({ collapsed = false }: { collaps
             return (
               <IconButton
                 key={pipeline.id}
-                size="lg"
+                size="md"
                 tone={isActive ? 'accent' : 'default'}
                 onClick={() => switchPipeline(pipeline.id)}
                 title={pipeline.name}
                 tooltipSide="right"
-                className="h-11 w-11 text-sm font-black"
+                className="h-9 w-9 text-sm font-black"
               >
                 {isPipelineRunning ? (
                   <span className="h-4 w-4 animate-spin rounded-full border-2 border-transparent border-t-current" />
@@ -505,7 +517,7 @@ export function PipelineSidebarPipelinesSection({ collapsed = false }: { collaps
             onClick={() => createNewPipeline(t('pipeline.pipelineNumber', { number: pipelines.length + 1 }))}
             title={t('pipeline.newPipeline')}
             tooltipSide="right"
-            className="border-dashed bg-editorial-bg"
+            className="h-9 w-9 border-dashed bg-editorial-bg"
           >
             <Plus size={14} />
           </IconButton>
@@ -518,7 +530,7 @@ export function PipelineSidebarPipelinesSection({ collapsed = false }: { collaps
           ariaLabel={t('pipeline.configurePipeline')}
           ariaPressed={showConfigDrawer}
           tooltipSide="right"
-          className={showConfigDrawer ? '' : 'bg-editorial-textbox'}
+          className={`h-9 w-9 ${showConfigDrawer ? '' : 'bg-editorial-textbox'}`}
         >
           <Settings2 size={15} />
         </IconButton>
@@ -657,34 +669,34 @@ export function PipelineSidebarDocumentSection({
 
   if (collapsed) {
     return (
-      <div className="flex flex-col items-center gap-2 px-1">
+      <div className="flex flex-col items-center gap-3 px-1 pt-1">
         <Columns2 size={13} className="text-editorial-muted/70" aria-hidden="true" />
         {hasDocument ? (
           <>
-            <IconButton size="md" tone={documentPaneFocus === 'both' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('both')} title={t('document.focusBoth')} ariaPressed={documentPaneFocus === 'both'} tooltipSide="right">
+            <IconButton size="md" tone={documentPaneFocus === 'both' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('both')} title={t('document.focusBoth')} ariaPressed={documentPaneFocus === 'both'} tooltipSide="right" className="h-9 w-9">
               <Columns2 size={14} />
             </IconButton>
-            <IconButton size="md" tone={documentPaneFocus === 'source' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('source')} title={t('document.focusSource')} ariaPressed={documentPaneFocus === 'source'} tooltipSide="right">
+            <IconButton size="md" tone={documentPaneFocus === 'source' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('source')} title={t('document.focusSource')} ariaPressed={documentPaneFocus === 'source'} tooltipSide="right" className="h-9 w-9">
               <PanelLeft size={14} />
             </IconButton>
-            <IconButton size="md" tone={documentPaneFocus === 'translation' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('translation')} title={t('document.focusTranslation')} ariaPressed={documentPaneFocus === 'translation'} tooltipSide="right">
+            <IconButton size="md" tone={documentPaneFocus === 'translation' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('translation')} title={t('document.focusTranslation')} ariaPressed={documentPaneFocus === 'translation'} tooltipSide="right" className="h-9 w-9">
               <PanelRight size={14} />
             </IconButton>
-            <IconButton size="md" tone={syncScrollEnabled && !syncScrollDisabled ? 'accent' : 'default'} onClick={() => setSyncScrollEnabled(!syncScrollEnabled)} title={syncScrollEnabled ? t('document.scrollSyncDisable') : t('document.scrollSyncEnable')} disabled={syncScrollDisabled} ariaPressed={syncScrollEnabled && !syncScrollDisabled} tooltipSide="right">
+            <IconButton size="md" tone={syncScrollEnabled && !syncScrollDisabled ? 'accent' : 'default'} onClick={() => setSyncScrollEnabled(!syncScrollEnabled)} title={syncScrollEnabled ? t('document.scrollSyncDisable') : t('document.scrollSyncEnable')} disabled={syncScrollDisabled} ariaPressed={syncScrollEnabled && !syncScrollDisabled} tooltipSide="right" className="h-9 w-9">
               {syncScrollEnabled && !syncScrollDisabled ? <Link2 size={14} /> : <Link2Off size={14} />}
             </IconButton>
-            <IconButton size="md" tone={highlightsEnabled ? 'accent' : 'default'} onClick={() => setHighlightsEnabled(!highlightsEnabled)} title={t('document.highlightsToggle')} ariaPressed={highlightsEnabled} tooltipSide="right">
+            <IconButton size="md" tone={highlightsEnabled ? 'accent' : 'default'} onClick={() => setHighlightsEnabled(!highlightsEnabled)} title={t('document.highlightsToggle')} ariaPressed={highlightsEnabled} tooltipSide="right" className="h-9 w-9">
               <Highlighter size={14} />
             </IconButton>
-            <IconButton size="md" onClick={() => setShowExportDialog(true)} title={`${t('header.exportLabel')} (Ctrl+E)`} ariaLabel={t('header.exportLabel')} tooltipSide="right">
+            <IconButton size="md" onClick={() => setShowExportDialog(true)} title={`${t('header.exportLabel')} (Ctrl+E)`} ariaLabel={t('header.exportLabel')} tooltipSide="right" className="h-9 w-9">
               <FileOutput size={14} />
             </IconButton>
           </>
         ) : null}
-        <IconButton size="md" onClick={onImportDocument} title={t('files.import')} disabled={!onImportDocument} tooltipSide="right">
+        <IconButton size="md" onClick={onImportDocument} title={t('files.import')} disabled={!onImportDocument} tooltipSide="right" className="h-9 w-9">
           <Upload size={14} />
         </IconButton>
-        <IconButton size="md" tone="muted" onClick={onOpenWorkspaceSettings} title={t('workspace.configure')} disabled={!onOpenWorkspaceSettings} tooltipSide="right">
+        <IconButton size="md" tone="muted" onClick={onOpenWorkspaceSettings} title={t('workspace.configure')} disabled={!onOpenWorkspaceSettings} tooltipSide="right" className="h-9 w-9">
           <Settings2 size={14} />
         </IconButton>
         <PipelineSidebarExportDialogHost open={showExportDialog} onOpenChange={setShowExportDialog} />

--- a/src/components/layout/PipelineSidebarSections.tsx
+++ b/src/components/layout/PipelineSidebarSections.tsx
@@ -226,7 +226,7 @@ export function PipelineSidebarRunSection({
             <Zap size={14} className="text-editorial-accent" aria-hidden="true" />
           )}
           <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-editorial-accent">
-            {pipelineMode === 'test' ? t('pipeline.modeTest') : t('pipeline.modeProduction')}
+            {pipelineMode === 'test' ? t('pipeline.modeTest') : t('pipeline.modeProductionShort')}
           </span>
         </div>
         {isProcessing ? (
@@ -295,9 +295,6 @@ export function PipelineSidebarRunSection({
                 <Zap size={14} />
               </IconButton>
             </div>
-            <span className="font-display text-sm italic text-editorial-accent">
-              {pipelineMode === 'test' ? t('pipeline.modeTest') : t('pipeline.modeProduction')}
-            </span>
           </div>
 
           <div className="flex flex-col items-center gap-2.5">

--- a/src/components/layout/PipelineSidebarSections.tsx
+++ b/src/components/layout/PipelineSidebarSections.tsx
@@ -219,6 +219,7 @@ export function PipelineSidebarRunSection({
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 px-1">
+        <FlaskConical size={13} className="text-editorial-muted/70" aria-hidden="true" />
         {isProcessing ? (
           cancelRequested ? (
             <IconButton size="lg" tone="muted" disabled title={t('pipeline.stopping')} tooltipSide="right" className="h-11 w-11 bg-editorial-bg opacity-50">
@@ -472,6 +473,7 @@ export function PipelineSidebarPipelinesSection({ collapsed = false }: { collaps
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 px-1">
+        <Zap size={13} className="text-editorial-muted/70" aria-hidden="true" />
         {pipelines.length === 0 ? (
           <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-editorial-accent text-xs font-black text-white opacity-55">1</span>
         ) : (
@@ -656,6 +658,7 @@ export function PipelineSidebarDocumentSection({
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 px-1">
+        <Columns2 size={13} className="text-editorial-muted/70" aria-hidden="true" />
         {hasDocument ? (
           <>
             <IconButton size="md" tone={documentPaneFocus === 'both' ? 'accent' : 'default'} onClick={() => setDocumentPaneFocus('both')} title={t('document.focusBoth')} ariaPressed={documentPaneFocus === 'both'} tooltipSide="right">

--- a/src/components/layout/ProjectFlyout.tsx
+++ b/src/components/layout/ProjectFlyout.tsx
@@ -1,0 +1,68 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import { useUiStore } from '../../stores/uiStore';
+import { ChunkInspectorPanel, InsightDocPanel } from '../document';
+import { ResizeHandle, useEdgeResize } from './useEdgeResize';
+
+const FLYOUT_MIN = 300;
+const FLYOUT_MAX = 620;
+const FLYOUT_DISMISS_AT = 260;
+
+interface ProjectFlyoutProps {
+  onReauditChunk: (chunkId: string) => void;
+  onRunCoherenceAudit: () => void;
+}
+
+/**
+ * Seconda barra del progetto: esce dal bordo destro della barra primaria
+ * solo per i pannelli ricchi (Insight, Chunk). Spinge il documento, niente overlay.
+ * Ridimensionabile dal bordo destro; sotto soglia scompare (non collassa a icona).
+ */
+export function ProjectFlyout({ onReauditChunk, onRunCoherenceAudit }: ProjectFlyoutProps) {
+  const { t } = useTranslation();
+  const showDocumentDrawer = useUiStore((state) => state.showDocumentDrawer);
+  const showChunkDrawer = useUiStore((state) => state.showChunkDrawer);
+  const width = useUiStore((state) => state.projectFlyoutWidth);
+  const setWidth = useUiStore((state) => state.setProjectFlyoutWidth);
+  const setActiveProjectPanel = useUiStore((state) => state.setActiveProjectPanel);
+  const { dragging, startDrag } = useEdgeResize();
+
+  const open = showDocumentDrawer || showChunkDrawer;
+  const close = () => setActiveProjectPanel('document');
+
+  const handleResizeStart = (event: React.PointerEvent) => {
+    startDrag(event, {
+      startWidth: width,
+      min: FLYOUT_MIN,
+      max: FLYOUT_MAX,
+      threshold: FLYOUT_DISMISS_AT,
+      mode: 'dismiss',
+      onWidth: setWidth,
+      onDismiss: close,
+    });
+  };
+
+  return (
+    <AnimatePresence initial={false}>
+      {open ? (
+        <motion.aside
+          key="project-flyout"
+          initial={{ width: 0, opacity: 0 }}
+          animate={{ width, opacity: 1 }}
+          exit={{ width: 0, opacity: 0 }}
+          transition={dragging ? { duration: 0 } : { type: 'spring', damping: 30, stiffness: 280 }}
+          className="relative flex h-full shrink-0 overflow-hidden border-r border-editorial-border bg-editorial-bg/95"
+        >
+          <div className="flex h-full flex-col overflow-hidden" style={{ width }}>
+            {showChunkDrawer ? (
+              <ChunkInspectorPanel onReauditChunk={onReauditChunk} onClose={close} />
+            ) : (
+              <InsightDocPanel onRunCoherenceAudit={onRunCoherenceAudit} onClose={close} />
+            )}
+          </div>
+          <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizePanel')} />
+        </motion.aside>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react';
-import type { LucideIcon } from 'lucide-react';
-import { SectionLabel, Tooltip } from '../ui';
+import { HelpCircle, Settings, type LucideIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUiStore } from '../../stores/uiStore';
+import { IconButton, SectionLabel, Tooltip } from '../ui';
 
 /**
  * Multibar shell — superfici di navigazione laterali (home e progetto).
@@ -33,6 +35,41 @@ export function ShellNavSection({ icon: Icon, label, action, collapsed = false, 
         </div>
       )}
       <div className="space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+/** Footer barra: azioni app-level (impostazioni, aiuto) ancorate in basso. */
+export function ShellNavFooter({ collapsed = false }: { collapsed?: boolean }) {
+  const { t } = useTranslation();
+  const setShowSettings = useUiStore((state) => state.setShowSettings);
+  const setShowHelp = useUiStore((state) => state.setShowHelp);
+
+  return (
+    <div
+      className={`mt-auto flex border-t border-editorial-border/50 ${
+        collapsed ? 'flex-col items-center gap-1.5 py-2.5' : 'items-center gap-1 px-3 py-2.5'
+      }`}
+    >
+      <IconButton
+        size="md"
+        tone="muted"
+        onClick={() => setShowSettings(true)}
+        title={t('header.settings')}
+        tooltipSide="right"
+      >
+        <Settings size={15} />
+      </IconButton>
+      <IconButton
+        size="md"
+        tone="muted"
+        onClick={() => setShowHelp(true)}
+        title={`${t('help.title')} (Ctrl+H)`}
+        ariaLabel={t('help.title')}
+        tooltipSide="right"
+      >
+        <HelpCircle size={15} />
+      </IconButton>
     </div>
   );
 }

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { SectionLabel } from '../ui';
+import { SectionLabel, Tooltip } from '../ui';
 
 /**
  * Multibar shell — superfici di navigazione laterali (home e progetto).
@@ -26,8 +26,10 @@ export function ShellNavSection({ icon: Icon, label, action, collapsed = false, 
         </div>
       ) : (
         // Da collassata resta l'icona della sezione (header stabile): niente salto verticale.
-        <div className="flex justify-center pb-1.5 pt-3" title={label}>
-          <Icon size={13} className="text-editorial-muted/70" aria-hidden="true" />
+        <div className="flex justify-center pb-1.5 pt-3">
+          <Tooltip label={label} side="right">
+            <Icon size={13} className="text-editorial-muted/70" aria-hidden="true" />
+          </Tooltip>
         </div>
       )}
       <div className="space-y-0.5">{children}</div>
@@ -76,6 +78,32 @@ export function ShellNavItem({
       ? 'text-editorial-muted opacity-50'
       : 'text-editorial-muted hover:bg-editorial-textbox/30 hover:text-editorial-accent';
 
+  const button = (
+    <button
+      type="button"
+      id={id}
+      onClick={onClick}
+      disabled={disabled}
+      aria-current={ariaCurrent}
+      role={role}
+      aria-selected={role === 'tab' ? ariaSelected : undefined}
+      aria-controls={ariaControls}
+      className={`flex min-w-0 flex-1 items-center gap-2.5 rounded-[12px] py-2 text-left text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+        collapsed ? 'justify-center px-0' : 'px-2.5'
+      } ${disabled ? 'cursor-not-allowed' : ''}`}
+    >
+      <span className="inline-flex shrink-0 items-center justify-center">{icon}</span>
+      {collapsed ? (
+        <span className="sr-only">{hint ? `${label} ${hint}` : label}</span>
+      ) : (
+        <span className="min-w-0 flex-1">
+          <span className={`block truncate ${labelClassName}`}>{label}</span>
+          {hint ? <span className="mt-0.5 block truncate text-[11px] text-editorial-muted">{hint}</span> : null}
+        </span>
+      )}
+    </button>
+  );
+
   return (
     <div className={`group relative flex w-full items-center rounded-[12px] transition-colors duration-150 ${toneClassName}`}>
       {active && !collapsed ? (
@@ -84,30 +112,13 @@ export function ShellNavItem({
           className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-editorial-accent"
         />
       ) : null}
-      <button
-        type="button"
-        id={id}
-        onClick={onClick}
-        disabled={disabled}
-        aria-current={ariaCurrent}
-        role={role}
-        aria-selected={role === 'tab' ? ariaSelected : undefined}
-        aria-controls={ariaControls}
-        title={collapsed ? label : undefined}
-        className={`flex min-w-0 flex-1 items-center gap-2.5 rounded-[12px] py-2 text-left text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
-          collapsed ? 'justify-center px-0' : 'px-2.5'
-        } ${disabled ? 'cursor-not-allowed' : ''}`}
-      >
-        <span className="inline-flex shrink-0 items-center justify-center">{icon}</span>
-        {collapsed ? (
-          <span className="sr-only">{hint ? `${label} ${hint}` : label}</span>
-        ) : (
-          <span className="min-w-0 flex-1">
-            <span className={`block truncate ${labelClassName}`}>{label}</span>
-            {hint ? <span className="mt-0.5 block truncate text-[11px] text-editorial-muted">{hint}</span> : null}
-          </span>
-        )}
-      </button>
+      {collapsed ? (
+        <Tooltip label={hint ? `${label} — ${hint}` : label} side="right" className="w-full">
+          {button}
+        </Tooltip>
+      ) : (
+        button
+      )}
       {!collapsed && trailing ? (
         <div className="flex shrink-0 items-center gap-0.5 pr-1.5">{trailing}</div>
       ) : null}

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { SectionLabel } from '../ui';
+
+/**
+ * Multibar shell — superfici di navigazione laterali (home e progetto).
+ * Item attivo: barra accent verticale + tint leggero + testo accent.
+ * Niente linguetta flottante: la selezione resta contenuta nella colonna.
+ */
+
+interface ShellNavSectionProps {
+  icon: LucideIcon;
+  label: string;
+  action?: ReactNode;
+  collapsed?: boolean;
+  children: ReactNode;
+}
+
+export function ShellNavSection({ icon, label, action, collapsed = false, children }: ShellNavSectionProps) {
+  return (
+    <div className="px-2.5">
+      {!collapsed ? (
+        <div className="flex items-center justify-between gap-2 px-1.5 pb-1.5 pt-3">
+          <SectionLabel icon={icon} label={label} />
+          {action}
+        </div>
+      ) : (
+        <div className="pt-3" />
+      )}
+      <div className="space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+interface ShellNavItemProps {
+  icon: ReactNode;
+  label: string;
+  hint?: string;
+  labelFont?: 'sans' | 'display';
+  active: boolean;
+  disabled?: boolean;
+  collapsed?: boolean;
+  onClick?: () => void;
+  ariaCurrent?: 'page';
+  role?: 'tab';
+  ariaSelected?: boolean;
+  ariaControls?: string;
+  id?: string;
+  trailing?: ReactNode;
+}
+
+export function ShellNavItem({
+  icon,
+  label,
+  hint,
+  labelFont = 'sans',
+  active,
+  disabled = false,
+  collapsed = false,
+  onClick,
+  ariaCurrent,
+  role,
+  ariaSelected,
+  ariaControls,
+  id,
+  trailing,
+}: ShellNavItemProps) {
+  const labelClassName = labelFont === 'display' ? 'font-display text-sm italic' : 'font-sans text-sm';
+
+  const toneClassName = active
+    ? 'bg-editorial-accent/10 text-editorial-accent'
+    : disabled
+      ? 'text-editorial-muted opacity-50'
+      : 'text-editorial-muted hover:bg-editorial-textbox/30 hover:text-editorial-accent';
+
+  return (
+    <div className={`group relative flex w-full items-center rounded-[12px] transition-colors duration-150 ${toneClassName}`}>
+      {active && !collapsed ? (
+        <span
+          aria-hidden="true"
+          className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-editorial-accent"
+        />
+      ) : null}
+      <button
+        type="button"
+        id={id}
+        onClick={onClick}
+        disabled={disabled}
+        aria-current={ariaCurrent}
+        role={role}
+        aria-selected={role === 'tab' ? ariaSelected : undefined}
+        aria-controls={ariaControls}
+        title={collapsed ? label : undefined}
+        className={`flex min-w-0 flex-1 items-center gap-2.5 rounded-[12px] py-2 text-left text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+          collapsed ? 'justify-center px-0' : 'px-2.5'
+        } ${disabled ? 'cursor-not-allowed' : ''}`}
+      >
+        <span className="inline-flex shrink-0 items-center justify-center">{icon}</span>
+        {collapsed ? (
+          <span className="sr-only">{hint ? `${label} ${hint}` : label}</span>
+        ) : (
+          <span className="min-w-0 flex-1">
+            <span className={`block truncate ${labelClassName}`}>{label}</span>
+            {hint ? <span className="mt-0.5 block truncate text-[11px] text-editorial-muted">{hint}</span> : null}
+          </span>
+        )}
+      </button>
+      {!collapsed && trailing ? (
+        <div className="flex shrink-0 items-center gap-0.5 pr-1.5">{trailing}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -16,16 +16,19 @@ interface ShellNavSectionProps {
   children: ReactNode;
 }
 
-export function ShellNavSection({ icon, label, action, collapsed = false, children }: ShellNavSectionProps) {
+export function ShellNavSection({ icon: Icon, label, action, collapsed = false, children }: ShellNavSectionProps) {
   return (
     <div className="px-2.5">
       {!collapsed ? (
         <div className="flex items-center justify-between gap-2 px-1.5 pb-1.5 pt-3">
-          <SectionLabel icon={icon} label={label} />
+          <SectionLabel icon={Icon} label={label} />
           {action}
         </div>
       ) : (
-        <div className="pt-3" />
+        // Da collassata resta l'icona della sezione (header stabile): niente salto verticale.
+        <div className="flex justify-center pb-1.5 pt-3" title={label}>
+          <Icon size={13} className="text-editorial-muted/70" aria-hidden="true" />
+        </div>
       )}
       <div className="space-y-0.5">{children}</div>
     </div>

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 export { Header } from './Header';
 export { PipelineSidebar } from './PipelineSidebar';
+export { ProjectFlyout } from './ProjectFlyout';

--- a/src/components/layout/useEdgeResize.tsx
+++ b/src/components/layout/useEdgeResize.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type ResizeMode = 'collapse' | 'dismiss';
+
+interface DragConfig {
+  startWidth: number;
+  min: number;
+  max: number;
+  /** Sotto questa larghezza: collassa (mode 'collapse') o scompare al rilascio (mode 'dismiss'). */
+  threshold: number;
+  mode: ResizeMode;
+  onWidth: (width: number) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
+  onDismiss?: () => void;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+/**
+ * Resize a trascinamento sul bordo destro di una colonna ancorata a sinistra.
+ * - mode 'collapse': sotto soglia collassa a icone in tempo reale (reversibile nel drag).
+ * - mode 'dismiss': sotto soglia il pannello scompare al rilascio.
+ */
+export function useEdgeResize() {
+  const [dragging, setDragging] = useState(false);
+  const configRef = useRef<DragConfig | null>(null);
+  const startXRef = useRef(0);
+  const willDismissRef = useRef(false);
+
+  const stopDrag = useCallback(() => {
+    const config = configRef.current;
+    if (config?.mode === 'dismiss' && willDismissRef.current) {
+      config.onDismiss?.();
+    }
+    configRef.current = null;
+    willDismissRef.current = false;
+    setDragging(false);
+  }, []);
+
+  const onPointerMove = useCallback((event: PointerEvent) => {
+    const config = configRef.current;
+    if (!config) return;
+    const next = config.startWidth + (event.clientX - startXRef.current);
+
+    if (config.mode === 'collapse') {
+      if (next < config.threshold) {
+        config.onCollapsedChange?.(true);
+      } else {
+        config.onCollapsedChange?.(false);
+        config.onWidth(clamp(next, config.min, config.max));
+      }
+      return;
+    }
+
+    // dismiss
+    willDismissRef.current = next < config.threshold;
+    config.onWidth(clamp(next, config.min, config.max));
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', stopDrag);
+    window.addEventListener('pointercancel', stopDrag);
+    const previousCursor = document.body.style.cursor;
+    document.body.style.cursor = 'col-resize';
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', stopDrag);
+      window.removeEventListener('pointercancel', stopDrag);
+      document.body.style.cursor = previousCursor;
+    };
+  }, [dragging, onPointerMove, stopDrag]);
+
+  const startDrag = useCallback((event: React.PointerEvent, config: DragConfig) => {
+    event.preventDefault();
+    configRef.current = config;
+    startXRef.current = event.clientX;
+    willDismissRef.current = false;
+    setDragging(true);
+  }, []);
+
+  return { dragging, startDrag };
+}
+
+interface ResizeHandleProps {
+  onPointerDown: (event: React.PointerEvent) => void;
+  dragging: boolean;
+  label: string;
+}
+
+export function ResizeHandle({ onPointerDown, dragging, label }: ResizeHandleProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      onPointerDown={onPointerDown}
+      className={`absolute inset-y-0 right-0 z-30 w-1.5 cursor-col-resize touch-none select-none transition-colors ${
+        dragging ? 'bg-editorial-accent/40' : 'hover:bg-editorial-accent/25'
+      }`}
+    />
+  );
+}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -10,7 +10,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useUiStore } from '../../stores/uiStore';
-import type { UiFont } from '../../stores/uiStore';
+import type { SettingsTab, UiFont } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
 import { ApiKeyInput } from './ApiKeyInput';
 import { ollamaService } from '../../services/llmService';
@@ -31,8 +31,6 @@ const PROVIDER_LABELS: Record<ModelProvider, string> = {
   deepseek: 'DeepSeek',
   ollama: 'Ollama',
 };
-
-type SettingsTab = 'translations' | 'provider';
 
 function getModelGroupLabel(provider: ModelProvider, modelId: string): string {
   switch (provider) {
@@ -164,6 +162,8 @@ export function SettingsModal() {
     setHighlightColor,
     uiFont,
     setUiFont,
+    settingsTab: activeTab,
+    setSettingsTab: setActiveTab,
   } = useUiStore();
   const {
     ollamaStatus,
@@ -186,7 +186,6 @@ export function SettingsModal() {
   const [showPricingOverrides, setShowPricingOverrides] = useState(false);
   const [showSecurityAdvisory, setShowSecurityAdvisory] = useState(false);
   const [activeProviderTab, setActiveProviderTab] = useState<ModelProvider>('openai');
-  const [activeTab, setActiveTab] = useState<SettingsTab>('translations');
   const [urlDraft, setUrlDraft] = useState(ollamaBaseUrl);
   const [urlError, setUrlError] = useState<string | null>(null);
   const trapRef = useFocusTrap(showSettings, () => setShowSettings(false));

--- a/src/components/workspace/WorkspaceHome.test.tsx
+++ b/src/components/workspace/WorkspaceHome.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProjectStore } from '../../stores/projectStore';
+import { useUiStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { WorkspaceHome } from './WorkspaceHome';
+
+vi.mock('../../hooks/useProviderKeyStatus', () => ({
+  useProviderKeyStatus: () => ({
+    statuses: {
+      gemini: false,
+      openai: false,
+      anthropic: false,
+      deepseek: false,
+    },
+    isLoading: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+const initialUiState = useUiStore.getState();
+const originalProjectState = useProjectStore.getState();
+const originalWorkspaceState = useWorkspaceStore.getState();
+
+describe('WorkspaceHome provider onboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState(initialUiState, true);
+    useProjectStore.setState({
+      ...originalProjectState,
+      projects: [],
+      loadProjects: vi.fn().mockResolvedValue(undefined),
+      createAndOpen: vi.fn().mockResolvedValue(undefined),
+      openProject: vi.fn().mockResolvedValue(undefined),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+    });
+    useWorkspaceStore.setState({
+      ...originalWorkspaceState,
+      activeWorkspace: {
+        id: 'workspace-1',
+        name: 'Editorial',
+        description: undefined,
+        embeddingModel: 'text-embedding-3-small',
+        memoryExtractorProvider: 'openai',
+        memoryExtractorModel: 'gpt-5-nano',
+        memoryExtractorPrompt: '',
+        createdAt: '2026-01-01T10:00:00.000Z',
+      },
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'Editorial',
+          description: undefined,
+          embeddingModel: 'text-embedding-3-small',
+          memoryExtractorProvider: 'openai',
+          memoryExtractorModel: 'gpt-5-nano',
+          memoryExtractorPrompt: '',
+          createdAt: '2026-01-01T10:00:00.000Z',
+        },
+      ],
+      removeWorkspace: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('opens Settings on the provider tab from the onboarding banner', () => {
+    render(<WorkspaceHome />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'workspace.providerBannerCta' }));
+
+    const state = useUiStore.getState();
+    expect(state.showSettings).toBe(true);
+    expect(state.settingsTab).toBe('provider');
+  });
+});

--- a/src/components/workspace/WorkspaceHome.tsx
+++ b/src/components/workspace/WorkspaceHome.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import {
   BookOpenText,
   Database,
+  KeyRound,
   Plus,
-  Settings2,
   Trash2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
@@ -11,15 +11,18 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useProjectStore } from '../../stores/projectStore';
 import { confirm } from '../../stores/confirmStore';
+import { useUiStore } from '../../stores/uiStore';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useProviderKeyStatus } from '../../hooks/useProviderKeyStatus';
 import { EditorialModalShell } from '../common';
 import { IconButton, PillButton, SectionLabel } from '../ui';
-import { WorkspaceSettingsModal } from './WorkspaceSettingsModal';
 
 export function WorkspaceHome() {
   const { t, i18n } = useTranslation();
-  const { activeWorkspace, workspaces, removeWorkspace } = useWorkspaceStore();
+  const { activeWorkspace } = useWorkspaceStore();
+  const setShowSettings = useUiStore((state) => state.setShowSettings);
+  const { statuses: keyStatuses, isLoading: keyStatusLoading } = useProviderKeyStatus();
   const {
     projects,
     loadProjects,
@@ -28,7 +31,6 @@ export function WorkspaceHome() {
     removeProject,
   } = useProjectStore();
 
-  const [showWorkspaceSettings, setShowWorkspaceSettings] = useState(false);
   const [showNewProjectForm, setShowNewProjectForm] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
   const [creatingProject, setCreatingProject] = useState(false);
@@ -62,6 +64,8 @@ export function WorkspaceHome() {
       year: 'numeric',
     }).format(new Date(activeWorkspace.createdAt));
   }, [activeWorkspace?.createdAt, i18n.language]);
+  const hasRemoteProvider = Object.values(keyStatuses).some(Boolean);
+  const shouldShowProviderBanner = !keyStatusLoading && !hasRemoteProvider;
 
   const handleCreateProject = async () => {
     if (!newProjectName.trim()) return;
@@ -109,37 +113,6 @@ export function WorkspaceHome() {
     }
   };
 
-  const handleDeleteWorkspace = async () => {
-    if (!activeWorkspace) return;
-
-    if (projects.length > 0) {
-      await confirm({
-        title: t('workspace.deleteBlockedTitle'),
-        message: t('workspace.deleteBlockedMessage', { count: projects.length }),
-        confirmLabel: t('common.confirm'),
-        danger: true,
-      });
-      return;
-    }
-
-    const ok = await confirm({
-      title: t('workspace.deleteTitle'),
-      message: t('workspace.deleteMessage', { name: activeWorkspace.name }),
-      confirmLabel: t('common.delete'),
-      danger: true,
-    });
-    if (!ok) return;
-
-    try {
-      await removeWorkspace(activeWorkspace.id);
-      toast.success(t('workspace.deleted'));
-    } catch (err: unknown) {
-      toast.error(t('workspace.deleteFailed'), {
-        description: err instanceof Error ? err.message : String(err),
-      });
-    }
-  };
-
   return (
     <main className="flex flex-1 h-full min-h-0 flex-col overflow-y-auto bg-editorial-paper custom-scrollbar">
       <div className="grid w-full flex-1 min-h-0 gap-0 xl:grid-cols-[minmax(0,1fr)_22rem]">
@@ -147,7 +120,7 @@ export function WorkspaceHome() {
           <section className="min-w-0">
             <div className="flex flex-col gap-4">
               <div className="min-w-0">
-                <h1 className="font-display text-4xl italic tracking-tight text-editorial-ink md:text-5xl">
+                <h1 className="font-display text-4xl italic text-editorial-ink md:text-5xl">
                   {activeWorkspace?.name ?? t('workspace.noActive')}
                 </h1>
                 {activeWorkspace?.description ? (
@@ -166,26 +139,36 @@ export function WorkspaceHome() {
                 >
                   <Plus size={14} />
                 </IconButton>
-                <IconButton
-                  size="md"
-                  onClick={() => setShowWorkspaceSettings(true)}
-                  title={t('workspace.configure')}
-                  disabled={!activeWorkspace}
-                >
-                  <Settings2 size={14} />
-                </IconButton>
-                <IconButton
-                  size="md"
-                  tone="muted"
-                  onClick={() => void handleDeleteWorkspace()}
-                  title={t('workspace.delete')}
-                  disabled={!activeWorkspace}
-                >
-                  <Trash2 size={14} />
-                </IconButton>
               </div>
             </div>
           </section>
+
+          {shouldShowProviderBanner ? (
+            <section className="mt-5 rounded-[20px] border border-editorial-accent/35 bg-editorial-accent/8 px-5 py-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex min-w-0 items-start gap-3">
+                  <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-editorial-accent/35 bg-editorial-paper text-editorial-accent">
+                    <KeyRound size={15} />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="font-display text-xl italic text-editorial-ink">
+                      {t('workspace.providerBannerTitle')}
+                    </p>
+                    <p className="mt-1 max-w-2xl text-sm leading-relaxed text-editorial-muted [text-wrap:pretty]">
+                      {t('workspace.providerBannerBody')}
+                    </p>
+                  </div>
+                </div>
+                <PillButton
+                  variant="accent"
+                  onClick={() => setShowSettings(true, 'provider')}
+                  className="shrink-0"
+                >
+                  {t('workspace.providerBannerCta')}
+                </PillButton>
+              </div>
+            </section>
+          ) : null}
 
           <section className="mt-5 min-h-0">
             {projects.length === 0 ? (
@@ -285,7 +268,6 @@ export function WorkspaceHome() {
           <SectionLabel icon={Database} label={t('workspace.technicalSummary')} />
           <dl className="mt-4 space-y-3">
             <TechRow label={t('workspace.projectsMetric')} value={String(projects.length)} />
-            <TechRow label={t('workspace.workspacesMetric')} value={String(workspaces.length)} />
             <TechRow label={t('workspace.pipelineMetric')} value={String(projects.reduce((total, project) => total + (project.pipeline_count ?? 0), 0))} />
             <TechRow label={t('workspace.embeddingModel')} value={activeWorkspace?.embeddingModel ?? '—'} />
             <TechRow label={t('workspace.createdAt')} value={createdLabel} />
@@ -294,10 +276,6 @@ export function WorkspaceHome() {
         </aside>
       </div>
 
-      <WorkspaceSettingsModal
-        open={showWorkspaceSettings}
-        onClose={() => setShowWorkspaceSettings(false)}
-      />
       <AnimatePresence>
         {showNewProjectForm ? (
           <div
@@ -361,7 +339,7 @@ export function WorkspaceHome() {
                     {t('workspace.emptyProjectsBody')}
                   </p>
                   <label className="block space-y-1.5">
-                    <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-muted">
+                    <span className="text-[11px] font-bold uppercase tracking-[0.1em] text-editorial-muted">
                       {t('workspace.newBookCard')}
                     </span>
                     <input
@@ -391,8 +369,8 @@ export function WorkspaceHome() {
 
 function TechRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-start justify-between gap-4 border-b border-editorial-border/45 pb-2.5 last:border-b-0 last:pb-0">
-      <dt className="text-[10px] font-bold uppercase tracking-[0.24em] text-editorial-muted">
+    <div className="flex items-baseline justify-between gap-4 border-b border-editorial-border/45 pb-2.5 last:border-b-0 last:pb-0">
+      <dt className="text-[11px] font-bold uppercase tracking-[0.1em] text-editorial-muted">
         {label}
       </dt>
       <dd className="max-w-[12rem] truncate text-right font-mono text-xs text-editorial-ink">

--- a/src/components/workspace/WorkspaceWizard.test.tsx
+++ b/src/components/workspace/WorkspaceWizard.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { WorkspaceWizard } from './WorkspaceWizard';
+
+const originalCreateAndActivate = useWorkspaceStore.getState().createAndActivate;
+
+describe('WorkspaceWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceStore.setState({
+      createAndActivate: originalCreateAndActivate,
+    });
+  });
+
+  it('uses localized copy and does not ask for an embedding model', () => {
+    render(<WorkspaceWizard />);
+
+    expect(screen.getByText('workspace.wizardTitle')).toBeInTheDocument();
+    expect(screen.getByText('workspace.wizardBody')).toBeInTheDocument();
+    expect(screen.queryByText('workspace.embeddingModel')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('creates the workspace with the default embedding model', async () => {
+    const createAndActivate = vi.fn().mockResolvedValue(undefined);
+    useWorkspaceStore.setState({ createAndActivate });
+
+    render(<WorkspaceWizard />);
+
+    fireEvent.change(screen.getByPlaceholderText('workspace.namePlaceholder'), {
+      target: { value: 'Editorial' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'workspace.createFirst' }));
+
+    await waitFor(() => {
+      expect(createAndActivate).toHaveBeenCalledWith({
+        name: 'Editorial',
+        description: undefined,
+        embeddingModel: 'text-embedding-3-small',
+      });
+    });
+  });
+});

--- a/src/components/workspace/WorkspaceWizard.tsx
+++ b/src/components/workspace/WorkspaceWizard.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
-import type { EmbeddingModel } from '../../types';
 
 export function WorkspaceWizard() {
+  const { t } = useTranslation();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [model, setModel] = useState<EmbeddingModel>('text-embedding-3-small');
   const [loading, setLoading] = useState(false);
   const createAndActivate = useWorkspaceStore((s) => s.createAndActivate);
 
@@ -16,7 +16,7 @@ export function WorkspaceWizard() {
       await createAndActivate({
         name: name.trim(),
         description: description.trim() || undefined,
-        embeddingModel: model,
+        embeddingModel: 'text-embedding-3-small',
       });
     } finally {
       setLoading(false);
@@ -30,49 +30,28 @@ export function WorkspaceWizard() {
     <div className="flex min-h-dvh min-h-[var(--app-min-height)] min-w-[var(--app-min-width)] flex-col items-center justify-center gap-6 p-8">
       <div className="flex flex-col items-center gap-2">
         <h1 className="text-2xl font-semibold text-editorial-ink">
-          Crea il tuo primo workspace
+          {t('workspace.wizardTitle')}
         </h1>
         <p className="max-w-md text-center text-sm text-editorial-muted">
-          Un workspace raggruppa i tuoi libri e condivide la phrase memory tra di essi.
+          {t('workspace.wizardBody')}
         </p>
       </div>
 
       <div className="flex w-full max-w-sm flex-col gap-4">
         <input
           className={inputClass}
-          placeholder="Nome workspace"
+          placeholder={t('workspace.namePlaceholder')}
           value={name}
           onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
           autoFocus
         />
         <input
           className={inputClass}
-          placeholder="Descrizione (opzionale)"
+          placeholder={t('workspace.descriptionPlaceholder')}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-
-        <div className="flex flex-col gap-1">
-          <label className="px-1 text-xs text-editorial-muted">Modello di embedding</label>
-          <select
-            className={inputClass}
-            value={model}
-            onChange={(e) => setModel(e.target.value as EmbeddingModel)}
-          >
-            <option value="text-embedding-3-small">
-              text-embedding-3-small — testi nella stessa lingua
-            </option>
-            <option value="text-embedding-3-large">
-              text-embedding-3-large — lingue diverse (es. italiano antico → inglese)
-            </option>
-          </select>
-          {model === 'text-embedding-3-small' && (
-            <p className="px-1 text-xs text-editorial-accent">
-              Per tradurre tra lingue diverse usa text-embedding-3-large per risultati migliori.
-            </p>
-          )}
-        </div>
 
         <button
           type="button"
@@ -80,7 +59,7 @@ export function WorkspaceWizard() {
           onClick={handleCreate}
           disabled={!name.trim() || loading}
         >
-          {loading ? 'Creazione...' : 'Crea workspace'}
+          {loading ? t('workspace.saving') : t('workspace.createFirst')}
         </button>
       </div>
     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -39,8 +39,6 @@
     "areaLabel": "Area",
     "workspaceSection": "Workspace",
     "backToWorkspace": "Back to workspace",
-    "collapseAreas": "Collapse areas",
-    "expandAreas": "Expand areas",
     "resize": "Resize sidebar"
   },
   "projectShell": {
@@ -50,8 +48,6 @@
     "documentTab": "Document",
     "insightTab": "Insight",
     "chunkTab": "Chunk",
-    "collapseContext": "Collapse project panel",
-    "expandContext": "Expand project panel",
     "resizeRail": "Resize sidebar",
     "resizePanel": "Resize panel",
     "noDocumentHint": "Import a source document to unlock reader controls, export, and synchronized panes.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -822,6 +822,7 @@
     "searchInSource": "Search source",
     "searchInTranslation": "Search candidate",
     "clearPaneSearch": "Clear search",
+    "searchInPane": "Search this text",
     "searchEmptyTitle": "Document search",
     "searchEmptyBody": "Type a word or phrase to search across all chunks — source text, translation, and audit findings.",
     "searchNoResults": "No results found.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -186,6 +186,7 @@
     "resetPreviewDone": "Preview cleared",
     "modeTest": "Test",
     "modeProduction": "Production",
+    "modeProductionShort": "Prod",
     "modeTestHint": "Runs the pipeline on one chunk and produces a preview. Configuration stays editable.",
     "modeProductionHint": "Runs the pipeline on the entire document.",
     "modeLockedHint": "Mode locked — real translations exist. Use Full Reset to start over.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -38,7 +38,24 @@
   "sidebar": {
     "areaLabel": "Area",
     "workspaceSection": "Workspace",
-    "backToWorkspace": "Back to workspace"
+    "backToWorkspace": "Back to workspace",
+    "collapseAreas": "Collapse areas",
+    "expandAreas": "Expand areas",
+    "resize": "Resize sidebar"
+  },
+  "projectShell": {
+    "railLabel": "Project panels",
+    "runTab": "Run",
+    "pipelineTab": "Pipeline",
+    "documentTab": "Document",
+    "insightTab": "Insight",
+    "chunkTab": "Chunk",
+    "collapseContext": "Collapse project panel",
+    "expandContext": "Expand project panel",
+    "resizeRail": "Resize sidebar",
+    "resizePanel": "Resize panel",
+    "noDocumentHint": "Import a source document to unlock reader controls, export, and synchronized panes.",
+    "insightHint": "Open the insights drawer and jump directly to document index, search, stats, coherence, or glossary."
   },
   "a11y": {
     "runStarted": "Pipeline run started.",
@@ -569,6 +586,12 @@
     "activeLabel": "Translation workspace",
     "noActive": "No active workspace",
     "translationBoundary": "This workspace contains translation projects and shared phrase memory. Library and transcription will remain separate areas in Glossa 2.0.",
+    "wizardTitle": "Create your first workspace",
+    "wizardBody": "A workspace groups your books and shares phrase memory across them.",
+    "createFirst": "Create workspace",
+    "providerBannerTitle": "Configure a provider before the first run",
+    "providerBannerBody": "Remote model runs need at least one API key. Ollama remains available locally, but OpenAI, Gemini, Anthropic, and DeepSeek require their keys in Settings.",
+    "providerBannerCta": "Open Provider Settings",
     "configure": "Configure workspace",
     "create": "New workspace",
     "delete": "Delete workspace",
@@ -918,7 +941,8 @@
       "step4": "The AI Judge evaluates each chunk; optionally, a coherence audit reviews the whole document.",
       "step5": "Review and correct the candidate translation in the workspace, then re-evaluate or lock the chunk.",
       "step6": "Export in .txt, .md, .html, .docx, or bilingual .md for publication or external review.",
-      "p3": "Provider and model are independent for every stage and for the judge: you can mix a fast model for translation with a stronger one for refine or audit, or stay fully local with Ollama."
+      "p3": "Provider and model are independent for every stage and for the judge: you can mix a fast model for translation with a stronger one for refine or audit, or stay fully local with Ollama.",
+      "nav": "Navigation: the breadcrumb at the top (Glossa // workspace // project) returns to home when you click the workspace. On the left there is a single bar: on the home it lists areas and workspaces (edit and delete of the active workspace live on its row); inside a project it holds Run, Pipeline, Document, Insight and Chunk. Run/Pipeline/Document open inside the bar; Insight, Chunk and the pipeline configuration open in a second panel alongside. Every bar resizes by dragging its right edge and collapses to icons."
     },
     "pipeline": {
       "title": "Translation pipeline",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -822,6 +822,7 @@
     "searchInSource": "Cerca nel sorgente",
     "searchInTranslation": "Cerca nella candidata",
     "clearPaneSearch": "Cancella ricerca",
+    "searchInPane": "Cerca nel testo",
     "searchEmptyTitle": "Ricerca nel documento",
     "searchEmptyBody": "Digita una parola o frase per cercare in tutti i chunk, sia nel testo originale che nella traduzione e nell'audit.",
     "searchNoResults": "Nessun risultato trovato.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -186,6 +186,7 @@
     "resetPreviewDone": "Anteprima azzerata",
     "modeTest": "Test",
     "modeProduction": "Produzione",
+    "modeProductionShort": "Prod",
     "modeTestHint": "Esegue la pipeline su un solo blocco e produce un'anteprima. La configurazione rimane modificabile.",
     "modeProductionHint": "Esegue la pipeline sull'intero documento.",
     "modeLockedHint": "Modalità bloccata — esistono già traduzioni. Usa Reset completo per ricominciare.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -38,7 +38,24 @@
   "sidebar": {
     "areaLabel": "Area",
     "workspaceSection": "Workspace",
-    "backToWorkspace": "Torna al workspace"
+    "backToWorkspace": "Torna al workspace",
+    "collapseAreas": "Comprimi aree",
+    "expandAreas": "Espandi aree",
+    "resize": "Ridimensiona la barra"
+  },
+  "projectShell": {
+    "railLabel": "Pannelli progetto",
+    "runTab": "Run",
+    "pipelineTab": "Pipeline",
+    "documentTab": "Documento",
+    "insightTab": "Insight",
+    "chunkTab": "Chunk",
+    "collapseContext": "Comprimi pannello progetto",
+    "expandContext": "Espandi pannello progetto",
+    "resizeRail": "Ridimensiona la barra",
+    "resizePanel": "Ridimensiona il pannello",
+    "noDocumentHint": "Importa un documento sorgente per abilitare controlli lettura, export e pannelli sincronizzati.",
+    "insightHint": "Apri il pannello insight e vai direttamente a indice, ricerca, statistiche, coerenza o glossario."
   },
   "a11y": {
     "runStarted": "Esecuzione della pipeline avviata.",
@@ -569,6 +586,12 @@
     "activeLabel": "Workspace traduzioni",
     "noActive": "Nessun workspace attivo",
     "translationBoundary": "Questo workspace contiene progetti di traduzione e phrase memory condivisa. Biblioteca e trascrizioni resteranno aree separate in Glossa 2.0.",
+    "wizardTitle": "Crea il tuo primo workspace",
+    "wizardBody": "Un workspace raggruppa i tuoi libri e condivide la phrase memory tra di essi.",
+    "createFirst": "Crea workspace",
+    "providerBannerTitle": "Configura un provider prima del primo run",
+    "providerBannerBody": "I run con modelli remoti richiedono almeno una API key. Ollama resta disponibile in locale, ma OpenAI, Gemini, Anthropic e DeepSeek richiedono le rispettive chiavi nelle Impostazioni.",
+    "providerBannerCta": "Apri Provider",
     "configure": "Configura workspace",
     "create": "Nuovo workspace",
     "delete": "Elimina workspace",
@@ -918,7 +941,8 @@
       "step4": "Il Giudice AI valuta ciascun chunk e — opzionalmente — un audit di coerenza analizza il documento intero.",
       "step5": "Rivedi e correggi la traduzione candidata nel workspace, poi rivaluta o blocca il chunk come definitivo.",
       "step6": "Esporti in .txt, .md, .html, .docx o .md bilingue per pubblicazione o revisione esterna.",
-      "p3": "Provider e modello sono indipendenti per ogni stage e per il giudice: puoi mescolare un modello veloce per la traduzione e uno più potente per refine o audit, oppure restare in locale con Ollama."
+      "p3": "Provider e modello sono indipendenti per ogni stage e per il giudice: puoi mescolare un modello veloce per la traduzione e uno più potente per refine o audit, oppure restare in locale con Ollama.",
+      "nav": "Navigazione: in alto il breadcrumb (Glossa // workspace // progetto) riporta alla home cliccando sul workspace. A sinistra c'è un'unica barra: nella home elenca aree e workspace (modifica ed elimina del workspace attivo sono sulla sua riga); nel progetto contiene Run, Pipeline, Documento, Insight e Chunk. Run/Pipeline/Documento si aprono dentro la barra; Insight, Chunk e la configurazione pipeline escono in un secondo pannello a fianco. Tutte le barre si ridimensionano trascinando il bordo destro e si riducono a sole icone."
     },
     "pipeline": {
       "title": "Pipeline di traduzione",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -39,8 +39,6 @@
     "areaLabel": "Area",
     "workspaceSection": "Workspace",
     "backToWorkspace": "Torna al workspace",
-    "collapseAreas": "Comprimi aree",
-    "expandAreas": "Espandi aree",
     "resize": "Ridimensiona la barra"
   },
   "projectShell": {
@@ -50,8 +48,6 @@
     "documentTab": "Documento",
     "insightTab": "Insight",
     "chunkTab": "Chunk",
-    "collapseContext": "Comprimi pannello progetto",
-    "expandContext": "Espandi pannello progetto",
     "resizeRail": "Ridimensiona la barra",
     "resizePanel": "Ridimensiona il pannello",
     "noDocumentHint": "Importa un documento sorgente per abilitare controlli lettura, export e pannelli sincronizzati.",

--- a/src/index.css
+++ b/src/index.css
@@ -345,15 +345,3 @@ a[data-footnote-backref] {
 .terminal-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: var(--color-terminal-secondary);
 }
-
-@layer components {
-  .dashboard-sidebar-tab-surface {
-    background: var(--color-editorial-paper);
-    border: 1px solid var(--color-editorial-border);
-    border-right: 0;
-    border-radius: 20px 0 0 20px;
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.55),
-      6px 10px 20px rgba(74, 50, 17, 0.04);
-  }
-}

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -66,6 +66,14 @@ describe('uiStore drawer mutual exclusion', () => {
     expect(state.showChunkDrawer).toBe(false);
   });
 
+  it('can open settings directly on the provider tab', () => {
+    useUiStore.getState().setShowSettings(true, 'provider');
+
+    const state = useUiStore.getState();
+    expect(state.showSettings).toBe(true);
+    expect(state.settingsTab).toBe('provider');
+  });
+
   it('closing a drawer does not toggle other panels', () => {
     useUiStore.setState({ showSettings: true, showConfigDrawer: true });
 
@@ -100,6 +108,57 @@ describe('uiStore drawer mutual exclusion', () => {
     expect(state.showChunkDrawer).toBe(true);
     expect(state.chunkDrawerTab).toBe('operations');
     expect(state.showConfigDrawer).toBe(false);
+  });
+});
+
+describe('uiStore project shell state', () => {
+  it('defaults to the run panel with context expanded', () => {
+    const state = useUiStore.getState();
+    expect(state.activeProjectPanel).toBe('run');
+    expect(state.projectContextCollapsed).toBe(false);
+  });
+
+  it('updates project panel and collapse state independently', () => {
+    useUiStore.getState().setActiveProjectPanel('document');
+    useUiStore.getState().setProjectContextCollapsed(true);
+
+    const state = useUiStore.getState();
+    expect(state.activeProjectPanel).toBe('document');
+    expect(state.projectContextCollapsed).toBe(true);
+  });
+
+  it('raises the document fly-out when the insight panel is selected', () => {
+    useUiStore.getState().setActiveProjectPanel('insight');
+
+    const state = useUiStore.getState();
+    expect(state.activeProjectPanel).toBe('insight');
+    expect(state.showDocumentDrawer).toBe(true);
+    expect(state.showChunkDrawer).toBe(false);
+  });
+
+  it('raises the chunk fly-out when the chunk panel is selected', () => {
+    useUiStore.getState().setActiveProjectPanel('chunk');
+
+    const state = useUiStore.getState();
+    expect(state.activeProjectPanel).toBe('chunk');
+    expect(state.showChunkDrawer).toBe(true);
+    expect(state.showDocumentDrawer).toBe(false);
+  });
+
+  it('closes the fly-out drawers when an inline panel is selected', () => {
+    useUiStore.getState().setActiveProjectPanel('insight');
+    useUiStore.getState().setActiveProjectPanel('document');
+
+    const state = useUiStore.getState();
+    expect(state.activeProjectPanel).toBe('document');
+    expect(state.showDocumentDrawer).toBe(false);
+    expect(state.showChunkDrawer).toBe(false);
+  });
+
+  it('syncs the rail to the chunk panel when the chunk drawer is opened externally', () => {
+    useUiStore.getState().setShowChunkDrawer(true, 'audit');
+
+    expect(useUiStore.getState().activeProjectPanel).toBe('chunk');
   });
 });
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -12,6 +12,11 @@ export type DocumentPaneFocus = 'both' | 'source' | 'translation';
 export type HelpSection = 'overview' | 'pipeline' | 'features' | 'context' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts' | 'troubleshooting' | 'design';
 export type ActivePanel = 'config' | 'insights' | 'chunk' | 'settings' | 'help' | null;
 export type UiFont = 'jakarta' | 'geist' | 'inter' | 'plex';
+export type SettingsTab = 'translations' | 'provider';
+export type ProjectPanelTab = 'run' | 'pipeline' | 'document' | 'insight' | 'chunk';
+
+/** Pannelli che vivono inline nella barra primaria (non aprono il fly-out). */
+const INLINE_PROJECT_PANELS: ReadonlyArray<ProjectPanelTab> = ['run', 'pipeline', 'document'];
 
 interface UiState {
   viewMode: ViewMode;
@@ -21,6 +26,7 @@ interface UiState {
   uiFont: UiFont;
   selectedChunkId: string | null;
   showSettings: boolean;
+  settingsTab: SettingsTab;
   showHelp: boolean;
   helpSection: HelpSection;
   showConfigDrawer: boolean;
@@ -45,6 +51,13 @@ interface UiState {
   focusIsAnnotation: boolean;
   traceStageId: string | null;
   activePanel: ActivePanel;
+  activeProjectPanel: ProjectPanelTab;
+  projectContextCollapsed: boolean;
+  dashboardSidebarCollapsed: boolean;
+  dashboardSidebarWidth: number;
+  projectSidebarWidth: number;
+  projectFlyoutWidth: number;
+  configFlyoutWidth: number;
   pendingAnnotationAnchor: { chunkId: string; text: string; content?: string } | null;
 
   setTraceStageId: (id: string | null) => void;
@@ -55,7 +68,8 @@ interface UiState {
   setSyncScrollEnabled: (enabled: boolean) => void;
   setUiFont: (font: UiFont) => void;
   setSelectedChunkId: (chunkId: string | null) => void;
-  setShowSettings: (show: boolean) => void;
+  setShowSettings: (show: boolean, tab?: SettingsTab) => void;
+  setSettingsTab: (tab: SettingsTab) => void;
   setShowHelp: (show: boolean, section?: HelpSection) => void;
   setShowConfigDrawer: (show: boolean) => void;
   showExportDialog: boolean;
@@ -72,7 +86,14 @@ interface UiState {
   focusAnnotationInChunk: (chunkId: string, query: string) => void;
   clearFocusedIssue: () => void;
   clearAnnotationFocus: () => void;
-  setActivePanel: (panel: ActivePanel, tab?: InsightsDrawerTab | ChunkDrawerTab | HelpSection) => void;
+  setActiveProjectPanel: (panel: ProjectPanelTab) => void;
+  setProjectContextCollapsed: (collapsed: boolean) => void;
+  setDashboardSidebarCollapsed: (collapsed: boolean) => void;
+  setDashboardSidebarWidth: (width: number) => void;
+  setProjectSidebarWidth: (width: number) => void;
+  setProjectFlyoutWidth: (width: number) => void;
+  setConfigFlyoutWidth: (width: number) => void;
+  setActivePanel: (panel: ActivePanel, tab?: InsightsDrawerTab | ChunkDrawerTab | HelpSection | SettingsTab) => void;
 }
 
 export const useUiStore = create<UiState>()(
@@ -85,6 +106,7 @@ export const useUiStore = create<UiState>()(
       uiFont: 'jakarta',
       selectedChunkId: null,
       showSettings: false,
+      settingsTab: 'translations',
       showHelp: false,
       helpSection: 'overview',
       showConfigDrawer: false,
@@ -110,6 +132,13 @@ export const useUiStore = create<UiState>()(
       focusIsAnnotation: false,
       traceStageId: null,
       activePanel: null,
+      activeProjectPanel: 'run',
+      projectContextCollapsed: false,
+      dashboardSidebarCollapsed: false,
+      dashboardSidebarWidth: 240,
+      projectSidebarWidth: 240,
+      projectFlyoutWidth: 430,
+      configFlyoutWidth: 560,
       pendingAnnotationAnchor: null,
 
       setViewMode: (mode) =>
@@ -131,11 +160,12 @@ export const useUiStore = create<UiState>()(
           selectedChunkId: chunkId,
           ...(chunkId !== state.focusedChunkId && { focusedIssueQuery: null, focusedSourceIssueQuery: null }),
         })),
-      setShowSettings: (show) =>
+      setShowSettings: (show, tab) =>
         set((state) =>
           show
             ? {
                 showSettings: true,
+                settingsTab: tab ?? state.settingsTab,
                 showHelp: false,
                 showConfigDrawer: false,
                 showDocumentDrawer: false,
@@ -144,6 +174,7 @@ export const useUiStore = create<UiState>()(
               }
             : { showSettings: false, showHelp: state.showHelp, activePanel: state.showHelp ? 'help' as const : null },
         ),
+      setSettingsTab: (tab) => set({ settingsTab: tab }),
       setShowHelp: (show, section) =>
         set((state) =>
           show
@@ -169,6 +200,8 @@ export const useUiStore = create<UiState>()(
                 showSettings: false,
                 showHelp: false,
                 activePanel: 'config' as const,
+                // Config esce dal fly-out della voce Pipeline: mantieni il rail su 'pipeline'.
+                activeProjectPanel: 'pipeline' as const,
               }
             : { showConfigDrawer: false, activePanel: null },
         ),
@@ -183,6 +216,8 @@ export const useUiStore = create<UiState>()(
                 showSettings: false,
                 showHelp: false,
                 activePanel: 'insights' as const,
+                activeProjectPanel: 'insight' as const,
+                projectContextCollapsed: true,
               }
             : { showDocumentDrawer: false, activePanel: null },
         ),
@@ -198,6 +233,8 @@ export const useUiStore = create<UiState>()(
                 showSettings: false,
                 showHelp: false,
                 activePanel: 'chunk' as const,
+                activeProjectPanel: 'chunk' as const,
+                projectContextCollapsed: true,
               }
             : { showChunkDrawer: false, activePanel: null },
         ),
@@ -227,12 +264,51 @@ export const useUiStore = create<UiState>()(
       clearAnnotationFocus: () => set({ focusedIssueQuery: null, focusIsAnnotation: false }),
       setTraceStageId: (id) => set({ traceStageId: id }),
       setPendingAnnotationAnchor: (anchor) => set({ pendingAnnotationAnchor: anchor }),
+      setActiveProjectPanel: (panel) =>
+        set((state) => {
+          if (panel === 'insight') {
+            return {
+              activeProjectPanel: 'insight' as const,
+              showDocumentDrawer: true,
+              showChunkDrawer: false,
+              showConfigDrawer: false,
+              activePanel: 'insights' as const,
+              // Aprendo il fly-out la barra principale si riduce a icone.
+              projectContextCollapsed: true,
+            };
+          }
+          if (panel === 'chunk') {
+            return {
+              activeProjectPanel: 'chunk' as const,
+              showChunkDrawer: true,
+              showDocumentDrawer: false,
+              showConfigDrawer: false,
+              activePanel: 'chunk' as const,
+              projectContextCollapsed: true,
+            };
+          }
+          // run / pipeline / document → contenuto inline, fly-out chiuso.
+          return {
+            activeProjectPanel: panel,
+            showDocumentDrawer: false,
+            showChunkDrawer: false,
+            showConfigDrawer: false,
+            activePanel: state.activePanel === 'insights' || state.activePanel === 'chunk' || state.activePanel === 'config' ? null : state.activePanel,
+          };
+        }),
+      setProjectContextCollapsed: (collapsed) => set({ projectContextCollapsed: collapsed }),
+      setDashboardSidebarCollapsed: (collapsed) => set({ dashboardSidebarCollapsed: collapsed }),
+      setDashboardSidebarWidth: (width) => set({ dashboardSidebarWidth: width }),
+      setProjectSidebarWidth: (width) => set({ projectSidebarWidth: width }),
+      setProjectFlyoutWidth: (width) => set({ projectFlyoutWidth: width }),
+      setConfigFlyoutWidth: (width) => set({ configFlyoutWidth: width }),
       setActivePanel: (panel, tab) =>
         set((state) => {
           switch (panel) {
             case 'settings':
               return {
-                showSettings: true, showHelp: false, showConfigDrawer: false,
+                showSettings: true, settingsTab: (tab as SettingsTab) ?? state.settingsTab,
+                showHelp: false, showConfigDrawer: false,
                 showDocumentDrawer: false, showChunkDrawer: false, activePanel: 'settings' as const,
               };
             case 'help':
@@ -270,7 +346,7 @@ export const useUiStore = create<UiState>()(
     }),
     {
       name: 'glossa-ui-prefs',
-      version: 7,
+      version: 10,
       migrate: (persisted: unknown, fromVersion: number) => {
         const s = persisted as Record<string, unknown>;
         if (fromVersion < 1) {
@@ -306,6 +382,24 @@ export const useUiStore = create<UiState>()(
         if (fromVersion < 7) {
           s.uiFont = 'jakarta';
         }
+        if (fromVersion < 8) {
+          s.activeProjectPanel = 'run';
+          s.projectContextCollapsed = false;
+        }
+        if (fromVersion < 9) {
+          // I pannelli fly-out (insight/chunk) non sono uno stato di rail persistibile:
+          // ripristina su 'run' così la barra non resta evidenziata su un fly-out chiuso.
+          if (!INLINE_PROJECT_PANELS.includes(s.activeProjectPanel as ProjectPanelTab)) {
+            s.activeProjectPanel = 'run';
+          }
+        }
+        if (fromVersion < 10) {
+          s.dashboardSidebarCollapsed = false;
+          s.dashboardSidebarWidth = 240;
+          s.projectSidebarWidth = 240;
+          s.projectFlyoutWidth = 430;
+          s.configFlyoutWidth = 560;
+        }
         return s;
       },
       storage: createJSONStorage(() => localStorage),
@@ -314,6 +408,15 @@ export const useUiStore = create<UiState>()(
         documentPaneFocus: state.documentPaneFocus,
         syncScrollEnabled: state.syncScrollEnabled,
         uiFont: state.uiFont,
+        activeProjectPanel: INLINE_PROJECT_PANELS.includes(state.activeProjectPanel)
+          ? state.activeProjectPanel
+          : 'run',
+        projectContextCollapsed: state.projectContextCollapsed,
+        dashboardSidebarCollapsed: state.dashboardSidebarCollapsed,
+        dashboardSidebarWidth: state.dashboardSidebarWidth,
+        projectSidebarWidth: state.projectSidebarWidth,
+        projectFlyoutWidth: state.projectFlyoutWidth,
+        configFlyoutWidth: state.configFlyoutWidth,
         highlightsEnabled: state.highlightsEnabled,
         highlightColors: state.highlightColors,
       }),


### PR DESCRIPTION
## Sommario

Seconda passata sul refactor UI/UX: la shell di **home** e **progetto** diventa un'unica **barra laterale** (`ShellNav`) con una **seconda barra fly-out** per i pannelli ricchi. Risolve i difetti visivi della prima passata (linguette scollegate, righe tab sovrapposte, collapse a scatti, pannelli sparsi, animazione config rotta) e completa i punti aperti delle tre issue.

## Cosa cambia

**Shell**
- `ShellNav` (`ShellNavSection`/`ShellNavItem`): superficie laterale unica. Item attivo = barra accent verticale + tint (niente linguetta flottante). Riusata da home e progetto.
- **Home** (`DashboardSidebar`): colonna unica con sezioni *Aree* + *Workspace*. Aggiungi workspace nell'header; **modifica ed elimina del workspace attivo** come azioni di riga (tolte dal canvas).
- **Progetto** (`PipelineSidebar`): barra primaria con nav `Run / Pipeline / Document / Insight / Chunk`, controllo **comprimi in cima** (back alla home dal breadcrumb). Run/Pipeline/Document inline nella barra (icone anche da collassata); rimosso il rettangolo `SidebarSectionShell`.
- **Seconda barra** (`ProjectFlyout` + `ConfigDrawer`): Insight/Chunk (estratti da `InsightsDrawer`) e config pipeline escono come pannello push ancorato alla barra. Aprendo Insight/Chunk la barra primaria si **auto-collassa** a icone.
- **Resize** (`useEdgeResize` + `ResizeHandle`): tutte le barre si ridimensionano dal bordo destro. Primarie → collassano a icone sotto soglia; fly-out → scompaiono. Larghezze/collapse persistiti (`uiStore` v9→v10).

**Pulizia**
- Bottoni testuali → primitive (`IconButton`/`PillButton`); tracking/font allineati alla ladder del design system.
- Riepilogo tecnico home: rimossa la riga "Workspace" (conteggio globale fuori contesto).

## Issue

Closes #243 — breadcrumb header animato, shell home a barra (collapse a icona), cleanup project sidebar (card workspace fuori, comandi ricollocati).
Closes #252 — *Esegui solo audit* raggiungibile nel pannello **Run** in modalità documento (anche con barra collassata); `ConfigDrawer` resta con `showActions=false`.
Closes #258 — wizard localizzato, scelta embedding fuori dal primo avvio (default `text-embedding-3-small`, scelta in *Workspace → Memory*), banner provider con CTA a *Settings → Provider*, **toast import localizzati**. _Nota: il punto 4 (verifica chiave subito dopo il salvataggio) era esplicitamente rimandato a 1.1._

## Test
- `tsc --noEmit` pulito.
- Suite Vitest: **489 test verdi** (+ test per fly-out/sync store, insight fly-out + auto-collapse, azioni riga workspace).
- Verifica visiva/feel del drag: da fare in `tauri dev` (app desktop).

## Docs
Aggiornati `docs/ARCHITECTURE.md`, `docs/UI_DESIGN_SYSTEM.md` (multibar, item attivo, fly-out, resize, azioni di riga) e la guida utente in-app (`help.overview.nav`).