### PR TITLE
feat: polish multibar shell — a11y, resize, overlay & motion (#272)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Sviluppo attivo (pre-1.0). Priorità assoluta alla modalità documento/editorial
 ## Documentazione e Stato
 - **Architettura**: Aggiorna `docs-dev/ARCHITECTURE.md` per modifiche ai flussi, comandi Tauri, schemi DB o store Zustand.
 - **UI**: Consulta `docs-dev/UI_DESIGN_SYSTEM.md` prima di qualsiasi modifica visiva.
-- **Avanzamento**: Leggi `STATO_SESSIONE.md` a inizio sessione e aggiornalo obbligatoriamente a fine task/feature. Aggiorna l'help in-app per modifiche funzionali.
+- **Avanzamento**: Leggi `STATO_SESSIONE_2.0.md` a inizio sessione e aggiornalo obbligatoriamente a fine task/feature. Aggiorna l'help in-app per modifiche funzionali.
 
 ## Git e Test
 - **Git**: Aggiorna sempre `main` prima di creare un branch (`git checkout main && git pull origin main && git checkout -b nome-branch`).

--- a/docs-dev/UI_DESIGN_SYSTEM.md
+++ b/docs-dev/UI_DESIGN_SYSTEM.md
@@ -251,14 +251,29 @@ Regole:
 
 ### Seconda barra (fly-out progetto)
 
-Nel progetto la barra primaria contiene la nav (`Run/Pipeline/Document/Insight/Chunk`) + back arrow in cima. I pannelli **inline** (Run, Pipeline, Document) vivono dentro la barra; i pannelli **ricchi** (Insight, Chunk, Config pipeline) escono in una **seconda barra push** (`ProjectFlyout`, `ConfigDrawer`) ancorata al bordo destro della barra, che spinge il documento (niente overlay, niente backdrop). La larghezza è animata (`width 0 → N`), così l'apertura/chiusura è fluida e parte sempre dal bordo della barra.
+Nel progetto la barra primaria contiene la nav (`Run/Pipeline/Document/Insight/Chunk`) + back arrow in cima. I pannelli **inline** (Run, Pipeline, Document) vivono dentro la barra; i pannelli **ricchi** (Insight, Chunk, Config pipeline) escono in una **seconda barra push** (`ProjectFlyout`, `ConfigDrawer`) ancorata al bordo destro della barra, che spinge il documento. La larghezza è animata (`width 0 → N`), così l'apertura/chiusura è fluida e parte sempre dal bordo della barra.
 
-### Resize (drag) — `useEdgeResize` + `ResizeHandle`
+**Auto-collapse non distruttivo**: aprendo Insight/Chunk la barra primaria si comprime a icone, ma la preferenza manuale dell'utente è ricordata in `uiStore.projectContextUserExpanded`. Alla chiusura del fly-out (ritorno a un pannello inline) la barra ritorna allo stato scelto dall'utente. `setProjectContextCollapsed` registra la scelta come preferenza.
+
+**Overlay su finestre strette**: sotto `FLYOUT_OVERLAY_BELOW` (1100px, `hooks/useViewportWidth.ts`) i fly-out passano da push a **overlay** (`position: absolute` con offset sinistro pari alla larghezza del rail + ombra), così il documento resta leggibile. Sopra soglia tornano push.
+
+**Caricamento documento**: `chunksStore.loadDocument` **non** apre il Chunk drawer (eviterebbe di spostare il layout di lettura); il pannello Chunk si apre solo su azione esplicita.
+
+### Resize (drag + tastiera) — `useEdgeResize` + `ResizeHandle`
 
 Tutte le superfici laterali sono ridimensionabili dal bordo destro (`components/layout/useEdgeResize.tsx`). Le larghezze e lo stato collapse sono persistiti in `uiStore`.
 - **Barre primarie** (home, progetto): mode `collapse` — trascinando sotto soglia collassano a icone in tempo reale (reversibile nel drag).
 - **Fly-out** (Insight, Chunk, ConfigDrawer): mode `dismiss` — trascinando sotto soglia il pannello **scompare** al rilascio (non collassa a icona).
+- **Accessibilità**: `ResizeHandle` è tabbabile (`role="separator"` + `aria-valuenow/min/max`); ←/→ ridimensionano a step di 16px, Home/End vanno a min/max, **doppio click = reset** alla larghezza di default (rail 240, flyout 430, config 560). Grip sottile sempre visibile (scopribilità), accentuato in hover/drag.
 - Durante il drag la transizione di larghezza è disattivata (movimento 1:1); allo snap/chiusura riprende l'animazione. Niente larghezze hard-coded nei consumer: leggere da `uiStore`.
+
+### Token di motion — `components/layout/motion.ts`
+
+Spring e curve condivise dalla shell, niente magic number duplicati: `SPRING_PANEL` (`spring 30/280`, fly-out), `EASE_EDITORIAL` (`[0.22,1,0.36,1]`, ingressi barre), `WIDTH_TRANSITION_CLASS` (`transition-[width] duration-200`).
+
+### Navigazione da tastiera del rail
+
+Il `role="tablist"` verticale del rail progetto (`PipelineSidebar`) usa roving tabindex (0 sull'attivo, -1 sugli altri): ↑/↓ (e ←/→) spostano il focus tra le voci, Home/End ai estremi; attivazione manuale con Enter/Space/click (non intrusiva sui fly-out). Stesso pattern dei tab strip di `InsightsDrawer`.
 
 ---
 

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -5,11 +5,16 @@ import { toast } from 'sonner';
 import { AnimatePresence, motion } from 'motion/react';
 import { IconButton, PillButton } from '../ui';
 import { ResizeHandle, useEdgeResize } from '../layout/useEdgeResize';
+import { SPRING_PANEL } from '../layout/motion';
+import { useViewportWidth, FLYOUT_OVERLAY_BELOW } from '../../hooks/useViewportWidth';
 import { PipelineConfig } from '../pipeline/PipelineConfig';
 
 const CONFIG_MIN = 420;
 const CONFIG_MAX = 760;
 const CONFIG_DISMISS_AT = 380;
+const CONFIG_DEFAULT = 560;
+/** Larghezza del rail collassato: offset sinistro dell'overlay su finestre strette. */
+const CONFIG_RAIL_COLLAPSED = 64;
 import { useUiStore } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
 import { usePipelineStore } from '../../stores/pipelineStore';
@@ -37,8 +42,15 @@ export function ConfigDrawer({
   const setShowConfigDrawer = useUiStore((state) => state.setShowConfigDrawer);
   const width = useUiStore((state) => state.configFlyoutWidth);
   const setWidth = useUiStore((state) => state.setConfigFlyoutWidth);
+  const projectContextCollapsed = useUiStore((state) => state.projectContextCollapsed);
+  const projectSidebarWidth = useUiStore((state) => state.projectSidebarWidth);
   const { dragging, startDrag } = useEdgeResize();
   const drawerRef = useRef<HTMLDivElement | null>(null);
+  const viewportWidth = useViewportWidth();
+
+  // Overlay sul documento su finestre strette (vedi ProjectFlyout): l'offset segue il rail.
+  const overlay = viewportWidth > 0 && viewportWidth < FLYOUT_OVERLAY_BELOW;
+  const railWidth = projectContextCollapsed ? CONFIG_RAIL_COLLAPSED : projectSidebarWidth;
 
   const handleResizeStart = (event: React.PointerEvent) => {
     startDrag(event, {
@@ -189,10 +201,13 @@ export function ConfigDrawer({
           initial={{ width: 0, opacity: 0 }}
           animate={{ width, opacity: 1 }}
           exit={{ width: 0, opacity: 0 }}
-          transition={dragging ? { duration: 0 } : { type: 'spring', damping: 30, stiffness: 280 }}
+          transition={dragging ? { duration: 0 } : SPRING_PANEL}
           role="dialog"
           aria-labelledby="config-drawer-title"
-          className="relative flex h-full shrink-0 overflow-hidden border-r border-editorial-border bg-editorial-bg"
+          style={overlay ? { left: railWidth } : undefined}
+          className={`flex h-full overflow-hidden border-r border-editorial-border bg-editorial-bg ${
+            overlay ? 'absolute inset-y-0 z-40 shadow-2xl shadow-black/25' : 'relative shrink-0'
+          }`}
         >
           <div className="flex h-full flex-col overflow-hidden" style={{ width }}>
           {/* Header */}
@@ -254,7 +269,16 @@ export function ConfigDrawer({
             </div>
           )}
           </div>
-          <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizePanel')} />
+          <ResizeHandle
+            onPointerDown={handleResizeStart}
+            dragging={dragging}
+            label={t('projectShell.resizePanel')}
+            width={width}
+            min={CONFIG_MIN}
+            max={CONFIG_MAX}
+            onResize={setWidth}
+            onReset={() => setWidth(CONFIG_DEFAULT)}
+          />
         </motion.aside>
       )}
     </AnimatePresence>

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -74,7 +74,7 @@ export function HelpGuide({ open, onClose }: HelpGuideProps) {
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-full border border-editorial-border px-5 py-3 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                className="rounded-full border border-editorial-border px-5 py-3 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
                 {t('common.close')}
               </button>
@@ -161,7 +161,7 @@ function Step({ n, title, children }: { n: number; title: string; children: Reac
 function Tip({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="mt-6 rounded-[20px] border border-editorial-border bg-editorial-textbox/30 px-5 py-4">
-      <h4 className="mb-2 text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-accent">{title}</h4>
+      <h4 className="mb-2 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-accent">{title}</h4>
       <p className="text-[13px] leading-relaxed text-editorial-ink/70">{children}</p>
     </div>
   );
@@ -187,7 +187,7 @@ function OverviewSection() {
       <P>{t('help.overview.p2')}</P>
 
       <div className="my-8 rounded-[20px] border border-editorial-border bg-editorial-textbox/25 p-6">
-        <div className="mb-4 text-[10px] font-bold uppercase tracking-[0.3em] text-editorial-muted">
+        <div className="mb-4 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-muted">
           {t('help.overview.flowTitle')}
         </div>
         <ol className="space-y-3 border-l-2 border-editorial-accent pl-5">
@@ -472,7 +472,7 @@ function AuditSection() {
       <div className="my-6 space-y-3">
         {issueTypes.map((type) => (
           <div key={type} className="flex items-start gap-3 rounded-[20px] border border-editorial-border bg-editorial-textbox/15 px-5 py-4">
-            <span className="shrink-0 rounded-full border border-editorial-accent/40 bg-editorial-accent/12 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-accent">
+            <span className="shrink-0 rounded-full border border-editorial-accent/40 bg-editorial-accent/12 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-accent">
               {t(`help.audit.${type}Label`)}
             </span>
             <span className="text-[13px] leading-relaxed text-editorial-ink/80">

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -14,6 +14,7 @@ import { IconButton, PillButton } from '../ui';
 import { WorkspaceSettingsModal } from '../workspace/WorkspaceSettingsModal';
 import { ShellNavFooter, ShellNavItem, ShellNavSection } from './ShellNav';
 import { ResizeHandle, useEdgeResize } from './useEdgeResize';
+import { EASE_EDITORIAL, WIDTH_TRANSITION_CLASS } from './motion';
 
 const AREA_ITEMS = [
   { id: 'translations', icon: BookOpenText, enabled: true },
@@ -25,6 +26,7 @@ const SIDEBAR_MIN = 180;
 const SIDEBAR_MAX = 320;
 const SIDEBAR_COLLAPSE_AT = 150;
 const SIDEBAR_COLLAPSED = 64;
+const SIDEBAR_DEFAULT = 240;
 
 export function DashboardSidebar() {
   const { t } = useTranslation();
@@ -137,11 +139,11 @@ export function DashboardSidebar() {
     <motion.nav
       initial={{ opacity: 0, x: -18 }}
       animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.4, ease: EASE_EDITORIAL }}
       aria-label={t('sidebar.areaLabel')}
       style={{ width: collapsed ? SIDEBAR_COLLAPSED : width }}
       className={`relative flex shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60 ${
-        dragging ? '' : 'transition-[width] duration-200'
+        dragging ? '' : WIDTH_TRANSITION_CLASS
       }`}
     >
       <div
@@ -242,7 +244,22 @@ export function DashboardSidebar() {
         <ShellNavFooter collapsed={collapsed} />
       </div>
 
-      <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('sidebar.resize')} />
+      <ResizeHandle
+        onPointerDown={handleResizeStart}
+        dragging={dragging}
+        label={t('sidebar.resize')}
+        width={collapsed ? SIDEBAR_MIN : width}
+        min={SIDEBAR_MIN}
+        max={SIDEBAR_MAX}
+        onResize={(next) => {
+          if (collapsed) setCollapsed(false);
+          setWidth(next);
+        }}
+        onReset={() => {
+          setCollapsed(false);
+          setWidth(SIDEBAR_DEFAULT);
+        }}
+      />
 
       <WorkspaceSettingsModal
         open={showWorkspaceSettings}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ import { useLibraryStore } from '../../stores/libraryStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { IconButton, Tooltip } from '../ui';
+import { EASE_EDITORIAL } from './motion';
 
 const HelpGuide = lazy(() =>
   import('../help/HelpGuide').then((m) => ({ default: m.HelpGuide })),
@@ -132,7 +133,7 @@ export function Header() {
                   initial={{ opacity: 0, x: -12 }}
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -12 }}
-                  transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+                  transition={{ duration: 0.28, ease: EASE_EDITORIAL }}
                   className="flex min-w-0 items-baseline gap-2.5"
                 >
                   <span className="shrink-0 font-display text-lg italic text-editorial-muted md:text-xl">

--- a/src/components/layout/PipelineSidebar.test.tsx
+++ b/src/components/layout/PipelineSidebar.test.tsx
@@ -69,4 +69,34 @@ describe('PipelineSidebar project shell', () => {
     expect(useUiStore.getState().showDocumentDrawer).toBe(true);
     expect(useUiStore.getState().projectContextCollapsed).toBe(true);
   });
+
+  it('applies a roving tabindex with only the active rail tab reachable by Tab', () => {
+    render(<PipelineSidebar />);
+
+    // Default: Run attivo → tabIndex 0, gli altri -1.
+    expect(screen.getByRole('tab', { name: 'projectShell.runTab' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: 'projectShell.documentTab' })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('moves focus down the rail with the ArrowDown key without activating', () => {
+    render(<PipelineSidebar />);
+
+    const runTab = screen.getByRole('tab', { name: 'projectShell.runTab' });
+    runTab.focus();
+    fireEvent.keyDown(runTab, { key: 'ArrowDown' });
+
+    // Il focus si sposta su Pipeline ma il pannello attivo resta Run (attivazione manuale).
+    expect(screen.getByRole('tab', { name: 'projectShell.pipelineTab' })).toHaveFocus();
+    expect(useUiStore.getState().activeProjectPanel).toBe('run');
+  });
+
+  it('jumps focus to the last rail tab with the End key', () => {
+    render(<PipelineSidebar />);
+
+    const runTab = screen.getByRole('tab', { name: 'projectShell.runTab' });
+    runTab.focus();
+    fireEvent.keyDown(runTab, { key: 'End' });
+
+    expect(screen.getByRole('tab', { name: 'projectShell.chunkTab' })).toHaveFocus();
+  });
 });

--- a/src/components/layout/PipelineSidebar.tsx
+++ b/src/components/layout/PipelineSidebar.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
+import { useRef } from 'react';
 import {
   ArrowLeft,
   BarChart2,
@@ -12,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { DashboardSidebar } from './DashboardSidebar';
 import { ShellNavFooter, ShellNavItem } from './ShellNav';
 import { ResizeHandle, useEdgeResize } from './useEdgeResize';
+import { EASE_EDITORIAL, WIDTH_TRANSITION_CLASS } from './motion';
 import {
   PipelineSidebarDocumentSection,
   PipelineSidebarPipelinesSection,
@@ -46,6 +48,7 @@ const SIDEBAR_MIN = 180;
 const SIDEBAR_MAX = 320;
 const SIDEBAR_COLLAPSE_AT = 150;
 const SIDEBAR_COLLAPSED = 64;
+const SIDEBAR_DEFAULT = 240;
 
 export function PipelineSidebar({
   mode = 'editor',
@@ -69,6 +72,7 @@ export function PipelineSidebar({
   const closeProject = useProjectStore((state) => state.closeProject);
   const isProcessing = useChunksStore((state) => state.isProcessing);
   const { dragging, startDrag } = useEdgeResize();
+  const tabRefs = useRef<Partial<Record<ProjectPanelTab, HTMLButtonElement | null>>>({});
 
   if (mode === 'dashboard') {
     return <DashboardSidebar />;
@@ -97,6 +101,22 @@ export function PipelineSidebar({
     }
   };
 
+  // Rail verticale: roving focus con frecce ↑/↓ + Home/End (WAI-ARIA APG tablist).
+  // Attivazione manuale: Enter/Space sul button (gestiti nativamente) o click.
+  const handleRailKeyDown = (tabId: ProjectPanelTab, event: KeyboardEvent<HTMLButtonElement>) => {
+    const idx = PROJECT_PANEL_TABS.findIndex((tab) => tab.id === tabId);
+    let nextIdx: number | null = null;
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight')
+      nextIdx = (idx + 1) % PROJECT_PANEL_TABS.length;
+    else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft')
+      nextIdx = (idx - 1 + PROJECT_PANEL_TABS.length) % PROJECT_PANEL_TABS.length;
+    else if (event.key === 'Home') nextIdx = 0;
+    else if (event.key === 'End') nextIdx = PROJECT_PANEL_TABS.length - 1;
+    if (nextIdx === null) return;
+    event.preventDefault();
+    tabRefs.current[PROJECT_PANEL_TABS[nextIdx].id]?.focus();
+  };
+
   const handleResizeStart = (event: React.PointerEvent) => {
     startDrag(event, {
       startWidth: collapsed ? SIDEBAR_COLLAPSED : width,
@@ -113,11 +133,11 @@ export function PipelineSidebar({
     <motion.nav
       initial={{ opacity: 0, x: -22 }}
       animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.42, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.42, ease: EASE_EDITORIAL }}
       aria-label={t('projectShell.railLabel')}
       style={{ width: collapsed ? SIDEBAR_COLLAPSED : width }}
       className={`relative flex shrink-0 flex-col border-r border-editorial-border bg-editorial-bg/60 ${
-        dragging ? '' : 'transition-[width] duration-200'
+        dragging ? '' : WIDTH_TRANSITION_CLASS
       }`}
     >
       {/* Contenuto ancorato alla larghezza collassata: niente slide orizzontale durante l'animazione. */}
@@ -141,6 +161,7 @@ export function PipelineSidebar({
 
         <div
           role="tablist"
+          aria-orientation="vertical"
           aria-label={t('projectShell.railLabel')}
           className="space-y-0.5 px-2.5 pt-2"
         >
@@ -153,7 +174,12 @@ export function PipelineSidebar({
               ariaControls="project-context-panel"
               active={activeProjectPanel === tab.id}
               collapsed={collapsed}
+              tabIndex={activeProjectPanel === tab.id ? 0 : -1}
+              buttonRef={(el) => {
+                tabRefs.current[tab.id] = el;
+              }}
               onClick={() => handleSelect(tab.id)}
+              onKeyDown={(event) => handleRailKeyDown(tab.id, event)}
               icon={tab.icon}
               label={t(tab.labelKey)}
             />
@@ -189,7 +215,22 @@ export function PipelineSidebar({
         <ShellNavFooter collapsed={collapsed} />
       </div>
 
-      <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizeRail')} />
+      <ResizeHandle
+        onPointerDown={handleResizeStart}
+        dragging={dragging}
+        label={t('projectShell.resizeRail')}
+        width={collapsed ? SIDEBAR_MIN : width}
+        min={SIDEBAR_MIN}
+        max={SIDEBAR_MAX}
+        onResize={(next) => {
+          if (collapsed) setProjectContextCollapsed(false);
+          setWidth(next);
+        }}
+        onReset={() => {
+          setProjectContextCollapsed(false);
+          setWidth(SIDEBAR_DEFAULT);
+        }}
+      />
     </motion.nav>
   );
 }

--- a/src/components/layout/ProjectFlyout.tsx
+++ b/src/components/layout/ProjectFlyout.tsx
@@ -3,10 +3,15 @@ import { useTranslation } from 'react-i18next';
 import { useUiStore } from '../../stores/uiStore';
 import { ChunkInspectorPanel, InsightDocPanel } from '../document';
 import { ResizeHandle, useEdgeResize } from './useEdgeResize';
+import { SPRING_PANEL } from './motion';
+import { useViewportWidth, FLYOUT_OVERLAY_BELOW } from '../../hooks/useViewportWidth';
 
 const FLYOUT_MIN = 300;
 const FLYOUT_MAX = 620;
 const FLYOUT_DISMISS_AT = 260;
+const FLYOUT_DEFAULT = 430;
+/** Larghezza del rail collassato: offset sinistro dell'overlay su finestre strette. */
+const RAIL_COLLAPSED = 64;
 
 interface ProjectFlyoutProps {
   onReauditChunk: (chunkId: string) => void;
@@ -25,10 +30,18 @@ export function ProjectFlyout({ onReauditChunk, onRunCoherenceAudit }: ProjectFl
   const width = useUiStore((state) => state.projectFlyoutWidth);
   const setWidth = useUiStore((state) => state.setProjectFlyoutWidth);
   const setActiveProjectPanel = useUiStore((state) => state.setActiveProjectPanel);
+  const projectContextCollapsed = useUiStore((state) => state.projectContextCollapsed);
+  const projectSidebarWidth = useUiStore((state) => state.projectSidebarWidth);
   const { dragging, startDrag } = useEdgeResize();
+  const viewportWidth = useViewportWidth();
 
   const open = showDocumentDrawer || showChunkDrawer;
   const close = () => setActiveProjectPanel('document');
+
+  // Su finestre strette il fly-out si sovrappone al documento (overlay) invece di spingerlo,
+  // così il testo resta leggibile. L'offset sinistro segue la larghezza del rail.
+  const overlay = viewportWidth > 0 && viewportWidth < FLYOUT_OVERLAY_BELOW;
+  const railWidth = projectContextCollapsed ? RAIL_COLLAPSED : projectSidebarWidth;
 
   const handleResizeStart = (event: React.PointerEvent) => {
     startDrag(event, {
@@ -50,8 +63,11 @@ export function ProjectFlyout({ onReauditChunk, onRunCoherenceAudit }: ProjectFl
           initial={{ width: 0, opacity: 0 }}
           animate={{ width, opacity: 1 }}
           exit={{ width: 0, opacity: 0 }}
-          transition={dragging ? { duration: 0 } : { type: 'spring', damping: 30, stiffness: 280 }}
-          className="relative flex h-full shrink-0 overflow-hidden border-r border-editorial-border bg-editorial-bg/95"
+          transition={dragging ? { duration: 0 } : SPRING_PANEL}
+          style={overlay ? { left: railWidth } : undefined}
+          className={`flex h-full overflow-hidden border-r border-editorial-border bg-editorial-bg/95 ${
+            overlay ? 'absolute inset-y-0 z-40 shadow-2xl shadow-black/25' : 'relative shrink-0'
+          }`}
         >
           <div className="flex h-full flex-col overflow-hidden" style={{ width }}>
             {showChunkDrawer ? (
@@ -60,7 +76,16 @@ export function ProjectFlyout({ onReauditChunk, onRunCoherenceAudit }: ProjectFl
               <InsightDocPanel onRunCoherenceAudit={onRunCoherenceAudit} onClose={close} />
             )}
           </div>
-          <ResizeHandle onPointerDown={handleResizeStart} dragging={dragging} label={t('projectShell.resizePanel')} />
+          <ResizeHandle
+            onPointerDown={handleResizeStart}
+            dragging={dragging}
+            label={t('projectShell.resizePanel')}
+            width={width}
+            min={FLYOUT_MIN}
+            max={FLYOUT_MAX}
+            onResize={setWidth}
+            onReset={() => setWidth(FLYOUT_DEFAULT)}
+          />
         </motion.aside>
       ) : null}
     </AnimatePresence>

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode, Ref } from 'react';
 import { HelpCircle, Settings, type LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useUiStore } from '../../stores/uiStore';
@@ -83,11 +83,15 @@ interface ShellNavItemProps {
   disabled?: boolean;
   collapsed?: boolean;
   onClick?: () => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLButtonElement>) => void;
   ariaCurrent?: 'page';
   role?: 'tab';
   ariaSelected?: boolean;
   ariaControls?: string;
   id?: string;
+  /** Roving tabindex per i pattern tablist: 0 sull'item attivo, -1 sugli altri. */
+  tabIndex?: number;
+  buttonRef?: Ref<HTMLButtonElement>;
   trailing?: ReactNode;
 }
 
@@ -100,11 +104,14 @@ export function ShellNavItem({
   disabled = false,
   collapsed = false,
   onClick,
+  onKeyDown,
   ariaCurrent,
   role,
   ariaSelected,
   ariaControls,
   id,
+  tabIndex,
+  buttonRef,
   trailing,
 }: ShellNavItemProps) {
   const labelClassName = labelFont === 'display' ? 'font-display text-sm italic' : 'font-sans text-sm';
@@ -119,12 +126,15 @@ export function ShellNavItem({
     <button
       type="button"
       id={id}
+      ref={buttonRef}
       onClick={onClick}
+      onKeyDown={onKeyDown}
       disabled={disabled}
       aria-current={ariaCurrent}
       role={role}
       aria-selected={role === 'tab' ? ariaSelected : undefined}
       aria-controls={ariaControls}
+      tabIndex={tabIndex}
       className={`flex min-w-0 flex-1 items-center gap-2.5 rounded-[12px] py-2 text-left text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
         collapsed ? 'justify-center px-0' : 'px-2.5'
       } ${disabled ? 'cursor-not-allowed' : ''}`}

--- a/src/components/layout/motion.ts
+++ b/src/components/layout/motion.ts
@@ -1,0 +1,15 @@
+import type { Transition } from 'motion/react';
+
+/**
+ * Token di motion condivisi della shell multibar.
+ * Centralizzano spring/curve/durate per evitare magic number duplicati tra le superfici.
+ */
+
+/** Curva editoriale (ease-out morbido) per gli ingressi delle barre. */
+export const EASE_EDITORIAL: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+/** Spring dei pannelli fly-out (ProjectFlyout, ConfigDrawer): apertura/chiusura larghezza. */
+export const SPRING_PANEL: Transition = { type: 'spring', damping: 30, stiffness: 280 };
+
+/** Transizione larghezza Tailwind condivisa dalle barre primarie (rail, dashboard). */
+export const WIDTH_TRANSITION_CLASS = 'transition-[width] duration-200';

--- a/src/components/layout/useEdgeResize.test.tsx
+++ b/src/components/layout/useEdgeResize.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ResizeHandle } from './useEdgeResize';
+
+describe('ResizeHandle accessibility', () => {
+  const baseProps = {
+    onPointerDown: vi.fn(),
+    dragging: false,
+    label: 'Resize',
+    width: 240,
+    min: 180,
+    max: 320,
+  };
+
+  it('exposes the current width through ARIA value attributes', () => {
+    render(<ResizeHandle {...baseProps} onResize={vi.fn()} onReset={vi.fn()} />);
+
+    const handle = screen.getByRole('separator', { name: 'Resize' });
+    expect(handle).toHaveAttribute('aria-valuenow', '240');
+    expect(handle).toHaveAttribute('aria-valuemin', '180');
+    expect(handle).toHaveAttribute('aria-valuemax', '320');
+    expect(handle).toHaveAttribute('tabindex', '0');
+  });
+
+  it('grows the width by one step on ArrowRight', () => {
+    const onResize = vi.fn();
+    render(<ResizeHandle {...baseProps} onResize={onResize} onReset={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize' }), { key: 'ArrowRight' });
+
+    expect(onResize).toHaveBeenCalledWith(256);
+  });
+
+  it('shrinks the width by one step on ArrowLeft', () => {
+    const onResize = vi.fn();
+    render(<ResizeHandle {...baseProps} onResize={onResize} onReset={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize' }), { key: 'ArrowLeft' });
+
+    expect(onResize).toHaveBeenCalledWith(224);
+  });
+
+  it('clamps the keyboard step to the max width', () => {
+    const onResize = vi.fn();
+    render(<ResizeHandle {...baseProps} width={318} onResize={onResize} onReset={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize' }), { key: 'ArrowRight' });
+
+    expect(onResize).toHaveBeenCalledWith(320);
+  });
+
+  it('resets the width on double click', () => {
+    const onReset = vi.fn();
+    render(<ResizeHandle {...baseProps} onResize={vi.fn()} onReset={onReset} />);
+
+    fireEvent.doubleClick(screen.getByRole('separator', { name: 'Resize' }));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/layout/useEdgeResize.tsx
+++ b/src/components/layout/useEdgeResize.tsx
@@ -1,6 +1,10 @@
+import type { KeyboardEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 type ResizeMode = 'collapse' | 'dismiss';
+
+/** Passo di ridimensionamento da tastiera (←/→) sul separator. */
+const KEYBOARD_RESIZE_STEP = 16;
 
 interface DragConfig {
   startWidth: number;
@@ -87,18 +91,64 @@ interface ResizeHandleProps {
   onPointerDown: (event: React.PointerEvent) => void;
   dragging: boolean;
   label: string;
+  /** Larghezza corrente, min e max: alimentano gli attributi ARIA e il clamp da tastiera. */
+  width: number;
+  min: number;
+  max: number;
+  /** Ridimensionamento da tastiera (←/→ a step). */
+  onResize: (width: number) => void;
+  /** Reset alla larghezza di default (doppio click). */
+  onReset: () => void;
 }
 
-export function ResizeHandle({ onPointerDown, dragging, label }: ResizeHandleProps) {
+/**
+ * Maniglia di resize accessibile sul bordo destro di una colonna.
+ * - Pointer: trascinamento (delegato a useEdgeResize via onPointerDown).
+ * - Tastiera: ←/→ ridimensionano a step di 16px (tabbabile, role separator con aria-value*).
+ * - Doppio click: reset alla larghezza di default.
+ * Grip sottile sempre visibile per scopribilità, accentuato in hover/drag.
+ */
+export function ResizeHandle({ onPointerDown, dragging, label, width, min, max, onResize, onReset }: ResizeHandleProps) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Separator sul bordo destro di colonna ancorata a sinistra: → allarga, ← restringe.
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      onResize(clamp(width + KEYBOARD_RESIZE_STEP, min, max));
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      onResize(clamp(width - KEYBOARD_RESIZE_STEP, min, max));
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      onResize(min);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      onResize(max);
+    }
+  };
+
   return (
     <div
       role="separator"
+      tabIndex={0}
       aria-orientation="vertical"
       aria-label={label}
+      aria-valuenow={Math.round(width)}
+      aria-valuemin={min}
+      aria-valuemax={max}
       onPointerDown={onPointerDown}
-      className={`absolute inset-y-0 right-0 z-30 w-1.5 cursor-col-resize touch-none select-none transition-colors ${
+      onKeyDown={handleKeyDown}
+      onDoubleClick={onReset}
+      className={`group absolute inset-y-0 right-0 z-30 flex w-1.5 cursor-col-resize touch-none select-none items-center justify-center transition-colors focus:outline-none focus-visible:bg-editorial-accent/30 focus-visible:ring-1 focus-visible:ring-editorial-accent ${
         dragging ? 'bg-editorial-accent/40' : 'hover:bg-editorial-accent/25'
       }`}
-    />
+    >
+      {/* Grip sempre visibile (linea sottile) che si accentua in hover/drag. */}
+      <span
+        aria-hidden="true"
+        className={`h-7 w-px rounded-full transition-colors ${
+          dragging ? 'bg-editorial-accent' : 'bg-editorial-border group-hover:bg-editorial-accent/60'
+        }`}
+      />
+    </div>
   );
 }

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -297,7 +297,7 @@ export function SettingsModal() {
                   <button
                     type="button"
                     onClick={() => setShowSettings(false)}
-                    className="rounded-full border border-editorial-border px-5 py-3 text-[10px] font-bold uppercase tracking-[0.25em] text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                    className="rounded-full border border-editorial-border px-5 py-3 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-muted transition-colors hover:text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                   >
                     {t('common.close')}
                   </button>
@@ -316,13 +316,13 @@ export function SettingsModal() {
                   <div className="space-y-3">
                     <div className="flex items-center gap-1.5">
                       <Scissors size={11} className="text-editorial-accent shrink-0" />
-                      <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                         {t('settings.segmentation')}
                       </p>
                     </div>
                     <div className="grid grid-cols-3 gap-4">
                       <div className="space-y-1.5">
-                        <label className="block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                        <label className="block text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                           {t('settings.chunkPresetShort')}
                         </label>
                         <input
@@ -336,7 +336,7 @@ export function SettingsModal() {
                         />
                       </div>
                       <div className="space-y-1.5">
-                        <label className="block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                        <label className="block text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                           {t('settings.chunkPresetMedium')}
                         </label>
                         <input
@@ -350,7 +350,7 @@ export function SettingsModal() {
                         />
                       </div>
                       <div className="space-y-1.5">
-                        <label className="block text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                        <label className="block text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                           {t('settings.chunkPresetLong')}
                         </label>
                         <input
@@ -369,7 +369,7 @@ export function SettingsModal() {
                   <div className="space-y-4">
                     <div className="flex items-center gap-1.5">
                       <Layers size={11} className="text-editorial-accent shrink-0" />
-                      <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                         {t('settings.newPipelineInit')}
                       </p>
                     </div>
@@ -386,7 +386,7 @@ export function SettingsModal() {
                   <div className="space-y-4">
                     <div className="flex items-center gap-1.5">
                       <LayoutTemplate size={11} className="text-editorial-accent shrink-0" />
-                      <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                         {t('header.readerLayout')}
                       </p>
                     </div>
@@ -403,7 +403,7 @@ export function SettingsModal() {
                   <div className="space-y-4">
                     <div className="flex items-center gap-1.5">
                       <Palette size={11} className="text-editorial-accent shrink-0" />
-                      <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                         {t('settings.highlights')}
                       </p>
                     </div>
@@ -441,7 +441,7 @@ export function SettingsModal() {
                   <div className="space-y-4">
                     <div className="flex items-center gap-1.5">
                       <Type size={11} className="text-editorial-accent shrink-0" />
-                      <p className="text-[10px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                         {t('settings.typography')}
                       </p>
                     </div>
@@ -487,7 +487,7 @@ export function SettingsModal() {
                 >
                   {/* Provider workspace */}
                   <div className="space-y-4">
-                    <p className="text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                    <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                       {t('settings.providerConfig')}
                     </p>
                     <div className="rounded-[20px] border border-editorial-border bg-editorial-textbox/20 p-6 space-y-4">
@@ -570,7 +570,7 @@ export function SettingsModal() {
                                   onClick={() => refreshOllama()}
                                   disabled={refreshing}
                                   title={t('ollama.refresh')}
-                                  className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-[0.35em] text-editorial-muted hover:text-editorial-ink transition-colors disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                                  className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-muted hover:text-editorial-ink transition-colors disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                                   aria-label={t('ollama.refresh')}
                                 >
                                   <RefreshCw size={12} className={refreshing ? 'animate-spin' : ''} />
@@ -619,7 +619,7 @@ export function SettingsModal() {
                               {groups.map(({ label, ids }) => (
                                 <div key={label || '_all'} className="space-y-1.5">
                                   {label && (
-                                    <p className="px-1 text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted">
+                                    <p className="px-1 text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
                                       {label}
                                     </p>
                                   )}
@@ -673,7 +673,7 @@ export function SettingsModal() {
                     <button
                       type="button"
                       onClick={() => setShowPricingOverrides(!showPricingOverrides)}
-                      className="flex items-center gap-2 text-[10px] font-sans uppercase tracking-[0.35em] text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                      className="flex items-center gap-2 text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                       aria-expanded={showPricingOverrides}
                     >
                       {showPricingOverrides ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
@@ -686,9 +686,9 @@ export function SettingsModal() {
                           <table className="w-full text-xs font-mono">
                             <thead>
                               <tr className="border-b border-editorial-border bg-editorial-textbox/30">
-                                <th className="text-left px-3 py-2 font-bold uppercase tracking-[0.35em] text-editorial-muted">Model</th>
-                                <th className="text-right px-3 py-2 font-bold uppercase tracking-[0.35em] text-editorial-muted">Input $/1M</th>
-                                <th className="text-right px-3 py-2 font-bold uppercase tracking-[0.35em] text-editorial-muted">Output $/1M</th>
+                                <th className="text-left px-3 py-2 font-bold uppercase tracking-[0.16em] text-editorial-muted">Model</th>
+                                <th className="text-right px-3 py-2 font-bold uppercase tracking-[0.16em] text-editorial-muted">Input $/1M</th>
+                                <th className="text-right px-3 py-2 font-bold uppercase tracking-[0.16em] text-editorial-muted">Output $/1M</th>
                                 <th className="px-3 py-2" />
                               </tr>
                             </thead>
@@ -729,7 +729,7 @@ export function SettingsModal() {
                                         <button
                                           type="button"
                                           onClick={() => resetOverride(key)}
-                                          className="text-xs font-bold uppercase tracking-[0.28em] text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
+                                          className="text-xs font-bold uppercase tracking-[0.16em] text-editorial-muted hover:text-editorial-accent transition-colors focus:outline-none"
                                         >
                                           {t('cost.resetOverride')}
                                         </button>
@@ -746,7 +746,7 @@ export function SettingsModal() {
                             <button
                               type="button"
                               onClick={resetAll}
-                              className="text-[10px] font-bold uppercase tracking-[0.35em] text-editorial-accent hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+                              className="text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-accent hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
                             >
                               {t('cost.resetAll')}
                             </button>
@@ -766,7 +766,7 @@ export function SettingsModal() {
                     >
                       <div className="flex items-center gap-3">
                         <AlertCircle size={18} className="text-editorial-accent shrink-0" />
-                        <div className="text-[10px] font-bold uppercase tracking-[0.35em] text-editorial-muted">
+                        <div className="text-[11px] font-bold uppercase tracking-[0.16em] text-editorial-muted">
                           {t('settings.securityAdvisory')}
                         </div>
                       </div>

--- a/src/hooks/useViewportWidth.ts
+++ b/src/hooks/useViewportWidth.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Larghezza corrente del viewport, aggiornata sul resize della finestra.
+ * Usata per decidere quando i pannelli fly-out passano da push a overlay su finestre strette.
+ */
+export function useViewportWidth(): number {
+  const [width, setWidth] = useState(() => (typeof window === 'undefined' ? 0 : window.innerWidth));
+
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return width;
+}
+
+/** Sotto questa larghezza di viewport i fly-out del progetto si sovrappongono al documento invece di spingerlo. */
+export const FLYOUT_OVERLAY_BELOW = 1100;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -50,8 +50,7 @@
     "chunkTab": "Chunk",
     "resizeRail": "Resize sidebar",
     "resizePanel": "Resize panel",
-    "noDocumentHint": "Import a source document to unlock reader controls, export, and synchronized panes.",
-    "insightHint": "Open the insights drawer and jump directly to document index, search, stats, coherence, or glossary."
+    "noDocumentHint": "Import a source document to unlock reader controls, export, and synchronized panes."
   },
   "a11y": {
     "runStarted": "Pipeline run started.",
@@ -940,7 +939,7 @@
       "step5": "Review and correct the candidate translation in the workspace, then re-evaluate or lock the chunk.",
       "step6": "Export in .txt, .md, .html, .docx, or bilingual .md for publication or external review.",
       "p3": "Provider and model are independent for every stage and for the judge: you can mix a fast model for translation with a stronger one for refine or audit, or stay fully local with Ollama.",
-      "nav": "Navigation: the breadcrumb at the top (Glossa // workspace // project) returns to home when you click the workspace. On the left there is a single bar: on the home it lists areas and workspaces (edit and delete of the active workspace live on its row); inside a project it holds Run, Pipeline, Document, Insight and Chunk. Run/Pipeline/Document open inside the bar; Insight, Chunk and the pipeline configuration open in a second panel alongside. Every bar resizes by dragging its right edge and collapses to icons."
+      "nav": "Navigation: the breadcrumb at the top (Glossa // workspace // project) returns to home when you click the workspace. On the left there is a single bar: on the home it lists areas and workspaces (edit and delete of the active workspace live on its row); inside a project it holds Run, Pipeline, Document, Insight and Chunk. Run/Pipeline/Document open inside the bar; Insight, Chunk and the pipeline configuration open in a second panel alongside. Every bar resizes by dragging its right edge and collapses to icons; the edge is keyboard-reachable too (←/→ to resize, double-click to reset the width) and the project entries are navigable with the arrow keys. Loading a document keeps the view full: the Chunk panel opens only when you call it."
     },
     "pipeline": {
       "title": "Translation pipeline",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -50,8 +50,7 @@
     "chunkTab": "Chunk",
     "resizeRail": "Ridimensiona la barra",
     "resizePanel": "Ridimensiona il pannello",
-    "noDocumentHint": "Importa un documento sorgente per abilitare controlli lettura, export e pannelli sincronizzati.",
-    "insightHint": "Apri il pannello insight e vai direttamente a indice, ricerca, statistiche, coerenza o glossario."
+    "noDocumentHint": "Importa un documento sorgente per abilitare controlli lettura, export e pannelli sincronizzati."
   },
   "a11y": {
     "runStarted": "Esecuzione della pipeline avviata.",
@@ -940,7 +939,7 @@
       "step5": "Rivedi e correggi la traduzione candidata nel workspace, poi rivaluta o blocca il chunk come definitivo.",
       "step6": "Esporti in .txt, .md, .html, .docx o .md bilingue per pubblicazione o revisione esterna.",
       "p3": "Provider e modello sono indipendenti per ogni stage e per il giudice: puoi mescolare un modello veloce per la traduzione e uno più potente per refine o audit, oppure restare in locale con Ollama.",
-      "nav": "Navigazione: in alto il breadcrumb (Glossa // workspace // progetto) riporta alla home cliccando sul workspace. A sinistra c'è un'unica barra: nella home elenca aree e workspace (modifica ed elimina del workspace attivo sono sulla sua riga); nel progetto contiene Run, Pipeline, Documento, Insight e Chunk. Run/Pipeline/Documento si aprono dentro la barra; Insight, Chunk e la configurazione pipeline escono in un secondo pannello a fianco. Tutte le barre si ridimensionano trascinando il bordo destro e si riducono a sole icone."
+      "nav": "Navigazione: in alto il breadcrumb (Glossa // workspace // progetto) riporta alla home cliccando sul workspace. A sinistra c'è un'unica barra: nella home elenca aree e workspace (modifica ed elimina del workspace attivo sono sulla sua riga); nel progetto contiene Run, Pipeline, Documento, Insight e Chunk. Run/Pipeline/Documento si aprono dentro la barra; Insight, Chunk e la configurazione pipeline escono in un secondo pannello a fianco. Tutte le barre si ridimensionano trascinando il bordo destro e si riducono a sole icone; il bordo è anche raggiungibile da tastiera (←/→ per ridimensionare, doppio click per ripristinare la larghezza) e le voci del progetto si scorrono con le frecce. Caricando un documento la vista resta piena: il pannello Chunk si apre solo quando lo richiami."
     },
     "pipeline": {
       "title": "Pipeline di traduzione",

--- a/src/stores/chunksStore.test.ts
+++ b/src/stores/chunksStore.test.ts
@@ -77,6 +77,18 @@ describe('chunksStore', () => {
     expect(useUiStore.getState().selectedChunkId).toBe(useChunksStore.getState().chunks[0].id);
   });
 
+  it('does not auto-open the chunk drawer when loading a document', () => {
+    useUiStore.setState({ showChunkDrawer: false });
+
+    useChunksStore.getState().loadDocument('Alpha.\n\nBeta.\n\nGamma.', {
+      useChunking: true,
+      targetWordsPerChunk: 1,
+    });
+
+    // Il layout di lettura resta pieno: nessuno spostamento automatico.
+    expect(useUiStore.getState().showChunkDrawer).toBe(false);
+  });
+
   it('marks existing translation stale when editing source text', () => {
     usePipelineStore.getState().setInputText('Original');
     useChunksStore.getState().generateChunks();

--- a/src/stores/chunksStore.ts
+++ b/src/stores/chunksStore.ts
@@ -220,7 +220,8 @@ export const useChunksStore = create<ChunksState>((set, get) => ({
       renderProfile: sourceDocument.renderProfile,
     });
     ui.setViewMode('document');
-    ui.setShowChunkDrawer(true);
+    // Niente auto-apertura del Chunk drawer: con la shell multibar spingerebbe il documento.
+    // Il pannello Chunk si apre solo su azione esplicita (click su chunk/problema o rail).
     syncSelectedChunk(chunks);
     set({ chunks });
   },

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -160,6 +160,32 @@ describe('uiStore project shell state', () => {
 
     expect(useUiStore.getState().activeProjectPanel).toBe('chunk');
   });
+
+  it('restores the manually expanded bar after closing the insight fly-out', () => {
+    // L'utente tiene la barra espansa (stato di default).
+    expect(useUiStore.getState().projectContextUserExpanded).toBe(true);
+
+    // Aprendo Insight la barra si comprime, ma la preferenza utente resta "espansa".
+    useUiStore.getState().setActiveProjectPanel('insight');
+    expect(useUiStore.getState().projectContextCollapsed).toBe(true);
+    expect(useUiStore.getState().projectContextUserExpanded).toBe(true);
+
+    // Chiudendo il fly-out (ritorno a un pannello inline) la barra torna espansa.
+    useUiStore.getState().setActiveProjectPanel('document');
+    expect(useUiStore.getState().projectContextCollapsed).toBe(false);
+  });
+
+  it('keeps the bar collapsed after closing the fly-out when the user collapsed it on purpose', () => {
+    // L'utente comprime la barra esplicitamente.
+    useUiStore.getState().setProjectContextCollapsed(true);
+    expect(useUiStore.getState().projectContextUserExpanded).toBe(false);
+
+    useUiStore.getState().setShowDocumentDrawer(true);
+    useUiStore.getState().setShowDocumentDrawer(false);
+
+    // La preferenza "collassata" viene rispettata anche dopo il fly-out.
+    expect(useUiStore.getState().projectContextCollapsed).toBe(true);
+  });
 });
 
 describe('uiStore uiFont preference', () => {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -53,6 +53,8 @@ interface UiState {
   activePanel: ActivePanel;
   activeProjectPanel: ProjectPanelTab;
   projectContextCollapsed: boolean;
+  /** Scelta esplicita dell'utente: la barra primaria deve tornare espansa alla chiusura del fly-out? */
+  projectContextUserExpanded: boolean;
   dashboardSidebarCollapsed: boolean;
   dashboardSidebarWidth: number;
   projectSidebarWidth: number;
@@ -134,6 +136,7 @@ export const useUiStore = create<UiState>()(
       activePanel: null,
       activeProjectPanel: 'run',
       projectContextCollapsed: false,
+      projectContextUserExpanded: true,
       dashboardSidebarCollapsed: false,
       dashboardSidebarWidth: 240,
       projectSidebarWidth: 240,
@@ -219,7 +222,7 @@ export const useUiStore = create<UiState>()(
                 activeProjectPanel: 'insight' as const,
                 projectContextCollapsed: true,
               }
-            : { showDocumentDrawer: false, activePanel: null },
+            : { showDocumentDrawer: false, activePanel: null, projectContextCollapsed: !state.projectContextUserExpanded },
         ),
       setDocumentDrawerTab: (tab) => set({ documentDrawerTab: tab }),
       setShowChunkDrawer: (show, tab) =>
@@ -236,7 +239,7 @@ export const useUiStore = create<UiState>()(
                 activeProjectPanel: 'chunk' as const,
                 projectContextCollapsed: true,
               }
-            : { showChunkDrawer: false, activePanel: null },
+            : { showChunkDrawer: false, activePanel: null, projectContextCollapsed: !state.projectContextUserExpanded },
         ),
       setChunkDrawerTab: (tab) => set({ chunkDrawerTab: tab }),
       setHighlightsEnabled: (enabled) => set({ highlightsEnabled: enabled }),
@@ -288,15 +291,19 @@ export const useUiStore = create<UiState>()(
             };
           }
           // run / pipeline / document → contenuto inline, fly-out chiuso.
+          // Ripristina la preferenza manuale di espansione (il fly-out l'aveva forzata a collassata).
           return {
             activeProjectPanel: panel,
             showDocumentDrawer: false,
             showChunkDrawer: false,
             showConfigDrawer: false,
+            projectContextCollapsed: !state.projectContextUserExpanded,
             activePanel: state.activePanel === 'insights' || state.activePanel === 'chunk' || state.activePanel === 'config' ? null : state.activePanel,
           };
         }),
-      setProjectContextCollapsed: (collapsed) => set({ projectContextCollapsed: collapsed }),
+      // Collassare/espandere dal rail o dal resize è una scelta esplicita: memorizzala come preferenza.
+      setProjectContextCollapsed: (collapsed) =>
+        set({ projectContextCollapsed: collapsed, projectContextUserExpanded: !collapsed }),
       setDashboardSidebarCollapsed: (collapsed) => set({ dashboardSidebarCollapsed: collapsed }),
       setDashboardSidebarWidth: (width) => set({ dashboardSidebarWidth: width }),
       setProjectSidebarWidth: (width) => set({ projectSidebarWidth: width }),
@@ -346,7 +353,7 @@ export const useUiStore = create<UiState>()(
     }),
     {
       name: 'glossa-ui-prefs',
-      version: 10,
+      version: 11,
       migrate: (persisted: unknown, fromVersion: number) => {
         const s = persisted as Record<string, unknown>;
         if (fromVersion < 1) {
@@ -400,6 +407,10 @@ export const useUiStore = create<UiState>()(
           s.projectFlyoutWidth = 430;
           s.configFlyoutWidth = 560;
         }
+        if (fromVersion < 11) {
+          // La preferenza di espansione deriva dallo stato collassato salvato.
+          s.projectContextUserExpanded = !s.projectContextCollapsed;
+        }
         return s;
       },
       storage: createJSONStorage(() => localStorage),
@@ -412,6 +423,7 @@ export const useUiStore = create<UiState>()(
           ? state.activeProjectPanel
           : 'run',
         projectContextCollapsed: state.projectContextCollapsed,
+        projectContextUserExpanded: state.projectContextUserExpanded,
         dashboardSidebarCollapsed: state.dashboardSidebarCollapsed,
         dashboardSidebarWidth: state.dashboardSidebarWidth,
         projectSidebarWidth: state.projectSidebarWidth,


### PR DESCRIPTION
## Contesto
Chiude l'**ultima issue aperta** della milestone **v1.0 stable** (#272): le 9 rifiniture di stile/usabilità rimaste dopo il refactor della shell multibar (#271). Dopo il merge la milestone è a 0 issue aperte.

## Modifiche (i 9 task di #272)
1. **A11y tastiera rail** — `PipelineSidebar`/`ShellNav`: roving tabindex (0 attivo / -1 altri), frecce ↑/↓/←/→ + Home/End, attivazione manuale Enter/Space (non apre i fly-out scorrendo), `aria-orientation="vertical"`. Pattern di `InsightsDrawer`.
2. **Resize accessibile** — `useEdgeResize`/`ResizeHandle`: tabbabile, `aria-valuenow/min/max`, ←/→ a step 16px, Home/End a min/max, **doppio click = reset** (rail 240 / flyout 430 / config 560).
3. **Auto-collapse non distruttivo** — `uiStore.projectContextUserExpanded`: la barra torna allo stato scelto dall'utente alla chiusura del fly-out. Persist **v10→v11** + migration.
4. **Niente auto-apertura Chunk al load** — `chunksStore.loadDocument`: il layout di lettura resta pieno.
5. **Overlay responsive** — `hooks/useViewportWidth.ts`: sotto 1100px `ProjectFlyout`/`ConfigDrawer` passano da push a overlay sopra il documento.
6. **Sweep tipografia** — caption fuori ladder in `SettingsModal`/`HelpGuide` → `text-[11px] tracking-[0.16em]`.
7. **Token di motion** — `components/layout/motion.ts`: `SPRING_PANEL`, `EASE_EDITORIAL`, `WIDTH_TRANSITION_CLASS`.
8. **Affordance resize** — grip sottile **sempre visibile**, accentuato in hover/drag.
9. **Pulizia i18n** — rimossa la chiave orfana `projectShell.insightHint` (it+en).

## Note
- La tracking proibita (`tracking-[0.35em]` ecc.) è ancora presente in ~40 file (pipeline/document/library): **fuori scope #272** per rischio di regressione visiva → candidata a issue follow-up.

## Test plan
- [x] `npm run lint` (tsc --noEmit) pulito
- [x] `npm test` — **500 test verdi** (+9 nuovi: uiStore restore, chunksStore no-auto-open, rail roving/frecce/End, ResizeHandle aria/step/clamp/reset)
- [ ] Verifica a video in `tauri dev`: feel drag + resize tastiera, doppio click reset, overlay su finestra stretta, grip sempre visibile (non verificabile headless)

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)