### PR TITLE
fix(#304): scopare la cronologia Operazioni/statistiche per pipeline

### DIFF
--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -204,6 +204,7 @@ describe('initDatabase migrations', () => {
     dbState.columnsByTable.set('pipeline_configs', ['id', 'project_id', 'stages', 'judge_prompt', 'judge_model', 'judge_provider', 'use_chunking']);
     dbState.columnsByTable.set('translations', ['id', 'project_id', 'original_text', 'final_translation', 'stage_results', 'judge_issues', 'created_at']);
     dbState.columnsByTable.set('prompt_templates', []);
+    dbState.columnsByTable.set('operation_logs', []);
   });
 
   it('backs up and resets a beta database with an old schema version', async () => {
@@ -328,6 +329,90 @@ describe('initDatabase migrations', () => {
     );
     expect(dbState.db.execute).toHaveBeenCalledWith(
       expect.stringContaining("SET value = 'ws_default'"),
+    );
+  });
+
+  it('adds a pipeline_id column to operation_logs for existing databases', async () => {
+    const { initDatabase } = await import('./dbService');
+
+    await initDatabase();
+
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('ALTER TABLE operation_logs ADD COLUMN pipeline_id TEXT DEFAULT NULL'),
+    );
+  });
+
+  it('backfills pipeline_id on existing operation_logs rows the first time the column is added', async () => {
+    const { initDatabase } = await import('./dbService');
+
+    await initDatabase();
+
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE operation_logs'),
+    );
+  });
+
+  it('does not re-run the pipeline_id backfill once the column already exists', async () => {
+    dbState.columnsByTable.set('operation_logs', ['id', 'project_id', 'pipeline_id', 'at', 'level', 'scope', 'message']);
+    const { initDatabase } = await import('./dbService');
+
+    await initDatabase();
+
+    expect(dbState.db.execute).not.toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE operation_logs'),
+    );
+  });
+});
+
+describe('operation log pipeline scoping', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    dbState.setExistingObjects([]);
+    dbState.setSchemaVersion(null);
+    dbState.setWorkspaceCount(0);
+  });
+
+  it('scopes saveOperationLogEntry writes to project and pipeline', async () => {
+    const { saveOperationLogEntry } = await import('./dbService');
+
+    await saveOperationLogEntry('proj-1', 'pipe-1', {
+      id: 'op-1',
+      at: '2026-01-01T00:00:00.000Z',
+      level: 'info',
+      scope: 'pipeline',
+      message: 'hello',
+    });
+
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT OR IGNORE INTO operation_logs'),
+      ['op-1', 'proj-1', 'pipe-1', '2026-01-01T00:00:00.000Z', 'info', 'pipeline', 'hello', null, null, null, null, null, null, null],
+    );
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM operation_logs'),
+      ['proj-1', 'pipe-1', 2000],
+    );
+  });
+
+  it('scopes loadOperationLogs reads to project and pipeline', async () => {
+    const { loadOperationLogs } = await import('./dbService');
+
+    await loadOperationLogs('proj-1', 'pipe-1');
+
+    expect(dbState.db.select).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT * FROM operation_logs WHERE project_id = $1 AND pipeline_id = $2'),
+      ['proj-1', 'pipe-1'],
+    );
+  });
+
+  it('scopes clearOperationLogs deletes to project and pipeline', async () => {
+    const { clearOperationLogs } = await import('./dbService');
+
+    await clearOperationLogs('proj-1', 'pipe-1');
+
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      'DELETE FROM operation_logs WHERE project_id = $1 AND pipeline_id = $2',
+      ['proj-1', 'pipe-1'],
     );
   });
 });

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -78,6 +78,7 @@ const ALLOWED_MIGRATIONS = new Set([
   'operation_logs.phase',
   'operation_logs.duration_ms',
   'operation_logs.detail_kind',
+  'operation_logs.pipeline_id',
   'pipelines.pipeline_mode',
   'pipelines.use_chunking',
   'pipelines.words_per_chunk',
@@ -371,6 +372,30 @@ export async function initDatabase(): Promise<void> {
   await ensureColumn('operation_logs', 'phase', 'TEXT DEFAULT NULL');
   await ensureColumn('operation_logs', 'duration_ms', 'INTEGER DEFAULT NULL');
   await ensureColumn('operation_logs', 'detail_kind', 'TEXT DEFAULT NULL');
+
+  const operationLogColumns = await conn.select<Array<{ name: string }>>('PRAGMA table_info(operation_logs)');
+  const hadPipelineIdColumn = operationLogColumns.some((column) => column.name === 'pipeline_id');
+  await ensureColumn('operation_logs', 'pipeline_id', 'TEXT DEFAULT NULL');
+  if (!hadPipelineIdColumn) {
+    // One-time backfill: entries logged before pipeline scoping existed had no
+    // pipeline_id, which would otherwise make them invisible to the new scoped
+    // queries. Best-effort attribution to the project's oldest pipeline keeps
+    // pre-existing history visible instead of silently disappearing.
+    await conn.execute(`
+      UPDATE operation_logs
+      SET pipeline_id = (
+        SELECT id FROM pipelines
+        WHERE pipelines.project_id = operation_logs.project_id
+        ORDER BY created_at ASC
+        LIMIT 1
+      )
+      WHERE pipeline_id IS NULL
+    `);
+  }
+  await conn.execute(`
+    CREATE INDEX IF NOT EXISTS idx_operation_logs_pipeline_id
+    ON operation_logs(project_id, pipeline_id, at)
+  `);
 
   await conn.execute(`
     CREATE TABLE IF NOT EXISTS macro_blocks (
@@ -669,6 +694,7 @@ const VALID_DETAIL_KINDS = new Set(['prompt', 'json', 'error', 'note']);
 interface DbOperationLogRow {
   id: string;
   project_id: string;
+  pipeline_id: string;
   at: string;
   level: string;
   scope: string;
@@ -697,14 +723,19 @@ export interface PersistedLogEntry {
   detailKind?: string;
 }
 
-export async function saveOperationLogEntry(projectId: string, entry: PersistedLogEntry): Promise<void> {
+export async function saveOperationLogEntry(
+  projectId: string,
+  pipelineId: string,
+  entry: PersistedLogEntry,
+): Promise<void> {
   await execute(
     `INSERT OR IGNORE INTO operation_logs
-       (id, project_id, at, level, scope, message, chunk_id, stage_id, meta, detail, phase, duration_ms, detail_kind)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+       (id, project_id, pipeline_id, at, level, scope, message, chunk_id, stage_id, meta, detail, phase, duration_ms, detail_kind)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
     [
       entry.id,
       projectId,
+      pipelineId,
       entry.at,
       entry.level,
       entry.scope,
@@ -721,31 +752,35 @@ export async function saveOperationLogEntry(projectId: string, entry: PersistedL
   await execute(
     `DELETE FROM operation_logs
      WHERE project_id = $1
+       AND pipeline_id = $2
        AND id NOT IN (
          SELECT id FROM operation_logs
          WHERE project_id = $1
+           AND pipeline_id = $2
          ORDER BY at DESC
-         LIMIT $2
+         LIMIT $3
        )`,
-    [projectId, MAX_OPERATION_LOG_ENTRIES],
+    [projectId, pipelineId, MAX_OPERATION_LOG_ENTRIES],
   );
 }
 
-export async function loadOperationLogs(projectId: string): Promise<PersistedLogEntry[]> {
+export async function loadOperationLogs(projectId: string, pipelineId: string): Promise<PersistedLogEntry[]> {
   await execute(
     `DELETE FROM operation_logs
      WHERE project_id = $1
+       AND pipeline_id = $2
        AND id NOT IN (
          SELECT id FROM operation_logs
          WHERE project_id = $1
+           AND pipeline_id = $2
          ORDER BY at DESC
-         LIMIT $2
+         LIMIT $3
        )`,
-    [projectId, MAX_OPERATION_LOG_ENTRIES],
+    [projectId, pipelineId, MAX_OPERATION_LOG_ENTRIES],
   );
   const rows = await select<DbOperationLogRow>(
-    `SELECT * FROM operation_logs WHERE project_id = $1 ORDER BY at ASC`,
-    [projectId],
+    `SELECT * FROM operation_logs WHERE project_id = $1 AND pipeline_id = $2 ORDER BY at ASC`,
+    [projectId, pipelineId],
   );
   return rows.map((row) => ({
     id: row.id,
@@ -763,6 +798,6 @@ export async function loadOperationLogs(projectId: string): Promise<PersistedLog
   }));
 }
 
-export async function clearOperationLogs(projectId: string): Promise<void> {
-  await execute('DELETE FROM operation_logs WHERE project_id = $1', [projectId]);
+export async function clearOperationLogs(projectId: string, pipelineId: string): Promise<void> {
+  await execute('DELETE FROM operation_logs WHERE project_id = $1 AND pipeline_id = $2', [projectId, pipelineId]);
 }

--- a/src/services/pipelineService.test.ts
+++ b/src/services/pipelineService.test.ts
@@ -16,6 +16,7 @@ const {
   saveFullState,
   loadTranslations,
   restoreTranslations,
+  deletePipeline,
 } = await import('./pipelineService');
 
 const basePipelineRow = {
@@ -427,6 +428,18 @@ describe('pipelineService', () => {
       expect(restored[0]?.blobId).toBe('blob-1');
       expect(restored[0]?.blobOrder).toBe(2);
       expect(restored[0]?.blobReferenceChunkIds).toEqual(['chunk-0', 'chunk-1', 'chunk-2']);
+    });
+  });
+
+  // ── deletePipeline ───────────────────────────────────────────────────
+
+  describe('deletePipeline', () => {
+    it('deletes translations and operation logs before the pipeline row, since neither has an FK cascade', async () => {
+      await deletePipeline('pipeline-1');
+
+      expect(dbMocks.execute).toHaveBeenCalledWith('DELETE FROM translations WHERE pipeline_id = $1', ['pipeline-1']);
+      expect(dbMocks.execute).toHaveBeenCalledWith('DELETE FROM operation_logs WHERE pipeline_id = $1', ['pipeline-1']);
+      expect(dbMocks.execute).toHaveBeenCalledWith('DELETE FROM pipelines WHERE id = $1', ['pipeline-1']);
     });
   });
 });

--- a/src/services/pipelineService.ts
+++ b/src/services/pipelineService.ts
@@ -223,6 +223,7 @@ export async function duplicatePipeline(sourcePipelineId: string, newName: strin
 
 export async function deletePipeline(pipelineId: string): Promise<void> {
   await execute('DELETE FROM translations WHERE pipeline_id = $1', [pipelineId]);
+  await execute('DELETE FROM operation_logs WHERE pipeline_id = $1', [pipelineId]);
   await execute('DELETE FROM pipelines WHERE id = $1', [pipelineId]);
 }
 

--- a/src/stores/operationLogStore.test.ts
+++ b/src/stores/operationLogStore.test.ts
@@ -1,8 +1,24 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  saveOperationLogEntry: vi.fn().mockResolvedValue(undefined),
+  loadOperationLogs: vi.fn().mockResolvedValue([]),
+  clearOperationLogs: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/dbService', async () => {
+  const actual =
+    await vi.importActual<typeof import('../services/dbService')>('../services/dbService');
+  return { ...actual, ...dbMocks };
+});
+
 import { logOperation, useOperationLogStore } from './operationLogStore';
 
 beforeEach(() => {
-  useOperationLogStore.setState({ entries: [] });
+  useOperationLogStore.setState({ entries: [], currentProjectId: null, currentPipelineId: null });
+  dbMocks.saveOperationLogEntry.mockClear();
+  dbMocks.loadOperationLogs.mockClear().mockResolvedValue([]);
+  dbMocks.clearOperationLogs.mockClear();
 });
 
 describe('operationLogStore', () => {
@@ -43,5 +59,92 @@ describe('operationLogStore', () => {
     expect(entry.durationMs).toBe(1234);
     expect(entry.detailKind).toBe('json');
     expect(entry.detail).toBe('{"foo":"bar"}');
+  });
+
+  describe('persistence scoping (project + pipeline)', () => {
+    it('does not persist entries until both project and pipeline ids are known', () => {
+      logOperation({ level: 'info', scope: 'pipeline', message: 'no project yet' });
+      expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
+
+      useOperationLogStore.setState({ currentProjectId: 'proj-1' });
+      logOperation({ level: 'info', scope: 'pipeline', message: 'project but no pipeline' });
+      expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
+    });
+
+    it('persists new entries once both ids are set', () => {
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      logOperation({ level: 'info', scope: 'pipeline', message: 'run started' });
+
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledWith(
+        'proj-1',
+        'pipe-1',
+        expect.objectContaining({ message: 'run started' }),
+      );
+    });
+
+    it('backfills entries logged before the project/pipeline had ids once they are set', async () => {
+      logOperation({ level: 'info', scope: 'pipeline', message: 'run started' });
+      logOperation({ level: 'success', scope: 'stage', message: 'stage done' });
+      expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
+
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      await Promise.resolve();
+
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledTimes(2);
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledWith(
+        'proj-1',
+        'pipe-1',
+        expect.objectContaining({ message: 'run started' }),
+      );
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledWith(
+        'proj-1',
+        'pipe-1',
+        expect.objectContaining({ message: 'stage done' }),
+      );
+    });
+
+    it('does not re-backfill already-persisted entries on a later setContext call', async () => {
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      logOperation({ level: 'info', scope: 'pipeline', message: 'already persisted' });
+      await Promise.resolve();
+      dbMocks.saveOperationLogEntry.mockClear();
+
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      await Promise.resolve();
+
+      expect(dbMocks.saveOperationLogEntry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loadFromDb', () => {
+    it('loads entries scoped to the given project and pipeline', async () => {
+      dbMocks.loadOperationLogs.mockResolvedValueOnce([
+        { id: 'op-1', at: '2026-01-01T00:00:00.000Z', level: 'info', scope: 'pipeline', message: 'restored' },
+      ]);
+
+      await useOperationLogStore.getState().loadFromDb('proj-1', 'pipe-1');
+
+      expect(dbMocks.loadOperationLogs).toHaveBeenCalledWith('proj-1', 'pipe-1');
+      const state = useOperationLogStore.getState();
+      expect(state.currentProjectId).toBe('proj-1');
+      expect(state.currentPipelineId).toBe('pipe-1');
+      expect(state.entries).toHaveLength(1);
+      expect(state.entries[0].message).toBe('restored');
+    });
+  });
+
+  describe('clear', () => {
+    it('clears only the current project + pipeline scope in the db', () => {
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      useOperationLogStore.getState().clear();
+
+      expect(dbMocks.clearOperationLogs).toHaveBeenCalledWith('proj-1', 'pipe-1');
+      expect(useOperationLogStore.getState().entries).toEqual([]);
+    });
+
+    it('does not hit the db when no full context is set', () => {
+      useOperationLogStore.getState().clear();
+      expect(dbMocks.clearOperationLogs).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/stores/operationLogStore.test.ts
+++ b/src/stores/operationLogStore.test.ts
@@ -103,6 +103,30 @@ describe('operationLogStore', () => {
       );
     });
 
+    it('backfills entries sequentially rather than firing them all at once', async () => {
+      let resolveFirst: () => void = () => {};
+      const firstSave = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      dbMocks.saveOperationLogEntry.mockImplementationOnce(() => firstSave);
+
+      logOperation({ level: 'info', scope: 'pipeline', message: 'first' });
+      logOperation({ level: 'info', scope: 'pipeline', message: 'second' });
+
+      useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledTimes(1);
+
+      resolveFirst();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(dbMocks.saveOperationLogEntry).toHaveBeenCalledTimes(2);
+    });
+
     it('does not re-backfill already-persisted entries on a later setContext call', async () => {
       useOperationLogStore.getState().setContext('proj-1', 'pipe-1');
       logOperation({ level: 'info', scope: 'pipeline', message: 'already persisted' });

--- a/src/stores/operationLogStore.ts
+++ b/src/stores/operationLogStore.ts
@@ -38,9 +38,10 @@ export interface OperationLogEntry {
 interface OperationLogState {
   entries: OperationLogEntry[];
   currentProjectId: string | null;
-  setProjectId: (id: string | null) => void;
+  currentPipelineId: string | null;
+  setContext: (projectId: string | null, pipelineId: string | null) => void;
   append: (entry: Omit<OperationLogEntry, 'id' | 'at'>) => void;
-  loadFromDb: (projectId: string) => Promise<void>;
+  loadFromDb: (projectId: string, pipelineId: string) => Promise<void>;
   clearChunk: (chunkId: string) => void;
   clear: () => void;
 }
@@ -50,8 +51,30 @@ const MAX_ENTRIES = 2000;
 export const useOperationLogStore = create<OperationLogState>((set, get) => ({
   entries: [],
   currentProjectId: null,
+  currentPipelineId: null,
 
-  setProjectId: (id) => set({ currentProjectId: id }),
+  setContext: (projectId, pipelineId) => {
+    const { currentProjectId: previousProjectId, currentPipelineId: previousPipelineId } = get();
+    set({ currentProjectId: projectId, currentPipelineId: pipelineId });
+    const hadFullContext = Boolean(previousProjectId && previousPipelineId);
+    const hasFullContext = Boolean(projectId && pipelineId);
+    // First save of a fresh project/pipeline: entries logged while running
+    // without a saved id yet were never persisted — backfill them now.
+    if (hasFullContext && !hadFullContext) {
+      for (const entry of get().entries) {
+        void saveOperationLogEntry(projectId as string, pipelineId as string, entry as PersistedLogEntry).catch(
+          (error: unknown) => {
+            logger.warn('operationLog.backfill_failed', {
+              projectId,
+              pipelineId,
+              entryId: entry.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          },
+        );
+      }
+    }
+  },
 
   append: (entry) => {
     const full: OperationLogEntry = {
@@ -62,23 +85,27 @@ export const useOperationLogStore = create<OperationLogState>((set, get) => ({
     set((state) => ({
       entries: [...state.entries, full].slice(-MAX_ENTRIES),
     }));
-    const { currentProjectId } = get();
-    if (currentProjectId) {
-      void saveOperationLogEntry(currentProjectId, full as PersistedLogEntry).catch((error: unknown) => {
-        logger.warn('operationLog.persist_failed', {
-          projectId: currentProjectId,
-          entryId: full.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
+    const { currentProjectId, currentPipelineId } = get();
+    if (currentProjectId && currentPipelineId) {
+      void saveOperationLogEntry(currentProjectId, currentPipelineId, full as PersistedLogEntry).catch(
+        (error: unknown) => {
+          logger.warn('operationLog.persist_failed', {
+            projectId: currentProjectId,
+            pipelineId: currentPipelineId,
+            entryId: full.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+      );
     }
   },
 
-  loadFromDb: async (projectId) => {
-    const rows = await loadOperationLogs(projectId);
+  loadFromDb: async (projectId, pipelineId) => {
+    const rows = await loadOperationLogs(projectId, pipelineId);
     set({
       entries: rows as OperationLogEntry[],
       currentProjectId: projectId,
+      currentPipelineId: pipelineId,
     });
   },
 
@@ -89,12 +116,13 @@ export const useOperationLogStore = create<OperationLogState>((set, get) => ({
   },
 
   clear: () => {
-    const { currentProjectId } = get();
+    const { currentProjectId, currentPipelineId } = get();
     set({ entries: [] });
-    if (currentProjectId) {
-      void clearOperationLogs(currentProjectId).catch((error: unknown) => {
+    if (currentProjectId && currentPipelineId) {
+      void clearOperationLogs(currentProjectId, currentPipelineId).catch((error: unknown) => {
         logger.warn('operationLog.clear_failed', {
           projectId: currentProjectId,
+          pipelineId: currentPipelineId,
           error: error instanceof Error ? error.message : String(error),
         });
       });

--- a/src/stores/operationLogStore.ts
+++ b/src/stores/operationLogStore.ts
@@ -61,18 +61,24 @@ export const useOperationLogStore = create<OperationLogState>((set, get) => ({
     // First save of a fresh project/pipeline: entries logged while running
     // without a saved id yet were never persisted — backfill them now.
     if (hasFullContext && !hadFullContext) {
-      for (const entry of get().entries) {
-        void saveOperationLogEntry(projectId as string, pipelineId as string, entry as PersistedLogEntry).catch(
-          (error: unknown) => {
+      const entriesToBackfill = get().entries;
+      void (async () => {
+        // Sequential on purpose: up to MAX_ENTRIES saves, each already doing
+        // 2 serialized DB writes — firing them all concurrently would queue
+        // thousands of writes at once and stall the DB write queue.
+        for (const entry of entriesToBackfill) {
+          try {
+            await saveOperationLogEntry(projectId as string, pipelineId as string, entry as PersistedLogEntry);
+          } catch (error: unknown) {
             logger.warn('operationLog.backfill_failed', {
               projectId,
               pipelineId,
               entryId: entry.id,
               error: error instanceof Error ? error.message : String(error),
             });
-          },
-        );
-      }
+          }
+        }
+      })();
     }
   },
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -414,9 +414,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         useChunksStore.getState().generateChunks();
       }
 
-      // New pipeline has no log entries of its own yet — load its (empty) history
-      // instead of clearing, so other pipelines' history in the project is untouched.
-      await useOperationLogStore.getState().loadFromDb(currentProjectId, newId);
+      // switchPipeline (above) already loaded the new pipeline's (empty)
+      // operation log — no separate clear/reload needed here, which also
+      // means other pipelines' history in the project stays untouched.
     })();
     createPipelineInFlight = op.finally(() => { createPipelineInFlight = null; });
     return createPipelineInFlight;

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -121,7 +121,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       viewMode: ui.viewMode,
     });
 
-    useOperationLogStore.getState().setProjectId(id);
+    useOperationLogStore.getState().setContext(id, activePipelineId);
     void get().loadProjects().catch(() => {});
     set({ currentProjectId: id, activePipelineId, pipelines, saveState: 'saved', lastSaveError: null, trackedSnapshot });
   },
@@ -146,7 +146,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         loadTranslations(activePipelineId),
       ]);
 
-      await useOperationLogStore.getState().loadFromDb(id);
+      await useOperationLogStore.getState().loadFromDb(id, activePipelineId);
 
       restoredChunks = restoreTranslations(savedTranslations);
 
@@ -221,7 +221,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     useUiStore.getState().setViewMode('document');
     useChunksStore.setState({ chunks: [], isProcessing: false, cancelRequested: false, activeStreamId: null });
     usePipelineStore.getState().resetToDefaults();
-    useOperationLogStore.setState({ entries: [], currentProjectId: null });
+    useOperationLogStore.setState({ entries: [], currentProjectId: null, currentPipelineId: null });
     useAnnotationsStore.getState().clearAll();
     set({
       currentProjectId: null,
@@ -297,7 +297,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         }
 
         logger.info('saveCurrentProject: done', { projectId: currentProjectId });
-        useOperationLogStore.getState().setProjectId(currentProjectId);
+        useOperationLogStore.getState().setContext(currentProjectId, activePipelineId);
         await get().loadProjects().catch(() => {});
         set({
           currentProjectId,
@@ -371,6 +371,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     annStore.clearAll();
     await annStore.loadAnnotations(pipelineId);
 
+    await useOperationLogStore.getState().loadFromDb(currentProjectId, pipelineId);
+
     useUiStore.getState().setSelectedChunkId(null);
 
     set({
@@ -412,8 +414,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         useChunksStore.getState().generateChunks();
       }
 
-      // New pipeline starts with a clean operation log
-      useOperationLogStore.getState().clear();
+      // New pipeline has no log entries of its own yet — load its (empty) history
+      // instead of clearing, so other pipelines' history in the project is untouched.
+      await useOperationLogStore.getState().loadFromDb(currentProjectId, newId);
     })();
     createPipelineInFlight = op.finally(() => { createPipelineInFlight = null; });
     return createPipelineInFlight;


### PR DESCRIPTION
## Sommario
- Le statistiche del pannello Insight (token, modello, cache hit, tempi per stage) derivano interamente dalla cronologia Operazioni, che era agganciata solo al progetto e non alla singola pipeline.
- Creare una nuova pipeline nel progetto, o premere "Rilancia tutto", cancellava per errore la cronologia (quindi le statistiche) di TUTTE le pipeline del progetto, non solo di quella interessata.
- Cambiare pipeline non ricaricava mai la cronologia corretta (bug preesistente, mai notato perché mascherato dallo scope errato).

## Fix
- Nuova colonna `pipeline_id` su `operation_logs`, con backfill una tantum delle righe esistenti (assegnate alla pipeline più vecchia del progetto) così lo storico già salvato resta visibile dopo l'aggiornamento.
- Salvataggio/lettura/cancellazione ora scoperti per (progetto, pipeline).
- Creare una pipeline nuova carica il suo storico vuoto invece di cancellare quello delle altre.
- Cambiare pipeline ricarica correttamente la cronologia di quella pipeline.
- Eliminare una pipeline ora cancella anche i suoi log operazioni (righe orfane altrimenti).

## Review Copilot
3 commenti risolti: backfill reso sequenziale (evita burst di migliaia di scritture DB), rimossa una lettura ridondante in `createNewPipeline`, aggiunta pulizia dei log orfani in `deletePipeline`.

## Nota di merge
Questo branch è stato aggiornato con `main` dopo il merge di #303 (fix #301): il conflitto su `operationLogStore.ts` è stato risolto tenendo la versione pipeline-aware di questa PR, che è un superset di quella fix.

## Test
- [x] Nuovi test: scoping persistenza, backfill su prima transizione (sequenziale), non ri-backfill, `loadFromDb`/`clear` scoperti, migrazione colonna + backfill righe esistenti, cleanup log su `deletePipeline`
- [x] Suite frontend completa verde (560 test)
- [x] `tsc` pulito

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)