### PR TITLE
ci: align npm toolchain for docs and release

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -26,9 +26,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/configure-pages@v5
+      - run: npm install -g npm@11
       - run: npm ci
       - run: npm run docs:build
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -43,6 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsecret-1-dev
+      - run: npm install -g npm@11
       - run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -68,12 +69,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+      - run: npm install -g npm@11
       - run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -99,12 +101,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+      - run: npm install -g npm@11
       - run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -130,12 +133,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
+      - run: npm install -g npm@11
       - run: npm ci
       - uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
## Summary
- Align Docs Site and release jobs with the npm 11 toolchain already used by the main CI.
- Move those npm install jobs from Node 20 to Node 22.
- Avoid changing app dependencies or regenerating the lockfile for a runner-specific npm 10 behavior.

## Verification
- npm run docs:build
- git diff --check