### PR TITLE
ci: enforce conventional PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-title:
+    name: Conventional title
+    runs-on: ubuntu-latest
+    steps:
+      # Il merge squash usa il titolo della PR come messaggio del commit su main:
+      # senza prefisso conventional release-please ignora il commit e il release
+      # bump salta (successo già a #318 → mancata 1.1.2).
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            perf
+            docs
+            test
+            chore
+            ci
+          requireScope: false


### PR DESCRIPTION
## Perché
Il merge squash usa il titolo della PR come messaggio del commit su `main`. La #318 è stata mergiata con un titolo senza prefisso conventional → release-please ha considerato 0 commit e la 1.1.2 non è partita (sbloccata poi con un commit vuoto `fix:` su main, 8d589cb).

## Cosa fa
Nuovo workflow `PR Title`: valida il titolo della PR con `amannn/action-semantic-pull-request` (tipi ammessi: feat, fix, refactor, perf, docs, test, chore, ci — allineati a `release-please-config.json` e alla regola commit del progetto). Titolo non conforme = check rosso.

## Note
- Nessun input non fidato in comandi shell (il titolo è gestito internamente dall'action).
- Da aggiungere ai required checks della branch protection se si vuole il blocco hard.

## Test plan
- [ ] Il check compare su questa PR e passa (titolo `ci: ...`)
- [ ] Rinominare temporaneamente la PR con un titolo non conventional → check rosso

🤖 Generated with [Claude Code](https://claude.com/claude-code)