### PR TITLE
fix(#301): persistere il Riepilogo/Operazioni prima del primo salvataggio

### DIFF
--- a/src/stores/operationLogStore.test.ts
+++ b/src/stores/operationLogStore.test.ts
@@ -1,8 +1,20 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  saveOperationLogEntry: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/dbService', async () => {
+  const actual =
+    await vi.importActual<typeof import('../services/dbService')>('../services/dbService');
+  return { ...actual, ...dbMocks };
+});
+
 import { logOperation, useOperationLogStore } from './operationLogStore';
 
 beforeEach(() => {
-  useOperationLogStore.setState({ entries: [] });
+  useOperationLogStore.setState({ entries: [], currentProjectId: null });
+  dbMocks.saveOperationLogEntry.mockClear();
 });
 
 describe('operationLogStore', () => {
@@ -43,5 +55,36 @@ describe('operationLogStore', () => {
     expect(entry.durationMs).toBe(1234);
     expect(entry.detailKind).toBe('json');
     expect(entry.detail).toBe('{"foo":"bar"}');
+  });
+
+  it('backfills entries logged before the project had an id once it gets one', async () => {
+    logOperation({ level: 'info', scope: 'pipeline', message: 'run started' });
+    logOperation({ level: 'success', scope: 'stage', message: 'stage done' });
+    expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
+
+    useOperationLogStore.getState().setProjectId('proj-1');
+    await Promise.resolve();
+
+    expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledTimes(2);
+    expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledWith(
+      'proj-1',
+      expect.objectContaining({ message: 'run started' }),
+    );
+    expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledWith(
+      'proj-1',
+      expect.objectContaining({ message: 'stage done' }),
+    );
+  });
+
+  it('does not re-backfill already-persisted entries on a later setProjectId call', async () => {
+    useOperationLogStore.getState().setProjectId('proj-1');
+    logOperation({ level: 'info', scope: 'pipeline', message: 'already persisted' });
+    await Promise.resolve();
+    dbMocks.saveOperationLogEntry.mockClear();
+
+    useOperationLogStore.getState().setProjectId('proj-1');
+    await Promise.resolve();
+
+    expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
   });
 });

--- a/src/stores/operationLogStore.ts
+++ b/src/stores/operationLogStore.ts
@@ -51,7 +51,23 @@ export const useOperationLogStore = create<OperationLogState>((set, get) => ({
   entries: [],
   currentProjectId: null,
 
-  setProjectId: (id) => set({ currentProjectId: id }),
+  setProjectId: (id) => {
+    const previousProjectId = get().currentProjectId;
+    set({ currentProjectId: id });
+    // First save of a fresh project: entries logged while running without a
+    // saved project id yet were never persisted — backfill them now.
+    if (id && !previousProjectId) {
+      for (const entry of get().entries) {
+        void saveOperationLogEntry(id, entry as PersistedLogEntry).catch((error: unknown) => {
+          logger.warn('operationLog.backfill_failed', {
+            projectId: id,
+            entryId: entry.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+    }
+  },
 
   append: (entry) => {
     const full: OperationLogEntry = {


### PR DESCRIPTION
## Sommario
- Le voci della cronologia Operazioni generate mentre la pipeline gira su un progetto non ancora salvato restavano solo in memoria e sparivano al riavvio dell'app, anche dopo il primo salvataggio.
- Fix: quando il progetto ottiene il suo primo id (transizione da nessun progetto salvato a progetto salvato), le voci già in coda vengono ora scritte anche su disco.

## Test
- [x] Nuovi test: backfill sulla prima transizione, nessun doppio backfill sui salvataggi successivi
- [x] Suite frontend completa verde (547 test)
- [x] `tsc` pulito

Chiude #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)