### PR TITLE
fix: retry GitHub Pages deploy on transient failure

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -41,7 +41,21 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.attempt1.outputs.page_url || steps.attempt2.outputs.page_url || steps.attempt3.outputs.page_url }}
     steps:
-      - id: deployment
+      - id: attempt1
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+      - name: Wait before retry
+        if: steps.attempt1.outcome == 'failure'
+        run: sleep 30
+      - id: attempt2
+        if: steps.attempt1.outcome == 'failure'
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+      - name: Wait before final retry
+        if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure'
+        run: sleep 30
+      - id: attempt3
+        if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Il job `deploy` di Docs Site falliva in modo intermittente con `Deployment failed, try again later` anche con build e config Pages corretti (branch policy, permessi, artifact size tutti ok, GitHub Pages status page = operational).
- Aggiunto retry (fino a 3 tentativi, 30s di attesa tra un tentativo e l'altro) sullo step `actions/deploy-pages@v4` prima di segnalare fallimento reale.

## Test plan
- [ ] Verificare che il workflow Docs Site su questa PR (o al merge su main) completi con successo
- [ ] Se fallisce ancora al primo tentativo, controllare che il retry scatti e converga entro i 3 tentativi