### PR TITLE
docs(#291): allinea docs-dev alla shell nuova mergiata

### DIFF
--- a/docs-dev/ARCHITECTURE.md
+++ b/docs-dev/ARCHITECTURE.md
@@ -65,7 +65,7 @@
 
 | Componente | Responsabilità |
 |---|---|
-| `components/document/DocumentView.tsx` | Layout principale documento con barra navigazione fissa in alto (`h-16`): sinistra (indicatori stadi + minimap pallini frammenti), destra (frecce prev/next + contatore m/n). Due pannelli bianchi a filo (Originale/Candidata) con header titolo + separatore; controlli testo in menu unico a scomparsa (non barra sempre visibile) aperto da pulsante nell'header pagina. Shell nuova (#291). |
+| `components/document/DocumentView.tsx` | Layout principale documento con barra navigazione fissa in alto (`h-20`, allineata alle testate dei pannelli laterali): sinistra a due righe (indicatori stadi del frammento + minimap pallini frammenti), destra (frecce prev/next + contatore m/n). Due pannelli bianchi a filo (Originale/Candidata) con header titolo + separatore; controlli testo in menu unico a scomparsa (non barra sempre visibile) aperto da pulsante nell'header pagina. |
 | `components/layout/shell-next/ShellNext.tsx` | Layout tre colonne shell nuova (#291): `ProjectRailNext` sinistra (azioni + selettore pipeline + Esegui) · documento centro · `ProjectInspectorNext` destra (schede Approfondimenti/Frammento). Collasso e larghezze persistiti su uiStore. |
 | `components/layout/shell-next/ProjectRailNext.tsx` | Barra sinistra nuova: navigazione inline (Run/Pipeline/Document), azioni progetto, selettore pipeline, pulsante Esegui. Collasso riduce a icone. |
 | `components/layout/shell-next/ProjectInspectorNext.tsx` | Pannello destro collassabile: schede Approfondimenti (index/search/stats/glossary/coherence) e Frammento. |

--- a/docs-dev/UI_DESIGN_SYSTEM.md
+++ b/docs-dev/UI_DESIGN_SYSTEM.md
@@ -326,15 +326,16 @@ Regole:
 - Area nav: testi `workspace.areas.<id>.title` e `workspace.areas.<id>.sidebarHint`. Niente badge "Attiva".
 - Le aree future possono essere disabilitate ma mantengono forma e gerarchia.
 
-### Seconda barra (fly-out progetto)
+### Colonne progetto (shell #291)
 
-Nel progetto la barra primaria contiene la nav (`Run/Pipeline/Document/Insight/Chunk`) + back arrow in cima. I pannelli **inline** (Run, Pipeline, Document) vivono dentro la barra; i pannelli **ricchi** (Insight, Chunk, Config pipeline) escono in una **seconda barra push** (`ProjectFlyout`, `ConfigDrawer`) ancorata al bordo destro della barra, che spinge il documento. La larghezza è animata (`width 0 → N`), così l'apertura/chiusura è fluida e parte sempre dal bordo della barra.
+La vista progetto è a **tre colonne** (`ShellNext`, `react-resizable-panels`):
+- **Rail sinistro** (`ProjectRailNext`): azioni di progetto in cima (testata `h-20`) + selettore pipeline + comandi Esegui. Collassabile a icone.
+- **Centro**: documento (`DocumentView`).
+- **Ispettore destro** (`ProjectInspectorNext`, testata `h-20`): pannello collassabile con schede **Approfondimenti** (documento) e **Frammento** (chunk); si apre su `showDocumentDrawer`/`showChunkDrawer`.
 
-**Auto-collapse non distruttivo**: aprendo Insight/Chunk la barra primaria si comprime a icone, ma la preferenza manuale dell'utente è ricordata in `uiStore.projectContextUserExpanded`. Alla chiusura del fly-out (ritorno a un pannello inline) la barra ritorna allo stato scelto dall'utente. `setProjectContextCollapsed` registra la scelta come preferenza.
+Le tre testate condividono `h-20` → bordi superiori coincidenti. Larghezze e stato collassato sono persistiti in `uiStore` (`projectSidebarWidth`, `projectFlyoutWidth`, `projectContextCollapsed`/`projectContextUserExpanded`). `activeProjectPanel` (`run|pipeline|document|insight|chunk`) è la source-of-truth del rail. La **config pipeline** (`ConfigDrawer`) esce come **finestra modale**, non più come fly-out push/overlay. Dettagli in `ARCHITECTURE.md`.
 
-**Overlay su finestre strette**: sotto `FLYOUT_OVERLAY_BELOW` (1100px, `hooks/useViewportWidth.ts`) i fly-out passano da push a **overlay** (`position: absolute` con offset sinistro pari alla larghezza del rail + ombra), così il documento resta leggibile. Sopra soglia tornano push.
-
-**Caricamento documento**: `chunksStore.loadDocument` **non** apre il Chunk drawer (eviterebbe di spostare il layout di lettura); il pannello Chunk si apre solo su azione esplicita.
+**Caricamento documento**: `chunksStore.loadDocument` **non** apre il pannello Frammento (eviterebbe di spostare il layout di lettura); si apre solo su azione esplicita.
 
 ### Resize (drag + tastiera) — `useEdgeResize` + `ResizeHandle`
 


### PR DESCRIPTION
Allineamento della documentazione interna dopo il merge di #293 (shell nuova). Solo docs-dev, nessun cambio di codice.

## Cosa
- **ARCHITECTURE.md**: la riga di `DocumentView` indicava ancora la barra di navigazione a `h-16` → corretta a `h-20` (allineata alle testate dei pannelli laterali).
- **UI_DESIGN_SYSTEM.md**: la sezione "Seconda barra (fly-out progetto)" descriveva la shell vecchia (`ProjectFlyout` push/overlay, ora rimosso) → riscritta come "Colonne progetto (shell #291)": rail sinistro + documento + ispettore destro (`ShellNext`/`react-resizable-panels`), testate `h-20` coincidenti, config pipeline come finestra modale.

## Verificato up-to-date (nessuna modifica necessaria)
- **CLAUDE.md**: nessun riferimento alla shell/layout.
- **docs/ (VitePress pubbliche)**: descrivono workflow, non layout UI; nessun token stale.
- **Help in-app (it/en)**: già aggiornato in #293.

Nessun residuo di `useNewShell`/`Alt+N`/`ProjectFlyout`/`h-16` in CLAUDE.md, docs, docs-dev, i18n.