### PR TITLE
feat(#295): override runtime del colore accento da Impostazioni

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,18 @@ function HighlightColorSync() {
   return null;
 }
 
+function AccentColorSync() {
+  const colorScheme = useUiStore((s) => s.colorScheme);
+  const editorialAccentColor = useUiStore((s) => s.editorialAccentColor);
+  useEffect(() => {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = colorScheme === 'dark' || (colorScheme === 'system' && prefersDark);
+    const color = isDark ? editorialAccentColor.dark : editorialAccentColor.light;
+    document.documentElement.style.setProperty('--color-editorial-accent', color);
+  }, [colorScheme, editorialAccentColor]);
+  return null;
+}
+
 const UI_FONT_STACK: Record<UiFont, string> = {
   jakarta: '"Plus Jakarta Sans", system-ui, -apple-system, sans-serif',
   geist: '"Geist", system-ui, -apple-system, sans-serif',
@@ -480,6 +492,7 @@ export default function App() {
   return (
       <ErrorBoundary>
       <HighlightColorSync />
+      <AccentColorSync />
       <FontSync />
       <DocTypographySync />
       <ThemeSync />

--- a/src/components/help/StyleGuide.tsx
+++ b/src/components/help/StyleGuide.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Play, Plus, Save, Settings, CircleCheck, AlertCircle, Loader2, FilePen } from 'lucide-react';
 import { IconButton, PillButton } from '../ui';
+import { contrastRatio } from '../../utils/contrastRatio';
 
 function useCssVarMap(vars: readonly string[]): Record<string, string> {
   const [values, setValues] = useState<Record<string, string>>({});
@@ -13,21 +14,6 @@ function useCssVarMap(vars: readonly string[]): Record<string, string> {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return values;
-}
-
-function hexToLuminance(hex: string): number {
-  if (!hex || hex.length < 7) return 0;
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
-  const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
-  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
-}
-
-function contrastRatio(fg: string, bg: string): number {
-  const l1 = hexToLuminance(fg);
-  const l2 = hexToLuminance(bg);
-  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
 }
 
 function ContrastBadge({ fg, bg }: { fg: string; bg: string }) {

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -23,6 +23,13 @@ import { Dialog, IconButton, DialogCancelButton, Tooltip } from '../ui';
 import type { ModelProvider } from '../../types';
 import { ModelCapabilityHint } from '../models/ModelCapabilityHint';
 import { useProviderKeyStatus } from '../../hooks/useProviderKeyStatus';
+import { contrastRatio } from '../../utils/contrastRatio';
+
+/** Sfondo editoriale di riferimento per il controllo contrasto AA dell'accento. */
+const ACCENT_CONTRAST_BG: Record<'light' | 'dark', string> = {
+  light: '#F8F5F0',
+  dark: '#1c1814',
+};
 
 const PROVIDER_LABELS: Record<ModelProvider, string> = {
   gemini: 'Gemini',
@@ -162,6 +169,8 @@ export function SettingsModal() {
     setDocumentLayout,
     highlightColors,
     setHighlightColor,
+    editorialAccentColor,
+    setEditorialAccentColor,
     uiFont,
     setUiFont,
     colorScheme,
@@ -516,6 +525,51 @@ export function SettingsModal() {
                             {icon}
                             {t(labelKey)}
                           </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Accento */}
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-1.5">
+                      <Palette size={11} className="text-editorial-accent shrink-0" />
+                      <p className="text-[11px] font-sans uppercase tracking-[0.16em] text-editorial-muted">
+                        {t('settings.accentColor')}
+                      </p>
+                    </div>
+                    <p className="text-xs leading-relaxed text-editorial-muted">{t('settings.accentColorHint')}</p>
+                    <div className="flex gap-2">
+                      {(['light', 'dark'] as const).map((mode) => {
+                        const ratio = contrastRatio(editorialAccentColor[mode], ACCENT_CONTRAST_BG[mode]);
+                        const passesAA = ratio >= 4.5;
+                        return (
+                          <label
+                            key={mode}
+                            className="flex flex-1 cursor-pointer items-center gap-3 rounded-[20px] border border-editorial-border bg-editorial-bg/60 px-4 py-3.5 transition-colors hover:border-editorial-accent/40"
+                          >
+                            <div className="relative h-5 w-5 shrink-0 overflow-hidden rounded-full shadow-sm">
+                              <div className="absolute inset-0" style={{ backgroundColor: editorialAccentColor[mode] }} />
+                              <input
+                                type="color"
+                                value={editorialAccentColor[mode]}
+                                onChange={(e) => setEditorialAccentColor(mode, e.target.value)}
+                                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                                aria-label={t(mode === 'dark' ? 'colorScheme_dark' : 'colorScheme_light')}
+                              />
+                            </div>
+                            <span className="mx-0.5 h-5 w-px shrink-0 bg-editorial-border/70" aria-hidden="true" />
+                            <span className="flex flex-1 flex-col">
+                              <span className="font-display text-lg italic text-editorial-ink">
+                                {t(mode === 'dark' ? 'colorScheme_dark' : 'colorScheme_light')}
+                              </span>
+                              <span
+                                className={`font-mono text-[10px] ${passesAA ? 'text-editorial-success' : 'text-editorial-danger'}`}
+                              >
+                                {ratio.toFixed(1)}:1 {passesAA ? '✓ AA' : '✗ AA'}
+                              </span>
+                            </span>
+                          </label>
                         );
                       })}
                     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -441,6 +441,8 @@
     "typographyTab": "Typography",
     "uiFont": "Interface font",
     "uiFontHint": "Choose the typeface for the whole interface. Editorial serif values are unaffected.",
+    "accentColor": "Accent color",
+    "accentColorHint": "Customize the active state, selection, and focus color. Outcome colors (success/warning/error) stay unchanged.",
     "docFontSize": "Document font size",
     "docFontSize_sm": "Small",
     "docFontSize_md": "Medium",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -441,6 +441,8 @@
     "typographyTab": "Tipografia",
     "uiFont": "Font interfaccia",
     "uiFontHint": "Scegli il carattere dell'intera interfaccia. I valori serif editoriali non vengono toccati.",
+    "accentColor": "Colore accento",
+    "accentColorHint": "Personalizza il colore di stato attivo, selezione e focus. I colori di esito (successo/attenzione/errore) restano invariati.",
     "docFontSize": "Dimensione testo documento",
     "docFontSize_sm": "Piccolo",
     "docFontSize_md": "Medio",

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { useUiStore, migrateUiStorePersistedState, HL_COLORS_LIGHT, HL_COLORS_DARK } from './uiStore';
+import {
+  useUiStore,
+  migrateUiStorePersistedState,
+  HL_COLORS_LIGHT,
+  HL_COLORS_DARK,
+  EDITORIAL_ACCENT_LIGHT,
+  EDITORIAL_ACCENT_DARK,
+} from './uiStore';
 import { useConfigStore } from './configStore';
 
 const initial = useUiStore.getState();
@@ -263,5 +270,43 @@ describe('migrateUiStorePersistedState — highlightColors repair (regressione)'
     };
 
     expect(migrated.highlightColors.light.sourceTerm).toBe('#ff0000');
+  });
+});
+
+describe('uiStore editorialAccentColor preference', () => {
+  it('defaults to the Sage Teal palette for light and dark', () => {
+    const state = useUiStore.getState().editorialAccentColor;
+    expect(state.light).toBe(EDITORIAL_ACCENT_LIGHT);
+    expect(state.dark).toBe(EDITORIAL_ACCENT_DARK);
+  });
+
+  it('updates only the given mode through setEditorialAccentColor', () => {
+    useUiStore.getState().setEditorialAccentColor('light', '#123456');
+    const state = useUiStore.getState().editorialAccentColor;
+    expect(state.light).toBe('#123456');
+    expect(state.dark).toBe(EDITORIAL_ACCENT_DARK);
+  });
+});
+
+describe('migrateUiStorePersistedState — editorialAccentColor', () => {
+  it('backfills the accent default for stores saved before it existed', () => {
+    const migrated = migrateUiStorePersistedState({}, 15) as {
+      editorialAccentColor: { light: string; dark: string };
+    };
+
+    expect(migrated.editorialAccentColor).toEqual({
+      light: EDITORIAL_ACCENT_LIGHT,
+      dark: EDITORIAL_ACCENT_DARK,
+    });
+  });
+
+  it('leaves an already-migrated v16 store untouched', () => {
+    const complete = { editorialAccentColor: { light: '#abcdef', dark: '#fedcba' } };
+
+    const migrated = migrateUiStorePersistedState(complete, 16) as {
+      editorialAccentColor: { light: string; dark: string };
+    };
+
+    expect(migrated.editorialAccentColor).toEqual({ light: '#abcdef', dark: '#fedcba' });
   });
 });

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -51,6 +51,9 @@ export const HL_COLORS_DARK: HLColorSet = {
   auditPhrase:  'rgba(251,146,60,0.30)',
   annotation:   'rgba(94,195,185,0.28)',
 };
+
+export const EDITORIAL_ACCENT_LIGHT = '#2F746C';
+export const EDITORIAL_ACCENT_DARK = '#3A7A72';
 export type ProjectPanelTab = 'run' | 'pipeline' | 'document' | 'insight' | 'chunk';
 
 /** Pannelli che vivono inline nella barra primaria (non aprono il fly-out). */
@@ -85,6 +88,7 @@ interface UiState {
   consoleDrawerHeight: number;
   highlightsEnabled: boolean;
   highlightColors: { light: HLColorSet; dark: HLColorSet };
+  editorialAccentColor: { light: string; dark: string };
   searchQuery: string;
   focusedChunkId: string | null;
   focusedIssueQuery: string | null;
@@ -132,6 +136,7 @@ interface UiState {
   setConsoleDrawerHeight: (height: number) => void;
   setHighlightsEnabled: (enabled: boolean) => void;
   setHighlightColor: (mode: 'light' | 'dark', type: keyof HLColorSet, color: string) => void;
+  setEditorialAccentColor: (mode: 'light' | 'dark', color: string) => void;
   setSearchQuery: (query: string) => void;
   setFocusedChunkId: (chunkId: string | null) => void;
   focusIssueInChunk: (chunkId: string, query?: string | null, sourceQuery?: string | null) => void;
@@ -237,6 +242,9 @@ export function migrateUiStorePersistedState(persisted: unknown, fromVersion: nu
       dark: { ...HL_COLORS_DARK, ...(stored.dark ?? {}) },
     };
   }
+  if (fromVersion < 16) {
+    s.editorialAccentColor = { light: EDITORIAL_ACCENT_LIGHT, dark: EDITORIAL_ACCENT_DARK };
+  }
   return s;
 }
 
@@ -268,6 +276,7 @@ export const useUiStore = create<UiState>()(
       consoleDrawerHeight: 256,
       highlightsEnabled: true,
       highlightColors: { light: { ...HL_COLORS_LIGHT }, dark: { ...HL_COLORS_DARK } },
+      editorialAccentColor: { light: EDITORIAL_ACCENT_LIGHT, dark: EDITORIAL_ACCENT_DARK },
       searchQuery: '',
       focusedChunkId: null,
       focusedIssueQuery: null,
@@ -399,6 +408,10 @@ export const useUiStore = create<UiState>()(
             [mode]: { ...state.highlightColors[mode], [type]: color },
           },
         })),
+      setEditorialAccentColor: (mode, color) =>
+        set((state) => ({
+          editorialAccentColor: { ...state.editorialAccentColor, [mode]: color },
+        })),
       setSearchQuery: (query) => set({ searchQuery: query }),
       setFocusedChunkId: (chunkId) => set({ focusedChunkId: chunkId }),
       focusIssueInChunk: (chunkId, query, sourceQuery) =>
@@ -508,7 +521,7 @@ export const useUiStore = create<UiState>()(
     }),
     {
       name: 'glossa-ui-prefs',
-      version: 15,
+      version: 16,
       migrate: migrateUiStorePersistedState,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
@@ -532,6 +545,7 @@ export const useUiStore = create<UiState>()(
         consoleDrawerHeight: state.consoleDrawerHeight,
         highlightsEnabled: state.highlightsEnabled,
         highlightColors: state.highlightColors,
+        editorialAccentColor: state.editorialAccentColor,
       }),
     },
   ),

--- a/src/utils/contrastRatio.test.ts
+++ b/src/utils/contrastRatio.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { contrastRatio, hexToLuminance } from './contrastRatio';
+
+describe('hexToLuminance', () => {
+  it('returns 0 for black', () => {
+    expect(hexToLuminance('#000000')).toBe(0);
+  });
+
+  it('returns 1 for white', () => {
+    expect(hexToLuminance('#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('returns 0 for an invalid/short hex', () => {
+    expect(hexToLuminance('#fff')).toBe(0);
+  });
+});
+
+describe('contrastRatio', () => {
+  it('returns 21:1 for black on white (max WCAG contrast)', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 0);
+  });
+
+  it('returns 1:1 for identical colors', () => {
+    expect(contrastRatio('#2F746C', '#2F746C')).toBeCloseTo(1, 5);
+  });
+
+  it('is symmetric regardless of argument order', () => {
+    expect(contrastRatio('#2F746C', '#F8F5F0')).toBeCloseTo(contrastRatio('#F8F5F0', '#2F746C'), 5);
+  });
+});

--- a/src/utils/contrastRatio.ts
+++ b/src/utils/contrastRatio.ts
@@ -1,0 +1,14 @@
+export function hexToLuminance(hex: string): number {
+  if (!hex || hex.length < 7) return 0;
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+export function contrastRatio(fg: string, bg: string): number {
+  const l1 = hexToLuminance(fg);
+  const l2 = hexToLuminance(bg);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}


### PR DESCRIPTION
## Contesto
Ultimo task rimasto di #295 (il resto — nuova tinta, variabile CSS unica, separazione dai colori semantici — era già stato spedito in precedenza). #292 è confermata completa a vista (pannelli Insight/Frammento, tab, contenuti, misure, allineamento testate) senza lavoro residuo — questa PR chiude entrambe.

## Cosa cambia
- Il colore accento (`--color-editorial-accent`) è ora personalizzabile a runtime da Impostazioni > Tipografia, con lo stesso schema già usato per font ed evidenziazioni: preferenza persistita (`uiStore`), sincronizzazione su `:root` via componente dedicato, due selettori colore (chiaro/scuro).
- Badge di contrasto WCAG AA accanto a ogni selettore, per verificare subito che il colore scelto resti leggibile sullo sfondo editoriale.
- Estratta la funzione di calcolo contrasto (`contrastRatio`) in un'utility condivisa, prima duplicata solo in `StyleGuide`.

## Test
- [x] Nuovi test: default accento, setter, migrazione persistenza (v15→v16), utility di contrasto (valori WCAG noti)
- [x] Suite frontend completa verde (570 test)
- [x] `tsc` pulito

## Nota di verifica
Non ho potuto verificare visivamente nell'app reale in questo ambiente (niente shell Tauri/display disponibile, e la modalità solo-browser non ha il backend necessario per superare la creazione workspace). Consiglio una verifica visiva rapida al primo avvio locale: Impostazioni → Tipografia → sezione "Colore accento", cambiare il colore chiaro e controllare che bottoni attivi/focus ring nell'interfaccia si aggiornino dal vivo.

Closes #295.
Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)