### PR TITLE
feat(#283): Library area — glossari, phrase memory e template per workspace

### DIFF
--- a/docs-dev/ARCHITECTURE.md
+++ b/docs-dev/ARCHITECTURE.md
@@ -70,9 +70,11 @@
 | `components/pipeline/PipelineActions.tsx` | Run / Cancel / Audit buttons |
 | `components/pipeline/StageCard.tsx` | Visualizza singolo stage (token, retry info) |
 | `components/document/ConfigDrawer.tsx` | Drawer config pipeline: mode, lingue, stage, persona, glossary |
-| `components/layout/Header.tsx` | Breadcrumb navigazione + azioni globali (Salva, Libreria, Lingua) |
-| `components/workspace/WorkspaceHome.tsx` | Dashboard workspace: switch/create/config workspace, progetti, configurazione extractor Phrase Memory |
+| `components/layout/Header.tsx` | Breadcrumb navigazione + azioni globali (Salva, Libreria, Lingua). Il pulsante Libreria chiama `closeProject()` + `setActiveWorkspaceArea('library')` → naviga alla LibraryArea senza aprire modal. |
+| `components/workspace/WorkspaceHome.tsx` | Dashboard workspace: hub card per le aree (Traduzioni, Biblioteca, Trascrizioni), switch/create/config workspace, progetti recenti, configurazione extractor Phrase Memory |
 | `components/workspace/WorkspaceWizard.tsx` | Primo avvio: crea il primo workspace reale |
+| `components/workspace/TranslationsArea.tsx` | Area Traduzioni: lista progetti, creazione, ordinamento, eliminazione |
+| `components/workspace/LibraryArea.tsx` | Area Biblioteca: hub interno con tre sezioni (`LibrarySection = 'glossaries' \| 'memories' \| 'templates' \| null`). Il back arrow torna all'hub Biblioteca; il secondo livello torna al workspace hub (`setActiveWorkspaceArea(null)`). Render: `activeSection === null` → SectionCard grid; `'glossaries'` → `DictionariesTab`; `'memories'` → `MemoriesTab`; `'templates'` → `PromptTemplatesTab`. |
 | `components/document/AnnotationContextMenu.tsx` | Menu contestuale (clic destro sul testo della traduzione) → «Aggiungi annotazione» con anchor pre-compilato |
 | `utils/annotationMarkdown.ts` | `composeAnnotatedMarkdown()` — compone vista GFM con marcatori `[^a1]` e definizioni a piè di pagina; non modifica il draft salvato |
 
@@ -89,6 +91,21 @@ Glossa 2.0 separa tre livelli:
 | Pipeline/progetto | `ConfigDrawer` | Lingue, persona, stage, prompt, glossario assegnato, toggle/search Phrase Memory |
 
 Il workspace attuale è specifico per l'area **Traduzioni**. Biblioteca e Trascrizioni sono future macro-aree separate; non devono condividere implicitamente la Phrase Memory delle traduzioni.
+
+### Workspace areas (routing)
+
+`uiStore.activeWorkspaceArea` (`'translations' | 'library' | 'transcriptions' | null`) controlla quale area viene renderizzata al posto del workspace hub (`WorkspaceHome`):
+
+| Valore | Componente renderizzato |
+|---|---|
+| `null` | `WorkspaceHome` (hub con card per ogni area) |
+| `'translations'` | `TranslationsArea` |
+| `'library'` | `LibraryArea` |
+| `'transcriptions'` | (area futura, non implementata) |
+
+Navigazione in entrata: clic su una hub card in `WorkspaceHome` → `setActiveWorkspaceArea(area)`. Il pulsante Libreria in `Header.tsx` chiama `closeProject()` poi `setActiveWorkspaceArea('library')` per raggiungere la libreria anche da dentro un progetto aperto.
+
+Navigazione in uscita: ogni area ha un back button che chiama `setActiveWorkspaceArea(null)` per tornare all'hub.
 
 ### Shell UI (multibar)
 
@@ -309,6 +326,7 @@ glossaries / glossary_entries / project_glossaries
 
 prompt_templates
   id, name, prompt, context ('stage'|'audit'|'persona'|'memory')
+  workflow ('translation'|'transcription')   ← filtra i template per area di workflow
   default_model, default_provider
 
 operation_logs

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,6 +10,7 @@ const sidebarIt = [
     items: [
       { text: 'Pipeline documento', link: '/guides/document-pipeline' },
       { text: 'Progetti e workspace', link: '/guides/projects-and-workspace' },
+      { text: 'Area Biblioteca', link: '/guides/library-area' },
       { text: 'Glossario e phrase memory', link: '/guides/glossary-and-memory' },
       { text: 'Phrase memory', link: '/guides/phrase-memory' },
       { text: 'Audit e revisione', link: '/guides/audit-review' },
@@ -43,6 +44,7 @@ const sidebarEn = [
     items: [
       { text: 'Document pipeline', link: '/en/guides/document-pipeline' },
       { text: 'Projects and workspace', link: '/en/guides/projects-and-workspace' },
+      { text: 'Library area', link: '/en/guides/library-area' },
       { text: 'Glossary and phrase memory', link: '/en/guides/glossary-and-memory' },
       { text: 'Phrase memory', link: '/en/guides/phrase-memory' },
       { text: 'Audit and review', link: '/en/guides/audit-review' },

--- a/docs/en/guides/library-area.md
+++ b/docs/en/guides/library-area.md
@@ -1,0 +1,56 @@
+---
+title: Library area
+---
+
+# Library area
+
+The Library is a workspace area that groups shared terminology resources and prompt templates across all projects.
+
+## How to open it
+
+- **From the workspace hub**: click the **Library** card on the main workspace screen.
+- **From the header (even inside an open project)**: click the Library icon (📚) in the top-right corner. Glossa closes the current project and navigates directly to the Library.
+
+## Sections
+
+### Dictionaries
+
+Contains reusable glossaries. From here you can:
+
+- Create a new dictionary with the **+** button
+- Rename a dictionary with a double-click
+- Duplicate it with **Fork**
+- Import terms from CSV/XLSX
+- Assign a dictionary to the current project session
+
+### Phrase Memory
+
+Shows the source-target pairs stored for the active workspace. Pairs are extracted automatically from approved outputs during pipeline runs.
+
+From the Memories section you can:
+
+- Search through stored pairs
+- Delete individual pairs or in bulk
+- **Export to CSV** all pairs for the current workspace using the **Export CSV** button
+
+### Prompt Templates
+
+Holds reusable prompt templates, filterable by context and workflow.
+
+**Workflow filter** — choose between **Translation** and **Transcription** to see only templates that belong to the current working area. Templates are assigned to a workflow at creation time.
+
+**Context filter** — further narrows the list by template type:
+
+| Context | Used in |
+|---|---|
+| Stage | Translation stages (Translate, Refine, Format) |
+| Audit | Judge prompt and Coherence prompt |
+| Persona | Persona section in the pipeline config |
+| Memory | Workspace phrase-memory extractor |
+
+## Internal navigation
+
+From the Library hub, click a card to enter a section. The breadcrumb at the top always lets you go back:
+
+- Inside a section → click the Library name → returns to the Library hub
+- In the Library hub → click the workspace name → returns to the workspace hub

--- a/docs/guides/library-area.md
+++ b/docs/guides/library-area.md
@@ -1,0 +1,56 @@
+---
+title: Area Biblioteca
+---
+
+# Area Biblioteca
+
+La Biblioteca è un'area del workspace che raccoglie le risorse terminologiche e i template condivisi tra tutti i progetti.
+
+## Come accedervi
+
+- **Dal workspace hub**: clicca la card **Biblioteca** nella schermata principale del workspace.
+- **Dall'header (anche dentro un progetto aperto)**: clicca l'icona Libreria (📚) in alto a destra. Glossa chiude il progetto corrente e porta direttamente alla Biblioteca.
+
+## Sezioni
+
+### Dizionari
+
+Contiene i glossari di termini. Puoi:
+
+- Creare un nuovo dizionario con il pulsante **+**
+- Rinominare un dizionario con doppio clic
+- Duplicarlo con **Crea copia**
+- Importare termini da CSV/XLSX
+- Assegnare un dizionario alla sessione corrente di progetto
+
+### Phrase Memory
+
+Mostra le coppie sorgente-target memorizzate per il workspace attivo. Le coppie vengono estratte automaticamente dagli output approvati durante i run.
+
+Dalla sezione Memorie puoi:
+
+- Cercare tra le coppie memorizzate
+- Eliminare coppie singole o in blocco
+- **Esportare in CSV** le coppie del workspace corrente con il pulsante **Esporta CSV**
+
+### Template di prompt
+
+Raccoglie i template di prompt riusabili, filtrabili per contesto e workflow.
+
+**Filtro workflow** — seleziona tra **Traduzione** e **Trascrizione** per vedere solo i template relativi all'area di lavoro corrente. I template vengono associati a un workflow alla creazione.
+
+**Filtro contesto** — restringe ulteriormente la lista per tipo di template:
+
+| Contesto | Usato in |
+|---|---|
+| Fase | Stage di traduzione (Translate, Refine, Format) |
+| Audit | Prompt Giudice e Prompt Coerenza |
+| Persona | Sezione Persona nella config pipeline |
+| Memory | Estrattore phrase memory del workspace |
+
+## Navigazione interna
+
+Dall'hub Biblioteca, clicca una card per entrare nella sezione. Il breadcrumb in alto riporta sempre alla schermata precedente:
+
+- Dentro una sezione → clic sul nome della Biblioteca → torna all'hub Biblioteca
+- Nell'hub Biblioteca → clic sul nome del workspace → torna al workspace hub

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useWorkspaceStore } from './stores/workspaceStore';
 import { WorkspaceWizard } from './components/workspace/WorkspaceWizard';
 import { WorkspaceHome } from './components/workspace/WorkspaceHome';
 import { TranslationsArea } from './components/workspace/TranslationsArea';
+import { LibraryArea } from './components/workspace/LibraryArea';
 import { WorkspaceSettingsModal } from './components/workspace/WorkspaceSettingsModal';
 import { importTextFile } from './services/fileService';
 import { savePipelineConfig } from './services/pipelineService';
@@ -499,11 +500,17 @@ export default function App() {
             <div className="relative flex min-w-0 flex-1">
               {activeWorkspaceArea === 'translations' ? (
                 <TranslationsArea />
+              ) : activeWorkspaceArea === 'library' ? (
+                <LibraryArea />
               ) : (
                 <WorkspaceHome />
               )}
               <PanelTransitionVeil
-                panelKey={activeWorkspaceArea === 'translations' ? 'area-translations' : `workspace-home-${activeWorkspace?.id ?? 'none'}`}
+                panelKey={
+                  activeWorkspaceArea === 'translations' ? 'area-translations'
+                  : activeWorkspaceArea === 'library' ? 'area-library'
+                  : `workspace-home-${activeWorkspace?.id ?? 'none'}`
+                }
                 tone="paper"
                 variant="workspace"
               />

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -602,6 +602,9 @@ function GlossarySection() {
       <SubTitle>{t('help.glossary.csvTitle')}</SubTitle>
       <P>{t('help.glossary.csvDesc')}</P>
 
+      <SubTitle>{t('help.glossary.memoryExportTitle')}</SubTitle>
+      <P>{t('help.glossary.memoryExportDesc')}</P>
+
       <SubTitle>{t('help.glossary.projectTitle')}</SubTitle>
       <P>{t('help.glossary.projectDesc')}</P>
 

--- a/src/components/layout/DashboardSidebar.test.tsx
+++ b/src/components/layout/DashboardSidebar.test.tsx
@@ -29,13 +29,13 @@ describe('DashboardSidebar', () => {
     useUiStore.setState({ activeWorkspaceArea: null });
   });
 
-  it('shows translations as the only enabled macroarea', () => {
+  it('shows translations and library as enabled macroareas, transcriptions as disabled', () => {
     // Set translations as the active area to verify aria-current is applied correctly.
     useUiStore.setState({ activeWorkspaceArea: 'translations' });
     render(<DashboardSidebar />);
 
     expect(screen.getByRole('button', { name: /workspace\.areas\.translations\.title/ })).toHaveAttribute('aria-current', 'page');
-    expect(screen.getByRole('button', { name: /workspace\.areas\.library\.title/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /workspace\.areas\.library\.title/ })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: /workspace\.areas\.transcriptions\.title/ })).toBeDisabled();
   });
 

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -18,7 +18,7 @@ import { EASE_EDITORIAL, WIDTH_TRANSITION_CLASS } from './motion';
 
 const AREA_ITEMS = [
   { id: 'translations', icon: BookOpenText, enabled: true },
-  { id: 'library', icon: LibraryBig, enabled: false },
+  { id: 'library', icon: LibraryBig, enabled: true },
   { id: 'transcriptions', icon: FilePen, enabled: false },
 ] as const;
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,10 +17,11 @@ const HelpGuide = lazy(() =>
 );
 
 export function Header() {
-  const { setShowHelp, showHelp } = useUiStore(
+  const { setShowHelp, showHelp, setActiveWorkspaceArea } = useUiStore(
     useShallow((state) => ({
       setShowHelp: state.setShowHelp,
       showHelp: state.showHelp,
+      setActiveWorkspaceArea: state.setActiveWorkspaceArea,
     })),
   );
   const { currentProjectId, currentProjectName, saveCurrentProject, closeProject } = useProjectStore(
@@ -32,11 +33,10 @@ export function Header() {
     })),
   );
   const activeWorkspace = useWorkspaceStore((state) => state.activeWorkspace);
-  const { dirtyIdsLength, saveAllDirty, setShowLibraryPanel } = useLibraryStore(
+  const { dirtyIdsLength, saveAllDirty } = useLibraryStore(
     useShallow((state) => ({
       dirtyIdsLength: state.dirtyIds.length,
       saveAllDirty: state.saveAllDirty,
-      setShowLibraryPanel: state.setShowLibraryPanel,
     })),
   );
   const isProcessing = useChunksStore((s) => s.isProcessing);
@@ -161,7 +161,10 @@ export function Header() {
             <Save size={16} />
           </IconButton>
           <IconButton
-            onClick={() => setShowLibraryPanel(true)}
+            onClick={() => {
+              closeProject();
+              setActiveWorkspaceArea('library');
+            }}
             title={t('library.openLibrary')}
             tooltipSide="bottom"
           >

--- a/src/components/library/MemoriesTab.tsx
+++ b/src/components/library/MemoriesTab.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { BookMarked, Brain, Check, Loader2, Pencil, RefreshCcw, Trash2, X } from 'lucide-react';
+import { BookMarked, Brain, Check, Download, Loader2, Pencil, RefreshCcw, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { save } from '@tauri-apps/plugin-dialog';
+import { writeTextFile } from '@tauri-apps/plugin-fs';
 import {
   deletePhraseMemoryEntry,
+  exportPhraseMemoryToCsv,
   getChunkPositions,
   listPhraseMemoryEntries,
   updatePhraseMemoryEntry,
@@ -35,6 +38,17 @@ export function MemoriesTab() {
   const [pickerOpenId, setPickerOpenId] = useState<string | null>(null);
   const [pickerGlossaryId, setPickerGlossaryId] = useState<string>('');
   const [addingId, setAddingId] = useState<string | null>(null);
+
+  const handleExportCsv = async () => {
+    const csvContent = exportPhraseMemoryToCsv(entries);
+    const path = await save({
+      filters: [{ name: 'CSV', extensions: ['csv'] }],
+      defaultPath: 'phrase-memory.csv',
+    });
+    if (path) {
+      await writeTextFile(path, csvContent);
+    }
+  };
 
   const loadEntries = useCallback(async () => {
     if (workspaces.length === 0) {
@@ -198,6 +212,14 @@ export function MemoriesTab() {
               ))}
             </select>
           </label>
+          <IconButton
+            size="md"
+            onClick={() => { void handleExportCsv(); }}
+            title={t('library.exportCsv')}
+            disabled={isLoading}
+          >
+            <Download size={14} />
+          </IconButton>
           <IconButton
             size="md"
             onClick={() => void loadEntries()}

--- a/src/components/library/MemoriesTab.tsx
+++ b/src/components/library/MemoriesTab.tsx
@@ -40,13 +40,19 @@ export function MemoriesTab() {
   const [addingId, setAddingId] = useState<string | null>(null);
 
   const handleExportCsv = async () => {
-    const csvContent = exportPhraseMemoryToCsv(entries);
-    const path = await save({
-      filters: [{ name: 'CSV', extensions: ['csv'] }],
-      defaultPath: 'phrase-memory.csv',
-    });
-    if (path) {
-      await writeTextFile(path, csvContent);
+    try {
+      const csvContent = exportPhraseMemoryToCsv(entries);
+      const path = await save({
+        filters: [{ name: 'CSV', extensions: ['csv'] }],
+        defaultPath: 'phrase-memory.csv',
+      });
+      if (path) {
+        await writeTextFile(path, csvContent);
+      }
+    } catch (err: unknown) {
+      toast.error(t('library.exportCsvError'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
     }
   };
 

--- a/src/components/library/PromptTemplatesTab.tsx
+++ b/src/components/library/PromptTemplatesTab.tsx
@@ -107,7 +107,7 @@ export function PromptTemplatesTab() {
   const handleSave = async () => {
     if (!newName.trim() || !newPrompt.trim()) return;
     try {
-      await saveTemplate(newName.trim(), newPrompt.trim(), newContext, refineModel, refineProvider);
+      await saveTemplate(newName.trim(), newPrompt.trim(), newContext, 'translation', refineModel, refineProvider);
       toast.success(t('pipeline.templates.saved'));
       setNewName('');
       setNewPrompt('');

--- a/src/components/library/PromptTemplatesTab.tsx
+++ b/src/components/library/PromptTemplatesTab.tsx
@@ -7,11 +7,14 @@ import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { useUiStore } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
 import { usePipelineStore } from '../../stores/pipelineStore';
-import type { ModelProvider, PromptTemplateContext } from '../../types';
+import type { ModelProvider, PromptTemplateContext, PromptTemplateWorkflow } from '../../types';
 import { llmService } from '../../services/llmService';
 import { getSelectableModelIds, MODEL_PROVIDER_ORDER } from '../../models/catalog';
 import { canRefineWithProvider, formatProviderModelLabel, useProviderKeyStatus } from '../../hooks/useProviderKeyStatus';
 import { IconButton } from '../ui';
+
+const WORKFLOW_OPTIONS = ['translation', 'transcription'] as const;
+type WorkflowFilter = (typeof WORKFLOW_OPTIONS)[number];
 
 const FILTER_OPTIONS = ['all', 'stage', 'audit', 'persona', 'memory'] as const;
 type FilterValue = (typeof FILTER_OPTIONS)[number];
@@ -34,6 +37,8 @@ export function PromptTemplatesTab() {
   const [newContext, setNewContext] = useState<PromptTemplateContext>('stage');
   const [creating, setCreating] = useState(false);
   const [filterContext, setFilterContext] = useState<FilterValue>('all');
+  const [filterWorkflow, setFilterWorkflow] = useState<WorkflowFilter>('translation');
+  const [newWorkflow, setNewWorkflow] = useState<PromptTemplateWorkflow>('translation');
   const [isRefining, setIsRefining] = useState(false);
   const { statuses: keyStatuses } = useProviderKeyStatus();
   const getProviderModels = (provider: ModelProvider) => getSelectableModelIds(provider, ollamaModels);
@@ -100,14 +105,16 @@ export function PromptTemplatesTab() {
     setRefineModel(stageDefaultModel);
   }, [newContext, auditDefaultProvider, auditDefaultModel, stageDefaultProvider, stageDefaultModel]);
 
-  const filtered = templates.filter(
-    (tmpl) => filterContext === 'all' || tmpl.context === filterContext,
-  );
+  const filtered = templates.filter((tmpl) => {
+    const matchesWorkflow = tmpl.workflow === filterWorkflow;
+    const matchesContext = filterContext === 'all' || tmpl.context === filterContext;
+    return matchesWorkflow && matchesContext;
+  });
 
   const handleSave = async () => {
     if (!newName.trim() || !newPrompt.trim()) return;
     try {
-      await saveTemplate(newName.trim(), newPrompt.trim(), newContext, 'translation', refineModel, refineProvider);
+      await saveTemplate(newName.trim(), newPrompt.trim(), newContext, newWorkflow, refineModel, refineProvider);
       toast.success(t('pipeline.templates.saved'));
       setNewName('');
       setNewPrompt('');
@@ -135,6 +142,24 @@ export function PromptTemplatesTab() {
 
   return (
     <div className="space-y-6">
+      {/* Workflow tabs */}
+      <div className="flex gap-1 rounded-full border border-editorial-border bg-editorial-bg/60 p-0.5 w-fit">
+        {WORKFLOW_OPTIONS.map((w) => (
+          <button
+            key={w}
+            type="button"
+            onClick={() => setFilterWorkflow(w)}
+            className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${
+              filterWorkflow === w
+                ? 'bg-editorial-paper text-editorial-ink shadow-sm'
+                : 'text-editorial-muted hover:text-editorial-ink'
+            }`}
+          >
+            {w === 'translation' ? t('workflow.translation') : t('workflow.transcription')}
+          </button>
+        ))}
+      </div>
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           {FILTER_OPTIONS.map((ctx) => {
@@ -168,7 +193,7 @@ export function PromptTemplatesTab() {
 
       {creating && (
         <div className="space-y-4 rounded-[20px] border border-editorial-border bg-editorial-textbox/15 p-5">
-          <div className="grid gap-3 sm:grid-cols-[2fr_1fr]">
+          <div className="grid gap-3 sm:grid-cols-[2fr_1fr_1fr]">
             <input
               autoFocus
               value={newName}
@@ -185,6 +210,17 @@ export function PromptTemplatesTab() {
               <option value="audit">{t('pipeline.tabAudit')}</option>
               <option value="persona">{t('pipeline.tabPersona')}</option>
               <option value="memory">{t('workspace.settings.memoryTab')}</option>
+            </select>
+            <select
+              value={newWorkflow}
+              onChange={(e) => setNewWorkflow(e.target.value as PromptTemplateWorkflow)}
+              className="rounded-[16px] border border-editorial-border bg-editorial-bg/80 px-3 py-2.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            >
+              {WORKFLOW_OPTIONS.map((w) => (
+                <option key={w} value={w}>
+                  {w === 'translation' ? t('workflow.translation') : t('workflow.transcription')}
+                </option>
+              ))}
             </select>
           </div>
           <p className="text-xs leading-relaxed text-editorial-muted">

--- a/src/components/pipeline/AuditPromptEditor.tsx
+++ b/src/components/pipeline/AuditPromptEditor.tsx
@@ -70,7 +70,7 @@ export function AuditPromptEditor({
     const name = templateName.trim();
     if (!name) return;
     try {
-      await saveTemplate(name, value, 'audit', defaultModel, defaultProvider);
+      await saveTemplate(name, value, 'audit', 'translation', defaultModel, defaultProvider);
       toast.success(t('pipeline.templates.saved'));
       setTemplateName('');
       setShowSaveName(false);

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -343,7 +343,7 @@ export function PipelineConfig({
             refineLabel={personaRefineLabel}
             onChange={(value) => setConfig((prev) => ({ ...prev, persona: value }))}
             onRefine={handleRefinePersona}
-            onSaveTemplate={(name, prompt) => saveTemplate(name, prompt, 'persona')}
+            onSaveTemplate={(name, prompt) => saveTemplate(name, prompt, 'persona', 'translation')}
             onDeleteTemplate={deleteTemplate}
           />
         </div>

--- a/src/components/pipeline/SettingsTabPanel.tsx
+++ b/src/components/pipeline/SettingsTabPanel.tsx
@@ -186,7 +186,7 @@ export function SettingsTabPanel({
         refineLabel={personaRefineLabel}
         onChange={(value) => setConfig((prev) => ({ ...prev, persona: value }))}
         onRefine={handleRefinePersona}
-        onSaveTemplate={(name, prompt) => saveTemplate(name, prompt, 'persona')}
+        onSaveTemplate={(name, prompt) => saveTemplate(name, prompt, 'persona', 'translation')}
         onDeleteTemplate={deleteTemplate}
       />
 

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import type { ModelProvider, OllamaStatus, PipelineStageConfig, PromptTemplate } from '../../types';
+import type { ModelProvider, OllamaStatus, PipelineStageConfig, PromptTemplate, PromptTemplateWorkflow } from '../../types';
 import { getKnownModelIds, getModelStatus, getResolvedModelReasoning, MODEL_PROVIDER_ORDER } from '../../models/catalog';
 import type { ReasoningEffortLevel } from '../../types';
 import { ModelCapabilityHint } from '../models/ModelCapabilityHint';
@@ -44,6 +44,7 @@ interface StageCardProps {
     name: string,
     prompt: string,
     context: 'stage' | 'audit',
+    workflow: PromptTemplateWorkflow,
     defaultModel?: string,
     defaultProvider?: string,
   ) => Promise<void>;
@@ -137,7 +138,7 @@ export function StageCard({
     const name = templateName.trim();
     if (!name) return;
     try {
-      await saveTemplate(name, stage.prompt, 'stage', stage.model, stage.provider);
+      await saveTemplate(name, stage.prompt, 'stage', 'translation', stage.model, stage.provider);
       toast.success(t('pipeline.templates.saved'));
       setTemplateName('');
       setShowSaveName(false);

--- a/src/components/workspace/LibraryArea.tsx
+++ b/src/components/workspace/LibraryArea.tsx
@@ -43,9 +43,9 @@ export function LibraryArea() {
   const [activeSection, setActiveSection] = useState<LibrarySection>(null);
 
   const sectionTitle =
-    activeSection === 'glossaries' ? t('library.tabs.dictionaries')
-    : activeSection === 'memories' ? t('library.tabs.memories')
-    : activeSection === 'templates' ? t('library.tabs.templates')
+    activeSection === 'glossaries' ? t('library.tabDictionaries')
+    : activeSection === 'memories' ? t('library.tabMemories')
+    : activeSection === 'templates' ? t('library.tabTemplates')
     : t('workspace.areas.library.title');
 
   return (
@@ -88,19 +88,19 @@ export function LibraryArea() {
           <div className="grid gap-3 sm:grid-cols-3">
             <SectionCard
               icon={BookMarked}
-              title={t('library.tabs.dictionaries')}
+              title={t('library.tabDictionaries')}
               body={t('workspace.libraryArea.glossariesBody')}
               onClick={() => setActiveSection('glossaries')}
             />
             <SectionCard
               icon={Brain}
-              title={t('library.tabs.memories')}
+              title={t('library.tabMemories')}
               body={t('workspace.libraryArea.memoriesBody')}
               onClick={() => setActiveSection('memories')}
             />
             <SectionCard
               icon={LibraryBig}
-              title={t('library.tabs.templates')}
+              title={t('library.tabTemplates')}
               body={t('workspace.libraryArea.templatesBody')}
               onClick={() => setActiveSection('templates')}
             />

--- a/src/components/workspace/LibraryArea.tsx
+++ b/src/components/workspace/LibraryArea.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { ArrowLeft, BookMarked, Brain, LibraryBig } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUiStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { DictionariesTab } from '../library/DictionariesTab';
+import { MemoriesTab } from '../library/MemoriesTab';
+import { PromptTemplatesTab } from '../library/PromptTemplatesTab';
+
+type LibrarySection = 'glossaries' | 'memories' | 'templates' | null;
+
+interface SectionCardProps {
+  icon: React.ComponentType<{ size?: number }>;
+  title: string;
+  body: string;
+  onClick: () => void;
+}
+
+function SectionCard({ icon: Icon, title, body, onClick }: SectionCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group rounded-[24px] border border-editorial-border bg-editorial-paper/75 px-5 py-4 text-left shadow-[var(--inset-highlight)] transition-colors hover:border-editorial-accent/45 hover:bg-editorial-paper focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+    >
+      <span className="flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-editorial-border bg-editorial-bg/85 text-editorial-muted transition-colors group-hover:border-editorial-accent/45 group-hover:text-editorial-accent">
+          <Icon size={16} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block font-display text-lg italic text-editorial-ink">{title}</span>
+          <span className="mt-1 block text-xs text-editorial-muted [text-wrap:pretty]">{body}</span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export function LibraryArea() {
+  const { t } = useTranslation();
+  const { activeWorkspace } = useWorkspaceStore();
+  const setActiveWorkspaceArea = useUiStore((s) => s.setActiveWorkspaceArea);
+  const [activeSection, setActiveSection] = useState<LibrarySection>(null);
+
+  const sectionTitle =
+    activeSection === 'glossaries' ? t('library.tabs.dictionaries')
+    : activeSection === 'memories' ? t('library.tabs.memories')
+    : activeSection === 'templates' ? t('library.tabs.templates')
+    : t('workspace.areas.library.title');
+
+  return (
+    <main className="flex flex-1 h-full min-h-0 flex-col overflow-y-auto bg-editorial-paper custom-scrollbar">
+      <div className="px-5 py-5 md:px-6 max-w-5xl">
+        {/* Back nav */}
+        <div className="mb-4">
+          {activeSection !== null ? (
+            <button
+              type="button"
+              onClick={() => setActiveSection(null)}
+              aria-label={t('workspace.libraryArea.backToLibrary')}
+              className="flex items-center gap-1.5 text-xs text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent rounded-md"
+            >
+              <ArrowLeft size={11} />
+              <span>{t('workspace.areas.library.title')}</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setActiveWorkspaceArea(null)}
+              aria-label={t('workspace.libraryArea.backLabel', { name: activeWorkspace?.name ?? '' })}
+              className="flex items-center gap-1.5 text-xs text-editorial-muted hover:text-editorial-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent rounded-md"
+            >
+              <ArrowLeft size={11} />
+              <span>{activeWorkspace?.name ?? t('workspace.noActive')}</span>
+            </button>
+          )}
+        </div>
+
+        {/* Header */}
+        <div className="mb-5">
+          <h1 className="font-display text-4xl italic text-editorial-ink md:text-5xl">
+            {sectionTitle}
+          </h1>
+        </div>
+
+        {/* Hub or section content */}
+        {activeSection === null ? (
+          <div className="grid gap-3 sm:grid-cols-3">
+            <SectionCard
+              icon={BookMarked}
+              title={t('library.tabs.dictionaries')}
+              body={t('workspace.libraryArea.glossariesBody')}
+              onClick={() => setActiveSection('glossaries')}
+            />
+            <SectionCard
+              icon={Brain}
+              title={t('library.tabs.memories')}
+              body={t('workspace.libraryArea.memoriesBody')}
+              onClick={() => setActiveSection('memories')}
+            />
+            <SectionCard
+              icon={LibraryBig}
+              title={t('library.tabs.templates')}
+              body={t('workspace.libraryArea.templatesBody')}
+              onClick={() => setActiveSection('templates')}
+            />
+          </div>
+        ) : activeSection === 'glossaries' ? (
+          <DictionariesTab />
+        ) : activeSection === 'memories' ? (
+          <MemoriesTab />
+        ) : (
+          <PromptTemplatesTab />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/workspace/MemoryExtractorSettings.tsx
+++ b/src/components/workspace/MemoryExtractorSettings.tsx
@@ -92,7 +92,7 @@ export function MemoryExtractorSettings({
     const name = templateName.trim();
     if (!name || !prompt.trim()) return;
     try {
-      await saveTemplate(name, prompt, 'memory', model, provider);
+      await saveTemplate(name, prompt, 'memory', 'translation', model, provider);
       setTemplateName('');
       setShowSaveName(false);
       toast.success(t('pipeline.templates.saved'));

--- a/src/components/workspace/WorkspaceHome.tsx
+++ b/src/components/workspace/WorkspaceHome.tsx
@@ -151,8 +151,26 @@ export function WorkspaceHome() {
               </span>
             </button>
 
-            {/* Library — locked */}
-            <LockedAreaCard area="library" />
+            {/* Library — active */}
+            <button
+              type="button"
+              onClick={() => setActiveWorkspaceArea('library')}
+              className="group rounded-[24px] border border-editorial-border bg-editorial-paper/75 px-5 py-4 text-left shadow-[var(--inset-highlight)] transition-colors hover:border-editorial-accent/45 hover:bg-editorial-paper focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            >
+              <span className="flex items-start gap-3">
+                <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-editorial-border bg-editorial-bg/85 text-editorial-muted transition-colors group-hover:border-editorial-accent/45 group-hover:text-editorial-accent">
+                  <LibraryBig size={16} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block font-display text-lg italic text-editorial-ink">
+                    {t('workspace.areas.library.title')}
+                  </span>
+                  <span className="mt-1 block text-xs text-editorial-muted [text-wrap:pretty]">
+                    {t('workspace.areas.library.body')}
+                  </span>
+                </span>
+              </span>
+            </button>
 
             {/* Transcriptions — locked */}
             <LockedAreaCard area="transcriptions" />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1526,5 +1526,9 @@
       "coverage": "Coverage ratio (translation / source)",
       "chunksProgress": "Completed segments"
     }
+  },
+  "workflow": {
+    "translation": "Translation",
+    "transcription": "Transcription"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1189,8 +1189,8 @@
       "thinkDesc": "Some Ollama models support an extended reasoning step before responding. In the Ollama section of Settings you can set the Think level: off, low, medium, or high. Higher levels can improve quality at the cost of time and tokens. Only enable it for models that explicitly support thinking — on standard models it has no effect."
     },
     "glossary": {
-      "title": "Library: dictionaries and templates",
-      "intro": "The Library is a global panel (library icon in the header) shared across all projects. It has two tabs: Dictionaries, where you manage reusable term→translation collections, and Prompt Templates, where you manage the global collection of prompt templates.",
+      "title": "Library area",
+      "intro": "The Library is a workspace area (library icon in the header, or the Library card on the hub screen) shared across all projects. It has three sections: Dictionaries (reusable term→translation collections), Memories (phrase-memory pairs for the workspace), and Prompt Templates (global templates for translation and transcription workflows).",
       "libraryTitle": "Global dictionaries",
       "libraryDesc": "In the Dictionaries tab you can create new dictionaries, rename them with double-click, duplicate (Fork), delete, import terms from CSV/TSV, and edit entries inline by expanding a dictionary. A dictionary can be assigned as the active glossary of the current project with the Assign button.",
       "csvTitle": "Import from CSV/TSV",
@@ -1203,8 +1203,10 @@
       "searchDesc": "The Search tab in the Insights panel lets you search for a word or phrase across all chunks at once — in the source text, translation, and audit findings. Each result shows a badge indicating where the match was found (source / translation / audit) and a snippet with the matched text in bold. Clicking a result jumps the workspace to that chunk, where the search term also appears highlighted in yellow.",
       "auditTitle": "Audit and glossary",
       "auditDesc": "The AI Judge explicitly checks adherence to the assigned dictionary and flags every deviation as a 'glossary' category issue, with severity and suggested fix. Particularly useful for technical, legal, or academic texts where terminology must remain stable.",
-      "templatesTitle": "Prompt templates",
-      "templatesDesc": "In the Prompt Templates tab of the Library you manage the global collection of templates, scoped by context: Stage (for translation, refine, format prompts), Audit (for judge and coherence), Persona (for system prompt openers). Create a template by setting name, context, and text; use the wand in the creation form to refine the text with an LLM. Saved templates are recallable via the bookmark buttons next to each matching prompt."
+      "templatesTitle": "Prompt templates and workflow filter",
+      "templatesDesc": "In the Prompt Templates tab of the Library you manage the global collection of templates, filterable by workflow (Translation or Transcription) and by context: Stage (translation, refine, format prompts), Audit (judge and coherence), Persona (system prompt openers), Memory (workspace phrase-memory extractor). The workflow filter isolates templates relevant to your current working area. Use the wand in the creation form to refine the text with an LLM. Saved templates are recallable via the bookmark buttons next to each matching prompt.",
+      "memoryExportTitle": "Export phrase memory to CSV",
+      "memoryExportDesc": "In the Memories section of the Library, the Export CSV button downloads all source-target pairs stored for the current workspace as a CSV file — useful for editorial review or backup."
     },
     "shortcuts": {
       "title": "Interface reference",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1347,7 +1347,8 @@
     "addToGlossary": "Add to glossary",
     "addedToGlossary": "Added to glossary",
     "addToGlossaryError": "Error adding to glossary",
-    "exportCsv": "Export CSV"
+    "exportCsv": "Export CSV",
+    "exportCsvError": "Failed to export CSV"
   },
   "stats": {
     "cacheHitRateHint": "Percentage of tokens served from the provider cache. Higher means lower cost.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -658,7 +658,7 @@
       },
       "library": {
         "title": "Library",
-        "body": "Future area for catalogues, texts, and study material, separated from translation memory.",
+        "body": "Glossaries, Phrase Memory and prompt templates for this workspace.",
         "sidebarHint": "Texts and catalogues"
       },
       "transcriptions": {
@@ -700,6 +700,13 @@
         "updatedAt": "Recent",
         "name": "Name"
       }
+    },
+    "libraryArea": {
+      "glossariesBody": "Term dictionaries with CSV and XLSX import/export.",
+      "memoriesBody": "Vector-embedded phrase pairs for this workspace.",
+      "templatesBody": "Prompt templates for translation and transcription workflows.",
+      "backLabel": "{{name}}",
+      "backToLibrary": "Library"
     },
     "hub": {
       "recentProjects": "Recent",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1344,7 +1344,8 @@
     "fromChunk": "Chunk",
     "addToGlossary": "Add to glossary",
     "addedToGlossary": "Added to glossary",
-    "addToGlossaryError": "Error adding to glossary"
+    "addToGlossaryError": "Error adding to glossary",
+    "exportCsv": "Export CSV"
   },
   "stats": {
     "cacheHitRateHint": "Percentage of tokens served from the provider cache. Higher means lower cost.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1189,8 +1189,8 @@
       "thinkDesc": "Alcuni modelli Ollama supportano un passaggio di ragionamento esteso prima di rispondere. Nella sezione Ollama delle Impostazioni puoi impostare il livello Think: off, basso, medio o alto. Un livello più alto può migliorare la qualità a costo di tempo e token. Abilitalo solo per modelli che supportano esplicitamente il thinking — su modelli standard non ha effetto."
     },
     "glossary": {
-      "title": "Libreria: dizionari e template",
-      "intro": "La Libreria è un pannello globale (icona libreria nell'header) condiviso tra tutti i progetti. Contiene due tab: Dizionari, dove gestisci raccolte riusabili di termine→traduzione, e Modelli Prompt, dove gestisci la collezione globale di template di prompt.",
+      "title": "Area Biblioteca",
+      "intro": "La Biblioteca è un'area del workspace (icona libreria nell'header o card nella schermata hub) condivisa tra tutti i progetti. Contiene tre sezioni: Dizionari (raccolte riusabili di termine→traduzione), Memorie (coppie phrase memory del workspace) e Modelli Prompt (template globali per pipeline e trascrizioni).",
       "libraryTitle": "Dizionari globali",
       "libraryDesc": "Nel tab Dizionari puoi creare nuovi dizionari, rinominarli con doppio clic, duplicarli (Crea copia), eliminarli, importare termini da CSV/TSV e modificare le voci inline espandendo il dizionario. Un dizionario può essere assegnato come glossario attivo del progetto corrente con il pulsante Assegna.",
       "csvTitle": "Importa da CSV/TSV",
@@ -1203,8 +1203,10 @@
       "searchDesc": "Il tab Cerca nel pannello Insight permette di cercare una parola o frase in tutti i chunk contemporaneamente: nel testo sorgente, nella traduzione e nei risultati dell'audit. Ogni risultato mostra un badge con il tipo di match (sorgente / traduzione / audit) e uno snippet con il testo evidenziato in grassetto. Cliccando un risultato il workspace si porta al chunk corrispondente, dove il termine cercato appare anche evidenziato in giallo nel testo.",
       "auditTitle": "Audit e glossario",
       "auditDesc": "Il Giudice AI verifica esplicitamente l'aderenza al dizionario assegnato e segnala come problema di categoria 'glossario' ogni deviazione, con severità e correzione suggerita. Particolarmente utile per testi tecnici, giuridici o accademici dove la terminologia deve essere stabile.",
-      "templatesTitle": "Modelli di prompt",
-      "templatesDesc": "Nel tab Modelli Prompt della Libreria gestisci la raccolta globale dei template, divisi per contesto: Stage (per prompt di traduzione, refine, format), Audit (per giudice e coerenza), Persona (per opener del system prompt). Crea un template specificando nome, contesto e testo; usa la bacchetta nella form di creazione per rifinire il testo con un modello LLM. I template salvati sono richiamabili nei pulsanti segnalibro accanto a ogni prompt corrispondente."
+      "templatesTitle": "Modelli di prompt e filtro workflow",
+      "templatesDesc": "Nel tab Modelli Prompt della Biblioteca gestisci la raccolta globale dei template, filtrabili per workflow (Traduzione o Trascrizione) e per contesto: Stage (prompt di traduzione, refine, format), Audit (giudice e coerenza), Persona (opener del system prompt), Memory (estrattore phrase memory). Il filtro workflow isola i template rilevanti per l'area di lavoro corrente. Usa la bacchetta nella form di creazione per rifinire il testo con un modello LLM. I template salvati sono richiamabili dai pulsanti segnalibro accanto a ogni prompt corrispondente.",
+      "memoryExportTitle": "Esporta phrase memory in CSV",
+      "memoryExportDesc": "Nella sezione Memorie della Biblioteca trovi il pulsante Esporta CSV: scarica tutte le coppie sorgente-target memorizzate per il workspace corrente in un file CSV, utile per revisioni editoriali o backup."
     },
     "shortcuts": {
       "title": "Riferimento interfaccia",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1344,7 +1344,8 @@
     "fromChunk": "Chunk",
     "addToGlossary": "Aggiungi a glossario",
     "addedToGlossary": "Aggiunto al glossario",
-    "addToGlossaryError": "Errore nell'aggiunta al glossario"
+    "addToGlossaryError": "Errore nell'aggiunta al glossario",
+    "exportCsv": "Esporta CSV"
   },
   "stats": {
     "cacheHitRateHint": "Percentuale di token serviti dalla cache del provider. Più è alta, minore il costo.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1347,7 +1347,8 @@
     "addToGlossary": "Aggiungi a glossario",
     "addedToGlossary": "Aggiunto al glossario",
     "addToGlossaryError": "Errore nell'aggiunta al glossario",
-    "exportCsv": "Esporta CSV"
+    "exportCsv": "Esporta CSV",
+    "exportCsvError": "Errore durante l'esportazione CSV"
   },
   "stats": {
     "cacheHitRateHint": "Percentuale di token serviti dalla cache del provider. Più è alta, minore il costo.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1526,5 +1526,9 @@
       "coverage": "Rapporto di copertura (traduzione / sorgente)",
       "chunksProgress": "Segmenti completati"
     }
+  },
+  "workflow": {
+    "translation": "Traduzione",
+    "transcription": "Trascrizione"
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -658,7 +658,7 @@
       },
       "library": {
         "title": "Biblioteca",
-        "body": "Area futura per catalogo, testi e materiali di studio, separata dalla memoria di traduzione.",
+        "body": "Glossari, Phrase Memory e template di prompt per questo workspace.",
         "sidebarHint": "Testi e catalogo"
       },
       "transcriptions": {
@@ -700,6 +700,13 @@
         "updatedAt": "Recenti",
         "name": "Nome"
       }
+    },
+    "libraryArea": {
+      "glossariesBody": "Dizionari di termini con import ed export CSV e XLSX.",
+      "memoriesBody": "Frasi memorizzate con embedding vettoriale per questo workspace.",
+      "templatesBody": "Template di prompt per i workflow di traduzione e trascrizione.",
+      "backLabel": "{{name}}",
+      "backToLibrary": "Biblioteca"
     },
     "hub": {
       "recentProjects": "Recenti",

--- a/src/services/__tests__/phraseMemoryService.export.test.ts
+++ b/src/services/__tests__/phraseMemoryService.export.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { exportPhraseMemoryToCsv } from '../phraseMemoryService';
+import type { PhraseMemoryEntry } from '../phraseMemoryService';
+
+const MOCK_ENTRIES: PhraseMemoryEntry[] = [
+  {
+    id: '1',
+    workspaceId: 'ws1',
+    sourcePhrase: 'Hello world',
+    targetPhrase: 'Ciao mondo',
+    confidence: 0.95,
+    sourceLanguage: 'en',
+    targetLanguage: 'it',
+    author: null,
+    work: null,
+    domain: 'general',
+    tags: null,
+    notes: null,
+    chunkId: null,
+    projectId: null,
+    embeddingModel: null,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+describe('exportPhraseMemoryToCsv', () => {
+  it('returns CSV string with header row', () => {
+    const csv = exportPhraseMemoryToCsv(MOCK_ENTRIES);
+    expect(csv).toContain('source_phrase');
+    expect(csv).toContain('target_phrase');
+  });
+
+  it('includes entry data', () => {
+    const csv = exportPhraseMemoryToCsv(MOCK_ENTRIES);
+    expect(csv).toContain('Hello world');
+    expect(csv).toContain('Ciao mondo');
+    expect(csv).toContain('0.95');
+  });
+
+  it('returns empty CSV with only headers for empty input', () => {
+    const csv = exportPhraseMemoryToCsv([]);
+    expect(csv).toContain('source_phrase');
+    expect(csv.split('\n').length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -71,6 +71,7 @@ const ALLOWED_MIGRATIONS = new Set([
   'translations.translation_processing_text',
   'translations.pipeline_id',
   'prompt_templates.context',
+  'prompt_templates.workflow',
   'translations.blob_id',
   'translations.blob_order',
   'translations.blob_reference_chunk_ids',
@@ -380,6 +381,7 @@ export async function initDatabase(): Promise<void> {
   `);
 
   await ensureColumn('prompt_templates', 'context', "TEXT NOT NULL DEFAULT 'stage'");
+  await ensureColumn('prompt_templates', 'workflow', "TEXT NOT NULL DEFAULT 'translation'");
   // Migrate unique index from (name) to (name, context) so stage/audit can share names
   await conn.execute('DROP INDEX IF EXISTS idx_prompt_templates_name');
   await conn.execute(`

--- a/src/services/phraseMemoryService.ts
+++ b/src/services/phraseMemoryService.ts
@@ -1,3 +1,4 @@
+import Papa from 'papaparse';
 import { invoke } from '@tauri-apps/api/core';
 import { select } from './dbService';
 import { logOperation } from '../stores/operationLogStore';
@@ -663,4 +664,29 @@ export async function getChunkPositions(chunkIds: string[]): Promise<Record<stri
     if (row.position !== null) map[row.id] = row.position;
   });
   return map;
+}
+
+const PHRASE_MEMORY_CSV_FIELDS = [
+  'source_phrase',
+  'target_phrase',
+  'confidence',
+  'source_language',
+  'target_language',
+  'domain',
+  'notes',
+  'created_at',
+] as const;
+
+export function exportPhraseMemoryToCsv(entries: PhraseMemoryEntry[]): string {
+  const rows = entries.map((e) => ({
+    source_phrase: e.sourcePhrase,
+    target_phrase: e.targetPhrase,
+    confidence: String(e.confidence),
+    source_language: e.sourceLanguage,
+    target_language: e.targetLanguage,
+    domain: e.domain ?? '',
+    notes: e.notes ?? '',
+    created_at: e.createdAt,
+  }));
+  return Papa.unparse({ fields: [...PHRASE_MEMORY_CSV_FIELDS], data: rows });
 }

--- a/src/services/promptTemplateService.test.ts
+++ b/src/services/promptTemplateService.test.ts
@@ -59,7 +59,7 @@ describe('promptTemplateService', () => {
 
   describe('savePromptTemplate', () => {
     it('inserts a new template with a generated id', async () => {
-      await savePromptTemplate({ name: 'My prompt', prompt: 'Translate carefully', context: 'stage' });
+      await savePromptTemplate({ name: 'My prompt', prompt: 'Translate carefully', context: 'stage', workflow: 'translation' });
 
       expect(dbMocks.execute).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO prompt_templates'),
@@ -68,7 +68,7 @@ describe('promptTemplateService', () => {
     });
 
     it('uses ON CONFLICT upsert on name+context collision', async () => {
-      await savePromptTemplate({ name: 'Existing', prompt: 'Updated content', context: 'stage' });
+      await savePromptTemplate({ name: 'Existing', prompt: 'Updated content', context: 'stage', workflow: 'translation' });
 
       expect(dbMocks.execute).toHaveBeenCalledWith(
         expect.stringContaining('ON CONFLICT(name, context) DO UPDATE SET'),
@@ -77,17 +77,17 @@ describe('promptTemplateService', () => {
     });
 
     it('returns void (does not return the id)', async () => {
-      const result = await savePromptTemplate({ name: 'Test', prompt: 'Test prompt', context: 'stage' });
+      const result = await savePromptTemplate({ name: 'Test', prompt: 'Test prompt', context: 'stage', workflow: 'translation' });
       expect(result).toBeUndefined();
     });
 
     it('stores empty strings for missing optional fields', async () => {
-      await savePromptTemplate({ name: 'Minimal', prompt: 'Min prompt', context: 'stage' });
+      await savePromptTemplate({ name: 'Minimal', prompt: 'Min prompt', context: 'stage', workflow: 'translation' });
 
       const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
-      // callArgs: [id, name, prompt, context, defaultModel, defaultProvider]
-      expect(callArgs[4]).toBe('');
+      // callArgs: [id, name, prompt, context, workflow, defaultModel, defaultProvider]
       expect(callArgs[5]).toBe('');
+      expect(callArgs[6]).toBe('');
     });
 
     it('stores provided model and provider', async () => {
@@ -95,13 +95,14 @@ describe('promptTemplateService', () => {
         name: 'Full',
         prompt: 'Full prompt',
         context: 'stage',
+        workflow: 'translation',
         defaultModel: 'claude-3-5-sonnet-latest',
         defaultProvider: 'anthropic',
       });
 
       const callArgs = dbMocks.execute.mock.calls[0][1] as unknown[];
-      expect(callArgs[4]).toBe('claude-3-5-sonnet-latest');
-      expect(callArgs[5]).toBe('anthropic');
+      expect(callArgs[5]).toBe('claude-3-5-sonnet-latest');
+      expect(callArgs[6]).toBe('anthropic');
     });
   });
 

--- a/src/services/promptTemplateService.ts
+++ b/src/services/promptTemplateService.ts
@@ -1,5 +1,5 @@
 import { select, execute } from './dbService';
-import type { PromptTemplate, PromptTemplateContext } from '../types';
+import type { PromptTemplate, PromptTemplateContext, PromptTemplateWorkflow } from '../types';
 import { generateId } from '../utils';
 
 interface TemplateRow {
@@ -7,6 +7,7 @@ interface TemplateRow {
   name: string;
   prompt: string;
   context: string;
+  workflow: string;
   default_model: string;
   default_provider: string;
   created_at: string;
@@ -17,11 +18,14 @@ function rowToTemplate(row: TemplateRow): PromptTemplate {
     row.context === 'audit' || row.context === 'persona' || row.context === 'memory'
       ? row.context
       : 'stage';
+  const workflow: PromptTemplateWorkflow =
+    row.workflow === 'transcription' ? 'transcription' : 'translation';
   return {
     id: row.id,
     name: row.name,
     prompt: row.prompt,
     context: ctx,
+    workflow,
     defaultModel: row.default_model || undefined,
     defaultProvider: row.default_provider || undefined,
     createdAt: row.created_at,
@@ -31,11 +35,11 @@ function rowToTemplate(row: TemplateRow): PromptTemplate {
 export async function getPromptTemplates(context?: PromptTemplateContext): Promise<PromptTemplate[]> {
   const rows = context
     ? await select<TemplateRow>(
-        'SELECT id, name, prompt, context, default_model, default_provider, created_at FROM prompt_templates WHERE context = $1 ORDER BY name ASC',
+        'SELECT id, name, prompt, context, workflow, default_model, default_provider, created_at FROM prompt_templates WHERE context = $1 ORDER BY name ASC',
         [context],
       )
     : await select<TemplateRow>(
-        'SELECT id, name, prompt, context, default_model, default_provider, created_at FROM prompt_templates ORDER BY name ASC',
+        'SELECT id, name, prompt, context, workflow, default_model, default_provider, created_at FROM prompt_templates ORDER BY name ASC',
       );
   return rows.map(rowToTemplate);
 }
@@ -45,14 +49,15 @@ export async function savePromptTemplate(
 ): Promise<void> {
   const id = generateId('tpl');
   await execute(
-    `INSERT INTO prompt_templates (id, name, prompt, context, default_model, default_provider)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO prompt_templates (id, name, prompt, context, workflow, default_model, default_provider)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
      ON CONFLICT(name, context) DO UPDATE SET
        prompt = excluded.prompt,
+       workflow = excluded.workflow,
        default_model = excluded.default_model,
        default_provider = excluded.default_provider,
        updated_at = CURRENT_TIMESTAMP`,
-    [id, input.name, input.prompt, input.context, input.defaultModel ?? '', input.defaultProvider ?? ''],
+    [id, input.name, input.prompt, input.context, input.workflow, input.defaultModel ?? '', input.defaultProvider ?? ''],
   );
 }
 

--- a/src/stores/promptTemplateStore.test.ts
+++ b/src/stores/promptTemplateStore.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/promptTemplateService', () => ({
+  getPromptTemplates: vi.fn().mockResolvedValue([]),
+  savePromptTemplate: vi.fn().mockResolvedValue(undefined),
+  deletePromptTemplate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { usePromptTemplateStore } from './promptTemplateStore';
+import { savePromptTemplate, getPromptTemplates } from '../services/promptTemplateService';
+
+const initial = usePromptTemplateStore.getState();
+
+beforeEach(() => {
+  usePromptTemplateStore.setState(initial, true);
+  vi.clearAllMocks();
+});
+
+describe('promptTemplateStore', () => {
+  it('saveTemplate passes workflow to service', async () => {
+    vi.mocked(getPromptTemplates).mockResolvedValue([]);
+    await usePromptTemplateStore.getState().saveTemplate(
+      'TestTemplate', 'prompt text', 'stage', 'transcription', undefined, undefined,
+    );
+    expect(savePromptTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow: 'transcription' }),
+    );
+  });
+
+  it('saveTemplate defaults workflow to translation', async () => {
+    vi.mocked(getPromptTemplates).mockResolvedValue([]);
+    await usePromptTemplateStore.getState().saveTemplate(
+      'T', 'p', 'stage', 'translation',
+    );
+    expect(savePromptTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow: 'translation' }),
+    );
+  });
+});

--- a/src/stores/promptTemplateStore.test.ts
+++ b/src/stores/promptTemplateStore.test.ts
@@ -27,7 +27,7 @@ describe('promptTemplateStore', () => {
     );
   });
 
-  it('saveTemplate defaults workflow to translation', async () => {
+  it("saveTemplate passes 'translation' workflow to service", async () => {
     vi.mocked(getPromptTemplates).mockResolvedValue([]);
     await usePromptTemplateStore.getState().saveTemplate(
       'T', 'p', 'stage', 'translation',

--- a/src/stores/promptTemplateStore.ts
+++ b/src/stores/promptTemplateStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { PromptTemplate, PromptTemplateContext } from '../types';
+import type { PromptTemplate, PromptTemplateContext, PromptTemplateWorkflow } from '../types';
 import {
   getPromptTemplates,
   savePromptTemplate,
@@ -10,6 +10,7 @@ export type SaveTemplateFn = (
   name: string,
   prompt: string,
   context: PromptTemplateContext,
+  workflow: PromptTemplateWorkflow,
   defaultModel?: string,
   defaultProvider?: string,
 ) => Promise<void>;
@@ -22,6 +23,7 @@ interface PromptTemplateState {
     name: string,
     prompt: string,
     context: PromptTemplateContext,
+    workflow: PromptTemplateWorkflow,
     defaultModel?: string,
     defaultProvider?: string,
   ) => Promise<void>;
@@ -38,8 +40,8 @@ export const usePromptTemplateStore = create<PromptTemplateState>((set, get) => 
     set({ templates, isLoaded: true });
   },
 
-  saveTemplate: async (name, prompt, context, defaultModel, defaultProvider) => {
-    await savePromptTemplate({ name, prompt, context, defaultModel, defaultProvider });
+  saveTemplate: async (name, prompt, context, workflow, defaultModel, defaultProvider) => {
+    await savePromptTemplate({ name, prompt, context, workflow, defaultModel, defaultProvider });
     const templates = await getPromptTemplates();
     set({ templates });
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,12 +164,14 @@ export interface ResponseInfo {
 }
 
 export type PromptTemplateContext = 'stage' | 'audit' | 'persona' | 'memory';
+export type PromptTemplateWorkflow = 'translation' | 'transcription';
 
 export interface PromptTemplate {
   id: string;
   name: string;
   prompt: string;
   context: PromptTemplateContext;
+  workflow: PromptTemplateWorkflow;
   defaultModel?: string;
   defaultProvider?: string;
   createdAt: string;


### PR DESCRIPTION
## Summary

- **Library area sbloccata** nel workspace hub e sidebar — navigabile via card o ShellNavItem
- **`LibraryArea` component** (`src/components/workspace/LibraryArea.tsx`): hub con 3 section card + routing interno (Glossari → DictionariesTab, Phrase Memory → MemoriesTab, Template → PromptTemplatesTab), doppio breadcrumb (sezione → hub → workspace)
- **`workflow` field** (`'translation' | 'transcription'`) aggiunto a `prompt_templates`: DB migration (`ensureColumn` + `ALLOWED_MIGRATIONS`), tipo `PromptTemplateWorkflow`, service, store, tutti i call site aggiornati
- **Filtro workflow** in `PromptTemplatesTab`: tab Traduzione / Trascrizione sopra il filtro contestuale esistente; creazione template con workflow selezionabile
- **CSV export Phrase Memory**: `exportPhraseMemoryToCsv` in `phraseMemoryService.ts`, pulsante Download in `MemoriesTab` con dialog Tauri + error handling
- **Header Library button** convertito: `closeProject()` + `setActiveWorkspaceArea('library')` — nessuna duplicazione con la Library area
- **Docs**: `ARCHITECTURE.md`, `docs/guides/library-area.md` (IT + EN), sidebar VitePress, `HelpGuide.tsx` + i18n help keys

## Closes

Closes #283

## Test plan

- [ ] Navigare al workspace hub → card Library cliccabile, porta a LibraryArea
- [ ] Sidebar → item Library abilitato e navigabile
- [ ] LibraryArea hub mostra 3 card (Glossari, Phrase Memory, Template)
- [ ] Ogni card apre la sezione corretta; breadcrumb "← Biblioteca" torna all'hub
- [ ] Breadcrumb "← [Workspace name]" torna al workspace hub
- [ ] DictionariesTab funzionante nell'area (crea, rinomina, elimina, import/export CSV+XLSX)
- [ ] MemoriesTab funzionante (lista, filtra per workspace, elimina, export CSV)
- [ ] PromptTemplatesTab: tab Traduzione / Trascrizione filtrano correttamente
- [ ] Creazione template con workflow Trascrizione → appare solo nel tab Trascrizione
- [ ] Header → pulsante Library naviga all'area (non apre più il pannello)
- [ ] Da progetto aperto: click Library chiude progetto e naviga all'area
- [ ] `npx vitest run` — 519/519 ✅
- [ ] `tsc --noEmit` — 0 errori ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)