### PR TITLE
chore: release 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "bump-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "✨ Features" },
         { "type": "fix", "section": "🐛 Bug Fixes" },


### PR DESCRIPTION
Promuove Glossa alla **1.0 stabile**: la milestone v1.0 è a 0 issue aperte dopo #272.

- Rimuove `bump-minor-pre-major` da `release-please-config.json` (non più necessario con major ≥ 1).
- Il footer `Release-As: 1.0.0` forza release-please a generare la release **1.0.0** al posto della 0.12.0 pending (#270).

Al merge: release-please rigenera la PR di release come `release glossa 1.0.0`; mergiandola, `release.yml` tagga `glossa-v1.0.0` e builda i bundle Tauri.