### PR TITLE
fix: stabilizzare cancellazione e output pipeline

### DIFF
--- a/docs-dev/ARCHITECTURE.md
+++ b/docs-dev/ARCHITECTURE.md
@@ -329,7 +329,7 @@ No fallback locale: se extractor, JSON parsing o validazione falliscono, chunk n
 - Auto-search parte solo se `usePhraseMemory` attivo e `autoSearchPhraseMemory !== false`.
 - Tab Memory può sempre lanciare refresh manuale per chunk corrente quando memoria abilitata.
 - Query embedding usa solo testo sorgente del chunk; match selezionati sono unici iniettati nel prompt di run/rerun.
-- Lo schema della memoria frasi (colonne e indici inclusi) viene creato o aggiornato una volta all'avvio dal servizio database frontend. Il backend mantiene una sola connessione SQLite con sqlite-vec per tutta la sessione e la riusa serialmente per ricerca e salvataggio; non modifica più lo schema durante questi comandi.
+- Lo schema della memoria frasi (colonne e indici inclusi) viene creato o aggiornato una volta all'avvio dal servizio database frontend. Il backend mantiene una sola connessione SQLite con sqlite-vec per tutta la sessione e la riusa serialmente per ricerca e salvataggio; non modifica più lo schema durante questi comandi. Se quella connessione non è disponibile all'avvio, l'app può comunque mostrare l'errore di inizializzazione del database; i comandi della memoria restituiscono il motivo originale senza ricreare connessioni.
 
 ---
 

--- a/docs-dev/ARCHITECTURE.md
+++ b/docs-dev/ARCHITECTURE.md
@@ -329,6 +329,7 @@ No fallback locale: se extractor, JSON parsing o validazione falliscono, chunk n
 - Auto-search parte solo se `usePhraseMemory` attivo e `autoSearchPhraseMemory !== false`.
 - Tab Memory può sempre lanciare refresh manuale per chunk corrente quando memoria abilitata.
 - Query embedding usa solo testo sorgente del chunk; match selezionati sono unici iniettati nel prompt di run/rerun.
+- Lo schema della memoria frasi (colonne e indici inclusi) viene creato o aggiornato una volta all'avvio dal servizio database frontend. Il backend mantiene una sola connessione SQLite con sqlite-vec per tutta la sessione e la riusa serialmente per ricerca e salvataggio; non modifica più lo schema durante questi comandi.
 
 ---
 
@@ -400,10 +401,12 @@ app_settings
 phrase_memory
   id, workspace_id FK, source_phrase, target_phrase
   source_language, target_language, author, work, domain, tags, notes
-  chunk_id, project_id, confidence, embedding, created_at
+  chunk_id, project_id, confidence, embedding, embedding_model, created_at
+  idx: workspace_id; (chunk_id, project_id)
 
 source_phrase_embeddings
   id, project_id, chunk_id, source_phrase, embedding, created_at
+  idx: (chunk_id, project_id)
 
 custom_providers
   id TEXT PK, name TEXT, base_url TEXT, requires_api_key INTEGER (0|1)
@@ -467,4 +470,4 @@ In release (`!debug_assertions`) livello log predefinito è `Info`. `RUST_LOG` l
 
 **Implicazione**: impostare `RUST_LOG=debug` o `RUST_LOG=trace` su build release espone log verbosi, inclusi dettagli richieste LLM (provider, modello, timing). Non loggati contenuti prompt o risposte, ma provider e metadati sì. In contesto supporto tecnico, chiedere sempre verificare che `RUST_LOG` non sia impostato prima condividere log.
 
-*Ultimo aggiornamento: 2026-06-11 — branch security/issue-254-hardening*
+*Ultimo aggiornamento: 2026-07-13 — PR #329, connessione persistente memoria frasi*

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1902,7 +1902,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/src-tauri/src/keystore.rs
+++ b/src-tauri/src/keystore.rs
@@ -259,10 +259,10 @@ pub fn get_api_key(app: &AppHandle, provider: &str) -> Result<String, String> {
     }
 
     // 3. Fallback to environment variable (custom: providers never have env vars)
-    if provider.starts_with("custom:") {
+    if let Some(provider_name) = provider.strip_prefix("custom:") {
         return Err(format!(
             "API key for custom endpoint '{}' is not configured. Add it in Settings.",
-            &provider["custom:".len()..]
+            provider_name
         ));
     }
     let env_key = match provider {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,8 +28,7 @@ pub fn run() {
 
     builder
         .setup(|app| {
-            let vector_database =
-                vector::VectorDatabase::initialize(app.handle()).map_err(std::io::Error::other)?;
+            let vector_database = vector::VectorDatabase::initialize(app.handle());
             app.manage(vector_database);
             #[allow(unused_mut)]
             let mut log_targets: Vec<tauri_plugin_log::Target> =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ mod keystore;
 mod llm;
 mod vector;
 
+use tauri::Manager;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // The updater plugin requires `plugins.updater` config which only ships in
@@ -26,6 +28,9 @@ pub fn run() {
 
     builder
         .setup(|app| {
+            let vector_database =
+                vector::VectorDatabase::initialize(app.handle()).map_err(std::io::Error::other)?;
+            app.manage(vector_database);
             #[allow(unused_mut)]
             let mut log_targets: Vec<tauri_plugin_log::Target> =
                 vec![tauri_plugin_log::Target::new(

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -10,7 +10,7 @@ use crate::llm::prompts::{
     REFINE_STAGE_SYSTEM_PROMPT,
 };
 use crate::llm::provider::{LlmProvider, LlmRequest};
-use crate::llm::providers::get_provider;
+use crate::llm::providers::{get_provider, with_retry_after};
 use crate::llm::stream::{stream_response, StreamGuard, StreamRegistry, STREAM_CANCELLED_ERROR};
 use crate::llm::types::{
     CoherenceChunkInput, CoherenceResponse, JudgeIssue, JudgeResponse, PipelineConfig,
@@ -67,6 +67,56 @@ fn pretty_json(value: &serde_json::Value, fallback: &str) -> String {
         log::warn!("Failed to pretty-print JSON response: {e}");
         fallback.to_string()
     })
+}
+
+fn verified_judge_phrase(value: Option<&str>, reference: &str, field: &str) -> Option<String> {
+    let phrase = value?.trim();
+    if phrase.is_empty() {
+        return None;
+    }
+    if reference.contains(phrase) {
+        return Some(phrase.to_string());
+    }
+
+    log::warn!(
+        "judge_response.discard_non_verbatim_phrase field={field} phrase_chars={}",
+        phrase.len()
+    );
+    None
+}
+
+fn parse_judge_issues(
+    parsed: &serde_json::Value,
+    source_text: &str,
+    target_text: &str,
+) -> Vec<JudgeIssue> {
+    parsed["issues"]
+        .as_array()
+        .map(|issues| {
+            issues
+                .iter()
+                .filter_map(|value| {
+                    Some(JudgeIssue {
+                        issue_type: value["type"].as_str()?.to_string(),
+                        severity: value["severity"].as_str()?.to_string(),
+                        description: value["description"].as_str()?.to_string(),
+                        suggested_fix: value["suggestedFix"].as_str().map(str::to_string),
+                        phrase: verified_judge_phrase(
+                            value["phrase"].as_str(),
+                            target_text,
+                            "phrase",
+                        ),
+                        source_phrase: verified_judge_phrase(
+                            value["sourcePhrase"].as_str(),
+                            source_text,
+                            "sourcePhrase",
+                        ),
+                        confidence: value["confidence"].as_f64().map(|value| value as f32),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[derive(serde::Serialize)]
@@ -246,12 +296,16 @@ pub async fn run_stage_stream(
     );
     let resp = provider.build_streaming_request(&client, &req).await?;
     let status = resp.status();
+    let response_headers = resp.headers().clone();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_else(|e| {
             log::warn!("Failed to read error response body: {e}");
             String::new()
         });
-        return Err(provider.format_http_error(status, &text));
+        return Err(with_retry_after(
+            provider.format_http_error(status, &text),
+            &response_headers,
+        ));
     }
 
     let result = stream_response(
@@ -358,25 +412,11 @@ pub async fn judge_translation(
         }
     };
 
-    let rating = parse_judge_rating(&parsed);
-    let issues: Vec<JudgeIssue> = parsed["issues"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| {
-                    Some(JudgeIssue {
-                        issue_type: v["type"].as_str()?.to_string(),
-                        severity: v["severity"].as_str()?.to_string(),
-                        description: v["description"].as_str()?.to_string(),
-                        suggested_fix: v["suggestedFix"].as_str().map(|s| s.to_string()),
-                        phrase: v["phrase"].as_str().map(|s| s.to_string()),
-                        source_phrase: v["sourcePhrase"].as_str().map(|s| s.to_string()),
-                        confidence: v["confidence"].as_f64().map(|f| f as f32),
-                    })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let rating = parse_judge_rating(&parsed).map_err(|error| {
+        log::warn!("judge_response.invalid_rating error={error}");
+        error
+    })?;
+    let issues = parse_judge_issues(&parsed, &original_text, &translation);
 
     Ok(JudgeResponse {
         rating,
@@ -582,24 +622,7 @@ pub async fn run_coherence_for_chunk(
         }
     };
 
-    let issues: Vec<JudgeIssue> = parsed["issues"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| {
-                    Some(JudgeIssue {
-                        issue_type: v["type"].as_str()?.to_string(),
-                        severity: v["severity"].as_str()?.to_string(),
-                        description: v["description"].as_str()?.to_string(),
-                        suggested_fix: v["suggestedFix"].as_str().map(|s| s.to_string()),
-                        phrase: v["phrase"].as_str().map(|s| s.to_string()),
-                        source_phrase: v["sourcePhrase"].as_str().map(|s| s.to_string()),
-                        confidence: v["confidence"].as_f64().map(|f| f as f32),
-                    })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let issues = parse_judge_issues(&parsed, &input.original, &input.translation);
 
     Ok(CoherenceResponse {
         issues,

--- a/src-tauri/src/llm/prompts.rs
+++ b/src-tauri/src/llm/prompts.rs
@@ -388,19 +388,15 @@ pub(crate) fn sanitize_llm_json_output(raw: &str) -> &str {
     }
 }
 
-pub(crate) fn parse_judge_rating(parsed: &serde_json::Value) -> String {
-    if let Some(raw) = parsed["rating"].as_str() {
-        match raw.trim().to_lowercase().as_str() {
-            "critical" | "critico" | "critica" => return "critical".to_string(),
-            "poor" | "scarso" => return "poor".to_string(),
-            "fair" | "sufficiente" | "accettabile" | "discreto" => return "fair".to_string(),
-            "good" | "buono" => return "good".to_string(),
-            "excellent" | "ottimo" => return "excellent".to_string(),
-            _ => {}
-        }
-    }
+pub(crate) fn parse_judge_rating(parsed: &serde_json::Value) -> Result<String, String> {
+    let raw = parsed["rating"]
+        .as_str()
+        .ok_or_else(|| "Judge response is missing rating".to_string())?;
 
-    "fair".to_string()
+    match raw.trim().to_lowercase().as_str() {
+        "critical" | "poor" | "fair" | "good" | "excellent" => Ok(raw.trim().to_lowercase()),
+        value => Err(format!("Invalid judge response rating: {value}")),
+    }
 }
 
 pub(crate) fn minimal_pipeline_config(

--- a/src-tauri/src/llm/provider.rs
+++ b/src-tauri/src/llm/provider.rs
@@ -105,6 +105,13 @@ pub trait LlmProvider: Send + Sync {
     /// Update usage counters from a single streaming event. Mutates `state` in place.
     fn update_streaming_usage(&self, data: &str, state: &mut UsageAccumulator);
 
+    /// Report a provider-declared terminal stream error, such as an output
+    /// truncated by the provider's token limit. Returning it here prevents a
+    /// partial response from being presented as a completed translation.
+    fn streaming_completion_error(&self, _data: &str) -> Option<String> {
+        None
+    }
+
     /// Non-streaming call. Returns content + optional token usage.
     async fn call(&self, client: &Client, req: &LlmRequest<'_>) -> Result<LlmResponse, String>;
 

--- a/src-tauri/src/llm/providers/anthropic.rs
+++ b/src-tauri/src/llm/providers/anthropic.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::{json, Value};
 
-use super::format_api_error;
+use super::{format_api_error, with_retry_after};
 use crate::llm::provider::{
     LlmProvider, LlmRequest, LlmResponse, StreamFormat, TokenUsage, UsageAccumulator,
 };
@@ -36,6 +36,26 @@ fn build_anthropic_system(req: &LlmRequest<'_>, force_json: bool) -> Value {
     }
 
     Value::Array(blocks)
+}
+
+fn max_output_tokens(req: &LlmRequest<'_>) -> usize {
+    const MIN_OUTPUT_TOKENS: usize = 2_048;
+    const MAX_OUTPUT_TOKENS: usize = 8_192;
+    const OUTPUT_OVERHEAD_TOKENS: usize = 1_024;
+
+    let source_estimate = req.structured.user.chars().count().div_ceil(3);
+    (source_estimate + OUTPUT_OVERHEAD_TOKENS).clamp(MIN_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS)
+}
+
+fn stop_reason_error(reason: Option<&str>) -> Option<String> {
+    match reason {
+        Some("end_turn" | "stop_sequence") => None,
+        Some("max_tokens") => {
+            Some("Anthropic response was truncated at the output token limit".to_string())
+        }
+        Some(reason) => Some(format!("Anthropic response ended unexpectedly: {reason}")),
+        None => Some("Anthropic response is missing a stop reason".to_string()),
+    }
 }
 
 pub struct AnthropicProvider;
@@ -105,11 +125,19 @@ impl LlmProvider for AnthropicProvider {
         }
     }
 
+    fn streaming_completion_error(&self, data: &str) -> Option<String> {
+        let json: Value = serde_json::from_str(data).ok()?;
+        if json["type"].as_str() != Some("message_delta") {
+            return None;
+        }
+        stop_reason_error(json["delta"]["stop_reason"].as_str())
+    }
+
     async fn call(&self, client: &Client, req: &LlmRequest<'_>) -> Result<LlmResponse, String> {
         let system = build_anthropic_system(req, req.json_mode);
         let body = json!({
             "model": req.model,
-            "max_tokens": 4096,
+            "max_tokens": max_output_tokens(req),
             "system": system,
             "messages": [{"role": "user", "content": req.structured.user}]
         });
@@ -126,21 +154,37 @@ impl LlmProvider for AnthropicProvider {
             .map_err(|e| format!("Anthropic request failed: {e}"))?;
 
         let status = resp.status();
+        let response_headers = resp.headers().clone();
         let text = resp
             .text()
             .await
             .map_err(|e| format!("Failed to read response: {e}"))?;
 
         if !status.is_success() {
-            return Err(format_api_error("Anthropic", status, &text));
+            return Err(with_retry_after(
+                format_api_error("Anthropic", status, &text),
+                &response_headers,
+            ));
         }
 
         let json: Value = serde_json::from_str(&text)
             .map_err(|e| format!("Failed to parse Anthropic response: {e}"))?;
 
-        let content = json["content"][0]["text"]
-            .as_str()
-            .map(String::from)
+        if let Some(error) = stop_reason_error(json["stop_reason"].as_str()) {
+            return Err(error);
+        }
+
+        let content = json["content"]
+            .as_array()
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter(|block| block["type"].as_str() == Some("text"))
+                    .filter_map(|block| block["text"].as_str())
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .filter(|content| !content.is_empty())
             .ok_or_else(|| "No text in Anthropic response".to_string())?;
 
         let usage = match (
@@ -171,7 +215,7 @@ impl LlmProvider for AnthropicProvider {
         let system = build_anthropic_system(req, false);
         let body = json!({
             "model": req.model,
-            "max_tokens": 4096,
+            "max_tokens": max_output_tokens(req),
             "system": system,
             "messages": [{"role": "user", "content": req.structured.user}],
             "stream": true
@@ -187,5 +231,43 @@ impl LlmProvider for AnthropicProvider {
             .send()
             .await
             .map_err(|e| format!("Anthropic request failed: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{max_output_tokens, stop_reason_error};
+    use crate::llm::provider::LlmRequest;
+    use crate::llm::types::{PromptBlock, StructuredPrompt};
+
+    fn request(user: String) -> LlmRequest<'static> {
+        let structured = Box::leak(Box::new(StructuredPrompt {
+            system: vec![PromptBlock {
+                text: "system".to_string(),
+                cacheable: false,
+            }],
+            user,
+        }));
+        LlmRequest {
+            model: "claude-test",
+            structured,
+            api_key: "key",
+            json_mode: false,
+            json_schema_strict: false,
+            provider_options: None,
+        }
+    }
+
+    #[test]
+    fn output_budget_scales_with_request_size_with_safe_bounds() {
+        assert_eq!(max_output_tokens(&request("short".to_string())), 2_048);
+        assert!(max_output_tokens(&request("x".repeat(12_000))) > 4_096);
+        assert_eq!(max_output_tokens(&request("x".repeat(100_000))), 8_192);
+    }
+
+    #[test]
+    fn max_tokens_stop_reason_is_reported_as_truncation() {
+        assert!(stop_reason_error(Some("max_tokens")).is_some());
+        assert_eq!(stop_reason_error(Some("end_turn")), None);
     }
 }

--- a/src-tauri/src/llm/providers/gemini.rs
+++ b/src-tauri/src/llm/providers/gemini.rs
@@ -8,7 +8,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
-use super::format_api_error;
+use super::{format_api_error, with_retry_after};
 use crate::llm::provider::{
     LlmProvider, LlmRequest, LlmResponse, StreamFormat, TokenUsage, UsageAccumulator,
 };
@@ -93,6 +93,14 @@ impl LlmProvider for GeminiProvider {
         }
     }
 
+    fn streaming_completion_error(&self, data: &str) -> Option<String> {
+        let json: Value = serde_json::from_str(data).ok()?;
+        if json["candidates"][0]["finishReason"].as_str() == Some("MAX_TOKENS") {
+            return Some("Gemini response was truncated at the output token limit".to_string());
+        }
+        None
+    }
+
     async fn call(&self, client: &Client, req: &LlmRequest<'_>) -> Result<LlmResponse, String> {
         let url = format!(
             "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
@@ -126,6 +134,7 @@ impl LlmProvider for GeminiProvider {
             .map_err(|e| format!("Gemini request failed: {e}"))?;
 
         let status = resp.status();
+        let response_headers = resp.headers().clone();
         let text = resp
             .text()
             .await
@@ -137,11 +146,18 @@ impl LlmProvider for GeminiProvider {
             {
                 invalidate_gemini_cache(req);
             }
-            return Err(format_api_error("Gemini", status, &text));
+            return Err(with_retry_after(
+                format_api_error("Gemini", status, &text),
+                &response_headers,
+            ));
         }
 
         let json: Value = serde_json::from_str(&text)
             .map_err(|e| format!("Failed to parse Gemini response: {e}"))?;
+
+        if json["candidates"][0]["finishReason"].as_str() == Some("MAX_TOKENS") {
+            return Err("Gemini response was truncated at the output token limit".to_string());
+        }
 
         let content = json["candidates"][0]["content"]["parts"][0]["text"]
             .as_str()

--- a/src-tauri/src/llm/providers/mod.rs
+++ b/src-tauri/src/llm/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod ollama;
 pub mod openai;
 
 use crate::llm::provider::LlmProvider;
+use reqwest::header::HeaderMap;
 
 pub fn get_provider(
     id: &str,
@@ -50,6 +51,27 @@ pub(crate) fn format_api_error(
         _ => "unexpected response",
     };
     format!("{provider_label} API error ({status}): {user_message}")
+}
+
+/// Preserve a provider-supplied retry delay without exposing response bodies.
+/// The frontend consumes this compact marker to schedule the next attempt.
+pub(crate) fn with_retry_after(error: String, headers: &HeaderMap) -> String {
+    let Some(value) = headers.get(reqwest::header::RETRY_AFTER) else {
+        return error;
+    };
+    let Ok(value) = value.to_str() else {
+        return error;
+    };
+    let Ok(seconds) = value.parse::<f64>() else {
+        return error;
+    };
+    if !seconds.is_finite() || seconds < 0.0 {
+        return error;
+    }
+    format!(
+        "{error}; retry-after-ms={}",
+        (seconds * 1000.0).ceil() as u64
+    )
 }
 
 /// Log the raw provider response body. Compiles to a no-op in release

--- a/src-tauri/src/llm/providers/ollama.rs
+++ b/src-tauri/src/llm/providers/ollama.rs
@@ -179,6 +179,14 @@ impl LlmProvider for OllamaProvider {
         }
     }
 
+    fn streaming_completion_error(&self, data: &str) -> Option<String> {
+        let json: Value = serde_json::from_str(data).ok()?;
+        if json["done_reason"].as_str() == Some("length") {
+            return Some("Ollama response was truncated at the output token limit".to_string());
+        }
+        None
+    }
+
     fn format_http_error(&self, status: reqwest::StatusCode, body: &str) -> String {
         format_ollama_api_error(status, body)
     }
@@ -237,6 +245,10 @@ impl LlmProvider for OllamaProvider {
 
         let json: Value = serde_json::from_str(&text)
             .map_err(|e| format!("Failed to parse Ollama response: {e}"))?;
+
+        if json["done_reason"].as_str() == Some("length") {
+            return Err("Ollama response was truncated at the output token limit".to_string());
+        }
 
         let content = json["message"]["content"]
             .as_str()

--- a/src-tauri/src/llm/providers/openai.rs
+++ b/src-tauri/src/llm/providers/openai.rs
@@ -1,4 +1,4 @@
-use super::{format_api_error, provider_label_from_url};
+use super::{format_api_error, provider_label_from_url, with_retry_after};
 use crate::llm::provider::{
     LlmProvider, LlmRequest, LlmResponse, StreamFormat, TokenUsage, UsageAccumulator,
 };
@@ -297,17 +297,27 @@ impl OpenAiCompatibleProvider {
             .map_err(|e| format!("API request failed: {e}"))?;
 
         let status = resp.status();
+        let response_headers = resp.headers().clone();
         let text = resp
             .text()
             .await
             .map_err(|e| format!("Failed to read response: {e}"))?;
 
         if !status.is_success() {
-            return Err(format_api_error("OpenAI", status, &text));
+            return Err(with_retry_after(
+                format_api_error("OpenAI", status, &text),
+                &response_headers,
+            ));
         }
 
         let json: Value =
             serde_json::from_str(&text).map_err(|e| format!("Failed to parse response: {e}"))?;
+
+        if json["status"].as_str() == Some("incomplete")
+            || json["incomplete_details"]["reason"].as_str() == Some("max_output_tokens")
+        {
+            return Err("OpenAI response was truncated at the output token limit".to_string());
+        }
 
         let content = json["output"]
             .as_array()
@@ -461,6 +471,25 @@ impl LlmProvider for OpenAiCompatibleProvider {
         }
     }
 
+    fn streaming_completion_error(&self, data: &str) -> Option<String> {
+        let json: Value = serde_json::from_str(data).ok()?;
+        if self.use_responses_api {
+            if json["type"].as_str() == Some("response.completed")
+                && (json["response"]["status"].as_str() == Some("incomplete")
+                    || json["response"]["incomplete_details"]["reason"].as_str()
+                        == Some("max_output_tokens"))
+            {
+                return Some("OpenAI response was truncated at the output token limit".to_string());
+            }
+            return None;
+        }
+
+        if json["choices"][0]["finish_reason"].as_str() == Some("length") {
+            return Some("Provider response was truncated at the output token limit".to_string());
+        }
+        None
+    }
+
     async fn call(&self, client: &Client, req: &LlmRequest<'_>) -> Result<LlmResponse, String> {
         if self.use_responses_api_for(req) {
             return self.call_responses(client, req).await;
@@ -499,21 +528,25 @@ impl LlmProvider for OpenAiCompatibleProvider {
             .map_err(|e| format!("API request failed: {e}"))?;
 
         let status = resp.status();
+        let response_headers = resp.headers().clone();
         let text = resp
             .text()
             .await
             .map_err(|e| format!("Failed to read response: {e}"))?;
 
         if !status.is_success() {
-            return Err(format_api_error(
-                provider_label_from_url(&self.base_url),
-                status,
-                &text,
+            return Err(with_retry_after(
+                format_api_error(provider_label_from_url(&self.base_url), status, &text),
+                &response_headers,
             ));
         }
 
         let json: Value =
             serde_json::from_str(&text).map_err(|e| format!("Failed to parse response: {e}"))?;
+
+        if json["choices"][0]["finish_reason"].as_str() == Some("length") {
+            return Err("Provider response was truncated at the output token limit".to_string());
+        }
 
         let content = json["choices"][0]["message"]["content"]
             .as_str()

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -268,6 +268,9 @@ impl StreamAccumulator {
     where
         E: FnMut(StreamToken),
     {
+        if let Some(error) = provider.streaming_completion_error(data) {
+            return Err(error);
+        }
         if let Some(text) = provider.extract_streaming_token(data) {
             if !text.is_empty() {
                 self.full_text.push_str(&text);

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -268,9 +268,6 @@ impl StreamAccumulator {
     where
         E: FnMut(StreamToken),
     {
-        if let Some(error) = provider.streaming_completion_error(data) {
-            return Err(error);
-        }
         if let Some(text) = provider.extract_streaming_token(data) {
             if !text.is_empty() {
                 self.full_text.push_str(&text);
@@ -278,6 +275,11 @@ impl StreamAccumulator {
             }
         }
         provider.update_streaming_usage(data, &mut self.usage);
+        if has_completion_marker(data) {
+            if let Some(error) = provider.streaming_completion_error(data) {
+                return Err(error);
+            }
+        }
         Ok(())
     }
 
@@ -360,6 +362,18 @@ impl StreamAccumulator {
             cache_miss_input_tokens: final_usage.as_ref().and_then(|u| u.cache_miss_input),
         });
     }
+}
+
+fn has_completion_marker(data: &str) -> bool {
+    [
+        "\"stop_reason\"",
+        "\"finish_reason\"",
+        "\"finishReason\"",
+        "\"done_reason\"",
+        "\"incomplete_details\"",
+    ]
+    .iter()
+    .any(|marker| data.contains(marker))
 }
 
 // ── Core streaming functions ──────────────────────────────────────────

--- a/src-tauri/src/llm/stream.rs
+++ b/src-tauri/src/llm/stream.rs
@@ -321,10 +321,27 @@ impl StreamAccumulator {
         Ok(())
     }
 
-    fn finish<E>(&mut self, provider: &dyn LlmProvider, stream_id: &str, emit: &mut E)
+    fn finish<E>(
+        &mut self,
+        provider: &dyn LlmProvider,
+        stream_id: &str,
+        emit: &mut E,
+    ) -> Result<(), String>
     where
         E: FnMut(StreamToken),
     {
+        // Newline-JSON providers can end with a complete JSON payload without a
+        // trailing newline. Check it for a terminal truncation before treating
+        // the stream as successfully finished.
+        if provider.stream_format() == StreamFormat::NewlineJson {
+            let trimmed = self.buffer.trim();
+            if has_completion_marker(trimmed) {
+                if let Some(error) = provider.streaming_completion_error(trimmed) {
+                    return Err(error);
+                }
+            }
+        }
+
         if let Some(extra) = provider.finalize_buffer(&self.buffer) {
             if !extra.is_empty() && !self.full_text.ends_with(&extra) {
                 self.full_text.push_str(&extra);
@@ -361,6 +378,7 @@ impl StreamAccumulator {
             cached_input_tokens: final_usage.as_ref().and_then(|u| u.cached_input),
             cache_miss_input_tokens: final_usage.as_ref().and_then(|u| u.cache_miss_input),
         });
+        Ok(())
     }
 }
 
@@ -432,7 +450,7 @@ where
         }
     }
 
-    acc.finish(provider, stream_id, &mut emit);
+    acc.finish(provider, stream_id, &mut emit)?;
     Ok(StreamResult {
         content: acc.full_text,
     })

--- a/src-tauri/src/llm/tests.rs
+++ b/src-tauri/src/llm/tests.rs
@@ -94,6 +94,14 @@ impl LlmProvider for DelegatingTestProvider {
         self.inner.update_streaming_usage(data, state)
     }
 
+    fn streaming_completion_error(&self, data: &str) -> Option<String> {
+        self.inner.streaming_completion_error(data)
+    }
+
+    fn finalize_buffer(&self, buffer: &str) -> Option<String> {
+        self.inner.finalize_buffer(buffer)
+    }
+
     async fn call(&self, client: &Client, req: &LlmRequest<'_>) -> Result<LlmResponse, String> {
         self.inner.call(client, req).await
     }
@@ -1269,6 +1277,38 @@ async fn consume_stream_openai_sse_multi_token() {
         .collect();
     assert_eq!(content, vec!["Ciao", " mondo"]);
     assert!(tokens.last().unwrap().done);
+}
+
+#[tokio::test]
+async fn consume_stream_rejects_unterminated_ollama_truncation() {
+    let cancel = Arc::new(CancelToken::new());
+    let provider = DelegatingTestProvider::with_timeouts(
+        "ollama",
+        StreamTimeouts {
+            header: Duration::from_millis(100),
+            idle: Duration::from_millis(500),
+            total: Duration::from_millis(5000),
+        },
+    );
+    let mut source = MockChunkSource::new(vec![
+        MockChunk::Immediate(Ok(Some(Bytes::from_static(
+            br#"{"message":{"content":"ciao"},"done":true,"done_reason":"length"}"#,
+        )))),
+        MockChunk::Immediate(Ok(None)),
+    ]);
+
+    let result = consume_stream(
+        &provider,
+        "stream-ollama",
+        &cancel,
+        &mut source,
+        |_| {},
+        "test-model",
+        || {},
+    )
+    .await;
+
+    assert!(result.unwrap_err().contains("truncated"));
 }
 
 #[tokio::test]

--- a/src-tauri/src/llm/tests.rs
+++ b/src-tauri/src/llm/tests.rs
@@ -304,6 +304,13 @@ fn stage_prompt_with_blob_context() {
     assert!(prompt.user.contains("Current chunk id: chunk-1"));
     assert!(system.contains("Reference document block"));
     assert!(system.contains("<chunk id=\"chunk-1\">"));
+    assert_eq!(prompt.system.len(), 3);
+    assert!(prompt.system[0].cacheable);
+    assert!(prompt.system[1].cacheable);
+    assert!(!prompt.system[2].cacheable);
+    assert!(prompt.system[0].text.contains("English to Italian"));
+    assert!(prompt.system[1].text.contains("Reference document block"));
+    assert!(prompt.system[2].text.contains("Core Instructions"));
 }
 
 #[test]
@@ -445,18 +452,18 @@ fn judge_prompt_includes_glossary_json() {
 }
 
 #[test]
-fn parses_semantic_judge_rating() {
-    let parsed = parse_judge_rating(&serde_json::json!({"rating": "sufficiente"}));
-    assert_eq!(parsed, "fair");
+fn parses_valid_judge_rating() {
+    let parsed = parse_judge_rating(&serde_json::json!({"rating": "fair"}));
+    assert_eq!(parsed.as_deref(), Ok("fair"));
 
-    let parsed = parse_judge_rating(&serde_json::json!({"rating": "ottimo"}));
-    assert_eq!(parsed, "excellent");
+    let parsed = parse_judge_rating(&serde_json::json!({"rating": "excellent"}));
+    assert_eq!(parsed.as_deref(), Ok("excellent"));
 }
 
 #[test]
-fn defaults_unknown_judge_rating_to_fair() {
+fn rejects_unknown_judge_rating() {
     let parsed = parse_judge_rating(&serde_json::json!({"rating": "ambiguous"}));
-    assert_eq!(parsed, "fair");
+    assert!(parsed.is_err());
 }
 
 #[test]
@@ -1110,7 +1117,7 @@ async fn call_openai_compatible_returns_content_on_success() {
     let prov = crate::llm::providers::openai::OpenAiCompatibleProvider::new_with_base_url(
         "openai",
         "OpenAI",
-        &format!("{}", server.uri()),
+        &server.uri().to_string(),
         "OPENAI_API_KEY",
         "gpt-4.1-mini",
         false,
@@ -1149,7 +1156,7 @@ async fn call_openai_compatible_maps_unauthorized_to_friendly_error() {
     let prov = crate::llm::providers::openai::OpenAiCompatibleProvider::new_with_base_url(
         "openai",
         "OpenAI",
-        &format!("{}", server.uri()),
+        &server.uri().to_string(),
         "OPENAI_API_KEY",
         "gpt-4.1-mini",
         false,
@@ -1189,7 +1196,7 @@ async fn call_openai_compatible_maps_rate_limit_to_friendly_error() {
     let prov = crate::llm::providers::openai::OpenAiCompatibleProvider::new_with_base_url(
         "openai",
         "OpenAI",
-        &format!("{}", server.uri()),
+        &server.uri().to_string(),
         "OPENAI_API_KEY",
         "gpt-4.1-mini",
         false,
@@ -1339,7 +1346,7 @@ async fn consume_stream_halts_immediately_when_pre_cancelled() {
 fn judge_response_parsed_from_raw_llm_output() {
     let raw = r#"```json
 {
-  "rating": "ottimo",
+  "rating": "excellent",
   "issues": [
     {
       "type": "fluency",
@@ -1354,7 +1361,7 @@ fn judge_response_parsed_from_raw_llm_output() {
     let sanitized = sanitize_llm_json_output(raw);
     let parsed: serde_json::Value =
         serde_json::from_str(sanitized).expect("should parse after sanitization");
-    let rating = parse_judge_rating(&parsed);
+    let rating = parse_judge_rating(&parsed).expect("valid rating");
     let issues: Vec<JudgeIssue> = parsed["issues"]
         .as_array()
         .into_iter()

--- a/src-tauri/src/vector/embedding.rs
+++ b/src-tauri/src/vector/embedding.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tauri::Manager;
+use tauri::State;
 
 const OPENAI_CONNECT_TIMEOUT_SECS: u64 = 10;
 const OPENAI_REQUEST_TIMEOUT_SECS: u64 = 45;
@@ -22,19 +22,18 @@ impl Serialize for EmbeddingError {
     }
 }
 
-fn db_path(app: &tauri::AppHandle) -> Result<PathBuf, EmbeddingError> {
-    app.path()
-        .app_config_dir()
-        .map(|p| p.join("glossa.db"))
-        .map_err(|e| EmbeddingError::Http(format!("cannot resolve db path: {e}")))
-}
-
 async fn run_blocking<T: Send + 'static>(
-    operation: impl FnOnce() -> Result<T, EmbeddingError> + Send + 'static,
+    connection: Arc<Mutex<rusqlite::Connection>>,
+    operation: impl FnOnce(&mut rusqlite::Connection) -> Result<T, EmbeddingError> + Send + 'static,
 ) -> Result<T, EmbeddingError> {
-    tokio::task::spawn_blocking(operation)
-        .await
-        .map_err(|error| EmbeddingError::Http(format!("database task failed: {error}")))?
+    tokio::task::spawn_blocking(move || {
+        let mut connection = connection.lock().map_err(|_| {
+            EmbeddingError::Http("vector database connection is unavailable".to_string())
+        })?;
+        operation(&mut connection)
+    })
+    .await
+    .map_err(|error| EmbeddingError::Http(format!("database task failed: {error}")))?
 }
 
 fn floats_to_blob(v: &[f32]) -> Vec<u8> {
@@ -47,99 +46,6 @@ fn openai_client() -> Result<reqwest::Client, EmbeddingError> {
         .timeout(Duration::from_secs(OPENAI_REQUEST_TIMEOUT_SECS))
         .build()
         .map_err(|e| EmbeddingError::Http(format!("cannot build OpenAI client: {e}")))
-}
-
-fn ensure_source_phrase_embeddings_schema(
-    conn: &rusqlite::Connection,
-) -> Result<(), EmbeddingError> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS source_phrase_embeddings (
-            id TEXT PRIMARY KEY,
-            project_id TEXT NOT NULL REFERENCES projects(id),
-            chunk_id TEXT,
-            source_phrase TEXT NOT NULL,
-            embedding BLOB NOT NULL,
-            created_at TEXT NOT NULL
-        );",
-    )
-    .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_source_phrase_embeddings_chunk_project \
-         ON source_phrase_embeddings(chunk_id, project_id);",
-    )
-    .map_err(|e| EmbeddingError::Http(e.to_string()))
-}
-
-fn has_column(
-    conn: &rusqlite::Connection,
-    table: &str,
-    column: &str,
-) -> Result<bool, EmbeddingError> {
-    let mut statement = conn
-        .prepare(&format!("PRAGMA table_info({table})"))
-        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-    let columns = statement
-        .query_map([], |row| row.get::<_, String>(1))
-        .map_err(|error| EmbeddingError::Http(error.to_string()))?
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-    Ok(columns.iter().any(|name| name == column))
-}
-
-fn ensure_column(
-    conn: &rusqlite::Connection,
-    table: &str,
-    column: &str,
-    definition: &str,
-) -> Result<(), EmbeddingError> {
-    if has_column(conn, table, column)? {
-        return Ok(());
-    }
-    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {definition}"))
-        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-    Ok(())
-}
-
-fn ensure_phrase_memory_schema(conn: &rusqlite::Connection) -> Result<(), EmbeddingError> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS phrase_memory (
-            id TEXT PRIMARY KEY,
-            workspace_id TEXT NOT NULL REFERENCES workspaces(id),
-            source_phrase TEXT NOT NULL,
-            target_phrase TEXT NOT NULL,
-            confidence REAL NOT NULL DEFAULT 1.0,
-            source_language TEXT NOT NULL,
-            target_language TEXT NOT NULL,
-            author TEXT,
-            work TEXT,
-            domain TEXT,
-            tags TEXT,
-            notes TEXT,
-            chunk_id TEXT,
-            project_id TEXT REFERENCES projects(id),
-            embedding BLOB NOT NULL,
-            created_at TEXT NOT NULL
-        );",
-    )
-    .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    ensure_column(
-        conn,
-        "phrase_memory",
-        "confidence",
-        "confidence REAL NOT NULL DEFAULT 1.0",
-    )?;
-    ensure_column(
-        conn,
-        "phrase_memory",
-        "embedding_model",
-        "embedding_model TEXT",
-    )?;
-    conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_phrase_memory_workspace_id ON phrase_memory(workspace_id); \
-         CREATE INDEX IF NOT EXISTS idx_phrase_memory_chunk_project ON phrase_memory(chunk_id, project_id);",
-    )
-    .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-    Ok(())
 }
 
 // ── OpenAI response types ────────────────────────────────────────────
@@ -263,14 +169,10 @@ pub struct PhraseMemoryEntryResult {
 
 #[tauri::command]
 pub async fn vec_list_phrase_memory(
-    app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
 ) -> Result<Vec<PhraseMemoryEntryResult>, EmbeddingError> {
-    let path = db_path(&app)?;
-    run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-        ensure_phrase_memory_schema(&conn)?;
+    run_blocking(database.connection(), move |conn| {
         let mut statement = conn
             .prepare(
                 "SELECT id, workspace_id, source_phrase, target_phrase, confidence, source_language, target_language, \
@@ -299,15 +201,11 @@ pub async fn vec_list_phrase_memory(
 
 #[tauri::command]
 pub async fn vec_delete_phrase_memory(
-    app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
     phrase_memory_id: String,
 ) -> Result<u32, EmbeddingError> {
-    let path = db_path(&app)?;
-    run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-        ensure_phrase_memory_schema(&conn)?;
+    run_blocking(database.connection(), move |conn| {
         conn.execute(
             "DELETE FROM phrase_memory WHERE id = ?1 AND workspace_id = ?2",
             rusqlite::params![phrase_memory_id, workspace_id],
@@ -320,18 +218,14 @@ pub async fn vec_delete_phrase_memory(
 
 #[tauri::command]
 pub async fn vec_update_phrase_memory(
-    app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
     phrase_memory_id: String,
     source_phrase: String,
     target_phrase: String,
     embedding: Vec<f32>,
 ) -> Result<u32, EmbeddingError> {
-    let path = db_path(&app)?;
-    run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-        ensure_phrase_memory_schema(&conn)?;
+    run_blocking(database.connection(), move |conn| {
         conn.execute(
             "UPDATE phrase_memory SET source_phrase = ?1, target_phrase = ?2, embedding = ?3 \
              WHERE id = ?4 AND workspace_id = ?5",
@@ -351,19 +245,15 @@ pub async fn vec_update_phrase_memory(
 
 #[tauri::command]
 pub async fn vec_search_phrase_memory(
-    app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
     query_embedding: Vec<f32>,
     threshold: f64,
     max_results: u32,
     embedding_model: String,
 ) -> Result<Vec<PhraseMatchResult>, EmbeddingError> {
-    let path = db_path(&app)?;
     let blob = floats_to_blob(&query_embedding);
-    run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-        ensure_phrase_memory_schema(&conn)?;
+    run_blocking(database.connection(), move |conn| {
         let mut statement = conn
             .prepare(
                 "WITH ranked AS ( \
@@ -410,7 +300,7 @@ pub struct PhrasePair {
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn vec_save_locked_phrases(
-    app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
     project_id: String,
     chunk_id: String,
@@ -428,29 +318,7 @@ pub async fn vec_save_locked_phrases(
         return Ok(0);
     }
 
-    let path = db_path(&app)?;
-    run_blocking(move || {
-        log::debug!(
-            "phrase_memory.vec_save_locked_phrases.db_path path={}",
-            path.display()
-        );
-        let mut conn = crate::vector::open_vec_connection(&path).map_err(|e| {
-        log::warn!(
-            "phrase_memory.vec_save_locked_phrases.db_open_failed path={} error={e}",
-            path.display()
-        );
-        EmbeddingError::Http(e.to_string())
-    })?;
-    log::debug!("phrase_memory.vec_save_locked_phrases.db_opened");
-    ensure_phrase_memory_schema(&conn).map_err(|e| {
-        log::warn!("phrase_memory.vec_save_locked_phrases.schema_phrase_failed error={e}");
-        e
-    })?;
-    ensure_source_phrase_embeddings_schema(&conn).map_err(|e| {
-        log::warn!("phrase_memory.vec_save_locked_phrases.schema_source_failed error={e}");
-        e
-    })?;
-    log::debug!("phrase_memory.vec_save_locked_phrases.schema_ready");
+    run_blocking(database.connection(), move |conn| {
 
     let workspace_exists: i64 = conn
         .query_row(
@@ -577,6 +445,7 @@ pub async fn vec_save_locked_phrases(
 #[tauri::command]
 pub async fn vec_regenerate_all_embeddings(
     app: tauri::AppHandle,
+    database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
     model: String,
 ) -> Result<u32, EmbeddingError> {
@@ -585,12 +454,9 @@ pub async fn vec_regenerate_all_embeddings(
     );
 
     // Phase 1: collect entries without blocking the async runtime.
-    let path = db_path(&app)?;
+    let connection = database.connection();
     let query_workspace_id = workspace_id.clone();
-    let entries: Vec<(String, String)> = run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
-        ensure_phrase_memory_schema(&conn)?;
+    let entries: Vec<(String, String)> = run_blocking(Arc::clone(&connection), move |conn| {
         let mut statement = conn
             .prepare("SELECT id, source_phrase FROM phrase_memory WHERE workspace_id = ?1")
             .map_err(|error| EmbeddingError::Http(error.to_string()))?;
@@ -617,11 +483,8 @@ pub async fn vec_regenerate_all_embeddings(
     let embeddings = get_embeddings(app.clone(), phrases, model.clone()).await?;
 
     // Phase 3: update without blocking the async runtime.
-    let path = db_path(&app)?;
     let update_model = model.clone();
-    let updated: u32 = run_blocking(move || {
-        let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+    let updated: u32 = run_blocking(connection, move |conn| {
         entries
             .iter()
             .zip(embeddings.iter())

--- a/src-tauri/src/vector/embedding.rs
+++ b/src-tauri/src/vector/embedding.rs
@@ -29,6 +29,14 @@ fn db_path(app: &tauri::AppHandle) -> Result<PathBuf, EmbeddingError> {
         .map_err(|e| EmbeddingError::Http(format!("cannot resolve db path: {e}")))
 }
 
+async fn run_blocking<T: Send + 'static>(
+    operation: impl FnOnce() -> Result<T, EmbeddingError> + Send + 'static,
+) -> Result<T, EmbeddingError> {
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| EmbeddingError::Http(format!("database task failed: {error}")))?
+}
+
 fn floats_to_blob(v: &[f32]) -> Vec<u8> {
     v.iter().flat_map(|f| f.to_le_bytes()).collect()
 }
@@ -54,7 +62,42 @@ fn ensure_source_phrase_embeddings_schema(
             created_at TEXT NOT NULL
         );",
     )
+    .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_source_phrase_embeddings_chunk_project \
+         ON source_phrase_embeddings(chunk_id, project_id);",
+    )
     .map_err(|e| EmbeddingError::Http(e.to_string()))
+}
+
+fn has_column(
+    conn: &rusqlite::Connection,
+    table: &str,
+    column: &str,
+) -> Result<bool, EmbeddingError> {
+    let mut statement = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|error| EmbeddingError::Http(error.to_string()))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+    Ok(columns.iter().any(|name| name == column))
+}
+
+fn ensure_column(
+    conn: &rusqlite::Connection,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> Result<(), EmbeddingError> {
+    if has_column(conn, table, column)? {
+        return Ok(());
+    }
+    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {definition}"))
+        .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+    Ok(())
 }
 
 fn ensure_phrase_memory_schema(conn: &rusqlite::Connection) -> Result<(), EmbeddingError> {
@@ -79,24 +122,23 @@ fn ensure_phrase_memory_schema(conn: &rusqlite::Connection) -> Result<(), Embedd
         );",
     )
     .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    if let Err(err) = conn.execute(
-        "ALTER TABLE phrase_memory ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0",
-        [],
-    ) {
-        let message = err.to_string();
-        if !message.contains("duplicate column") && !message.contains("already exists") {
-            return Err(EmbeddingError::Http(message));
-        }
-    }
-    if let Err(err) = conn.execute(
-        "ALTER TABLE phrase_memory ADD COLUMN embedding_model TEXT",
-        [],
-    ) {
-        let message = err.to_string();
-        if !message.contains("duplicate column") && !message.contains("already exists") {
-            return Err(EmbeddingError::Http(message));
-        }
-    }
+    ensure_column(
+        conn,
+        "phrase_memory",
+        "confidence",
+        "confidence REAL NOT NULL DEFAULT 1.0",
+    )?;
+    ensure_column(
+        conn,
+        "phrase_memory",
+        "embedding_model",
+        "embedding_model TEXT",
+    )?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_phrase_memory_workspace_id ON phrase_memory(workspace_id); \
+         CREATE INDEX IF NOT EXISTS idx_phrase_memory_chunk_project ON phrase_memory(chunk_id, project_id);",
+    )
+    .map_err(|error| EmbeddingError::Http(error.to_string()))?;
     Ok(())
 }
 
@@ -225,45 +267,34 @@ pub async fn vec_list_phrase_memory(
     workspace_id: String,
 ) -> Result<Vec<PhraseMemoryEntryResult>, EmbeddingError> {
     let path = db_path(&app)?;
-    let conn = crate::vector::open_vec_connection(&path)
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    ensure_phrase_memory_schema(&conn)?;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, workspace_id, source_phrase, target_phrase, confidence, source_language, target_language, \
-                    author, work, domain, tags, notes, chunk_id, project_id, embedding_model, created_at \
-             FROM phrase_memory \
-             WHERE workspace_id = ?1 \
-             ORDER BY datetime(created_at) DESC, id DESC",
-        )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-
-    let results: rusqlite::Result<Vec<PhraseMemoryEntryResult>> = stmt
-        .query_map(rusqlite::params![workspace_id], |row| {
-            Ok(PhraseMemoryEntryResult {
-                id: row.get(0)?,
-                workspace_id: row.get(1)?,
-                source_phrase: row.get(2)?,
-                target_phrase: row.get(3)?,
-                confidence: row.get(4)?,
-                source_language: row.get(5)?,
-                target_language: row.get(6)?,
-                author: row.get(7)?,
-                work: row.get(8)?,
-                domain: row.get(9)?,
-                tags: row.get(10)?,
-                notes: row.get(11)?,
-                chunk_id: row.get(12)?,
-                project_id: row.get(13)?,
-                embedding_model: row.get(14)?,
-                created_at: row.get(15)?,
+    run_blocking(move || {
+        let conn = crate::vector::open_vec_connection(&path)
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        ensure_phrase_memory_schema(&conn)?;
+        let mut statement = conn
+            .prepare(
+                "SELECT id, workspace_id, source_phrase, target_phrase, confidence, source_language, target_language, \
+                        author, work, domain, tags, notes, chunk_id, project_id, embedding_model, created_at \
+                 FROM phrase_memory WHERE workspace_id = ?1 ORDER BY datetime(created_at) DESC, id DESC",
+            )
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        let entries = statement
+            .query_map(rusqlite::params![workspace_id], |row| {
+                Ok(PhraseMemoryEntryResult {
+                    id: row.get(0)?, workspace_id: row.get(1)?, source_phrase: row.get(2)?,
+                    target_phrase: row.get(3)?, confidence: row.get(4)?, source_language: row.get(5)?,
+                    target_language: row.get(6)?, author: row.get(7)?, work: row.get(8)?,
+                    domain: row.get(9)?, tags: row.get(10)?, notes: row.get(11)?,
+                    chunk_id: row.get(12)?, project_id: row.get(13)?, embedding_model: row.get(14)?,
+                    created_at: row.get(15)?,
+                })
             })
-        })
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?
-        .collect();
-
-    results.map_err(|e| EmbeddingError::Http(e.to_string()))
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        Ok(entries)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -273,18 +304,18 @@ pub async fn vec_delete_phrase_memory(
     phrase_memory_id: String,
 ) -> Result<u32, EmbeddingError> {
     let path = db_path(&app)?;
-    let conn = crate::vector::open_vec_connection(&path)
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    ensure_phrase_memory_schema(&conn)?;
-
-    let deleted = conn
-        .execute(
+    run_blocking(move || {
+        let conn = crate::vector::open_vec_connection(&path)
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        ensure_phrase_memory_schema(&conn)?;
+        conn.execute(
             "DELETE FROM phrase_memory WHERE id = ?1 AND workspace_id = ?2",
             rusqlite::params![phrase_memory_id, workspace_id],
         )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-
-    Ok(deleted as u32)
+        .map(|count| count as u32)
+        .map_err(|error| EmbeddingError::Http(error.to_string()))
+    })
+    .await
 }
 
 #[tauri::command]
@@ -297,14 +328,12 @@ pub async fn vec_update_phrase_memory(
     embedding: Vec<f32>,
 ) -> Result<u32, EmbeddingError> {
     let path = db_path(&app)?;
-    let conn = crate::vector::open_vec_connection(&path)
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    ensure_phrase_memory_schema(&conn)?;
-
-    let updated = conn
-        .execute(
-            "UPDATE phrase_memory \
-             SET source_phrase = ?1, target_phrase = ?2, embedding = ?3 \
+    run_blocking(move || {
+        let conn = crate::vector::open_vec_connection(&path)
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        ensure_phrase_memory_schema(&conn)?;
+        conn.execute(
+            "UPDATE phrase_memory SET source_phrase = ?1, target_phrase = ?2, embedding = ?3 \
              WHERE id = ?4 AND workspace_id = ?5",
             rusqlite::params![
                 source_phrase,
@@ -314,9 +343,10 @@ pub async fn vec_update_phrase_memory(
                 workspace_id
             ],
         )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-
-    Ok(updated as u32)
+        .map(|count| count as u32)
+        .map_err(|error| EmbeddingError::Http(error.to_string()))
+    })
+    .await
 }
 
 #[tauri::command]
@@ -329,46 +359,43 @@ pub async fn vec_search_phrase_memory(
     embedding_model: String,
 ) -> Result<Vec<PhraseMatchResult>, EmbeddingError> {
     let path = db_path(&app)?;
-    let conn = crate::vector::open_vec_connection(&path)
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-    ensure_phrase_memory_schema(&conn)?;
-
     let blob = floats_to_blob(&query_embedding);
-
-    let mut stmt = conn
-        .prepare(
-            "WITH ranked AS ( \
-               SELECT pm.id, pm.source_phrase, pm.target_phrase, pm.confidence, \
-                      vec_distance_cosine(pm.embedding, ?1) AS distance \
-               FROM phrase_memory pm \
-               WHERE pm.workspace_id = ?2 \
-                 AND (pm.embedding_model IS NULL OR pm.embedding_model = ?5) \
-             ) \
-             SELECT id, source_phrase, target_phrase, confidence, distance \
-             FROM ranked \
-             WHERE distance < ?3 \
-             ORDER BY distance ASC \
-             LIMIT ?4",
-        )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-
-    let results: rusqlite::Result<Vec<PhraseMatchResult>> = stmt
-        .query_map(
-            rusqlite::params![blob, workspace_id, threshold, max_results, embedding_model],
-            |row| {
-                Ok(PhraseMatchResult {
-                    phrase_memory_id: row.get(0)?,
-                    source_phrase: row.get(1)?,
-                    target_phrase: row.get(2)?,
-                    confidence: row.get(3)?,
-                    distance: row.get(4)?,
-                })
-            },
-        )
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?
-        .collect();
-
-    results.map_err(|e| EmbeddingError::Http(e.to_string()))
+    run_blocking(move || {
+        let conn = crate::vector::open_vec_connection(&path)
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        ensure_phrase_memory_schema(&conn)?;
+        let mut statement = conn
+            .prepare(
+                "WITH ranked AS ( \
+                   SELECT pm.id, pm.source_phrase, pm.target_phrase, pm.confidence, \
+                          vec_distance_cosine(pm.embedding, ?1) AS distance \
+                   FROM phrase_memory pm \
+                   WHERE pm.workspace_id = ?2 \
+                     AND (pm.embedding_model IS NULL OR pm.embedding_model = ?5) \
+                 ) \
+                 SELECT id, source_phrase, target_phrase, confidence, distance FROM ranked \
+                 WHERE distance < ?3 ORDER BY distance ASC LIMIT ?4",
+            )
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        let matches = statement
+            .query_map(
+                rusqlite::params![blob, workspace_id, threshold, max_results, embedding_model],
+                |row| {
+                    Ok(PhraseMatchResult {
+                        phrase_memory_id: row.get(0)?,
+                        source_phrase: row.get(1)?,
+                        target_phrase: row.get(2)?,
+                        confidence: row.get(3)?,
+                        distance: row.get(4)?,
+                    })
+                },
+            )
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        Ok(matches)
+    })
+    .await
 }
 
 #[derive(Debug, Deserialize)]
@@ -402,11 +429,12 @@ pub async fn vec_save_locked_phrases(
     }
 
     let path = db_path(&app)?;
-    log::debug!(
-        "phrase_memory.vec_save_locked_phrases.db_path path={}",
-        path.display()
-    );
-    let mut conn = crate::vector::open_vec_connection(&path).map_err(|e| {
+    run_blocking(move || {
+        log::debug!(
+            "phrase_memory.vec_save_locked_phrases.db_path path={}",
+            path.display()
+        );
+        let mut conn = crate::vector::open_vec_connection(&path).map_err(|e| {
         log::warn!(
             "phrase_memory.vec_save_locked_phrases.db_open_failed path={} error={e}",
             path.display()
@@ -541,7 +569,9 @@ pub async fn vec_save_locked_phrases(
         pairs.len(),
         save_started.elapsed().as_millis()
     );
-    Ok(saved)
+        Ok(saved)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -554,24 +584,26 @@ pub async fn vec_regenerate_all_embeddings(
         "phrase_memory.vec_regenerate_all_embeddings.start workspace_id={workspace_id} model={model}"
     );
 
-    // Phase 1: collect entries — conn dropped before the await below
-    let entries: Vec<(String, String)> = {
-        let path = db_path(&app)?;
+    // Phase 1: collect entries without blocking the async runtime.
+    let path = db_path(&app)?;
+    let query_workspace_id = workspace_id.clone();
+    let entries: Vec<(String, String)> = run_blocking(move || {
         let conn = crate::vector::open_vec_connection(&path)
-            .map_err(|e| EmbeddingError::Http(e.to_string()))?;
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
         ensure_phrase_memory_schema(&conn)?;
-        let mut stmt = conn
+        let mut statement = conn
             .prepare("SELECT id, source_phrase FROM phrase_memory WHERE workspace_id = ?1")
-            .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-        let result: Vec<(String, String)> = stmt
-            .query_map(rusqlite::params![workspace_id], |row| {
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        let entries = statement
+            .query_map(rusqlite::params![query_workspace_id], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
-            .map_err(|e| EmbeddingError::Http(e.to_string()))?
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?
             .collect::<rusqlite::Result<_>>()
-            .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-        result
-    };
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        Ok(entries)
+    })
+    .await?;
 
     if entries.is_empty() {
         log::debug!(
@@ -584,25 +616,27 @@ pub async fn vec_regenerate_all_embeddings(
     let phrases: Vec<String> = entries.iter().map(|(_, p)| p.clone()).collect();
     let embeddings = get_embeddings(app.clone(), phrases, model.clone()).await?;
 
-    // Phase 3: update — reopen conn after await
+    // Phase 3: update without blocking the async runtime.
     let path = db_path(&app)?;
-    let conn = crate::vector::open_vec_connection(&path)
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?;
-
-    let updated: u32 = entries
-        .iter()
-        .zip(embeddings.iter())
-        .map(|((id, _), emb)| {
-            conn.execute(
-                "UPDATE phrase_memory SET embedding = ?1, embedding_model = ?2 WHERE id = ?3",
-                rusqlite::params![floats_to_blob(emb), &model, id],
-            )
-            .map(|n| n as u32)
-        })
-        .collect::<rusqlite::Result<Vec<u32>>>()
-        .map_err(|e| EmbeddingError::Http(e.to_string()))?
-        .iter()
-        .sum();
+    let update_model = model.clone();
+    let updated: u32 = run_blocking(move || {
+        let conn = crate::vector::open_vec_connection(&path)
+            .map_err(|error| EmbeddingError::Http(error.to_string()))?;
+        entries
+            .iter()
+            .zip(embeddings.iter())
+            .map(|((id, _), embedding)| {
+                conn.execute(
+                    "UPDATE phrase_memory SET embedding = ?1, embedding_model = ?2 WHERE id = ?3",
+                    rusqlite::params![floats_to_blob(embedding), &update_model, id],
+                )
+                .map(|count| count as u32)
+            })
+            .collect::<rusqlite::Result<Vec<u32>>>()
+            .map_err(|error| EmbeddingError::Http(error.to_string()))
+            .map(|counts| counts.into_iter().sum())
+    })
+    .await?;
 
     log::info!(
         "phrase_memory.vec_regenerate_all_embeddings.done workspace_id={workspace_id} model={model} updated={updated}"

--- a/src-tauri/src/vector/embedding.rs
+++ b/src-tauri/src/vector/embedding.rs
@@ -172,7 +172,8 @@ pub async fn vec_list_phrase_memory(
     database: State<'_, crate::vector::VectorDatabase>,
     workspace_id: String,
 ) -> Result<Vec<PhraseMemoryEntryResult>, EmbeddingError> {
-    run_blocking(database.connection(), move |conn| {
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
+    run_blocking(connection, move |conn| {
         let mut statement = conn
             .prepare(
                 "SELECT id, workspace_id, source_phrase, target_phrase, confidence, source_language, target_language, \
@@ -205,7 +206,8 @@ pub async fn vec_delete_phrase_memory(
     workspace_id: String,
     phrase_memory_id: String,
 ) -> Result<u32, EmbeddingError> {
-    run_blocking(database.connection(), move |conn| {
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
+    run_blocking(connection, move |conn| {
         conn.execute(
             "DELETE FROM phrase_memory WHERE id = ?1 AND workspace_id = ?2",
             rusqlite::params![phrase_memory_id, workspace_id],
@@ -225,7 +227,8 @@ pub async fn vec_update_phrase_memory(
     target_phrase: String,
     embedding: Vec<f32>,
 ) -> Result<u32, EmbeddingError> {
-    run_blocking(database.connection(), move |conn| {
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
+    run_blocking(connection, move |conn| {
         conn.execute(
             "UPDATE phrase_memory SET source_phrase = ?1, target_phrase = ?2, embedding = ?3 \
              WHERE id = ?4 AND workspace_id = ?5",
@@ -253,7 +256,8 @@ pub async fn vec_search_phrase_memory(
     embedding_model: String,
 ) -> Result<Vec<PhraseMatchResult>, EmbeddingError> {
     let blob = floats_to_blob(&query_embedding);
-    run_blocking(database.connection(), move |conn| {
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
+    run_blocking(connection, move |conn| {
         let mut statement = conn
             .prepare(
                 "WITH ranked AS ( \
@@ -318,7 +322,8 @@ pub async fn vec_save_locked_phrases(
         return Ok(0);
     }
 
-    run_blocking(database.connection(), move |conn| {
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
+    run_blocking(connection, move |conn| {
 
     let workspace_exists: i64 = conn
         .query_row(
@@ -454,7 +459,7 @@ pub async fn vec_regenerate_all_embeddings(
     );
 
     // Phase 1: collect entries without blocking the async runtime.
-    let connection = database.connection();
+    let connection = database.connection().map_err(EmbeddingError::Http)?;
     let query_workspace_id = workspace_id.clone();
     let entries: Vec<(String, String)> = run_blocking(Arc::clone(&connection), move |conn| {
         let mut statement = conn

--- a/src-tauri/src/vector/mod.rs
+++ b/src-tauri/src/vector/mod.rs
@@ -2,7 +2,27 @@ pub mod embedding;
 
 use rusqlite::{ffi::sqlite3_auto_extension, Connection, Result as RusqliteResult};
 use std::path::PathBuf;
-use tauri::Manager;
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Manager, State};
+
+#[derive(Clone)]
+pub struct VectorDatabase {
+    connection: Arc<Mutex<Connection>>,
+}
+
+impl VectorDatabase {
+    pub fn initialize(app: &AppHandle) -> Result<Self, String> {
+        let db_path = get_db_path(app)?;
+        let connection = open_vec_connection(&db_path).map_err(|error| error.to_string())?;
+        Ok(Self {
+            connection: Arc::new(Mutex::new(connection)),
+        })
+    }
+
+    pub fn connection(&self) -> Arc<Mutex<Connection>> {
+        Arc::clone(&self.connection)
+    }
+}
 
 /// Register sqlite-vec as an auto-extension.
 /// Must be called once at startup before opening any connection.
@@ -29,11 +49,14 @@ pub fn open_vec_connection(db_path: &PathBuf) -> RusqliteResult<Connection> {
 }
 
 #[tauri::command]
-pub fn vec_ping(app: tauri::AppHandle) -> Result<String, String> {
-    let db_path = get_db_path(&app)?;
-    open_vec_connection(&db_path)
-        .and_then(|conn| conn.query_row("SELECT vec_version()", [], |row| row.get::<_, String>(0)))
-        .map_err(|e| e.to_string())
+pub fn vec_ping(database: State<'_, VectorDatabase>) -> Result<String, String> {
+    let database_connection = database.connection();
+    let connection = database_connection
+        .lock()
+        .map_err(|_| "Vector database connection is unavailable".to_string())?;
+    connection
+        .query_row("SELECT vec_version()", [], |row| row.get::<_, String>(0))
+        .map_err(|error| error.to_string())
 }
 
 pub fn get_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -41,4 +64,22 @@ pub fn get_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         .app_config_dir()
         .map(|d| d.join("glossa.db"))
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reuses_the_same_connection_handle() -> RusqliteResult<()> {
+        let database = VectorDatabase {
+            connection: Arc::new(Mutex::new(Connection::open_in_memory()?)),
+        };
+
+        let first = database.connection();
+        let second = database.connection();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        Ok(())
+    }
 }

--- a/src-tauri/src/vector/mod.rs
+++ b/src-tauri/src/vector/mod.rs
@@ -7,20 +7,22 @@ use tauri::{AppHandle, Manager, State};
 
 #[derive(Clone)]
 pub struct VectorDatabase {
-    connection: Arc<Mutex<Connection>>,
+    connection: Result<Arc<Mutex<Connection>>, String>,
 }
 
 impl VectorDatabase {
-    pub fn initialize(app: &AppHandle) -> Result<Self, String> {
-        let db_path = get_db_path(app)?;
-        let connection = open_vec_connection(&db_path).map_err(|error| error.to_string())?;
-        Ok(Self {
-            connection: Arc::new(Mutex::new(connection)),
-        })
+    pub fn initialize(app: &AppHandle) -> Self {
+        let connection = get_db_path(app)
+            .and_then(|db_path| open_vec_connection(&db_path).map_err(|error| error.to_string()))
+            .map(|connection| Arc::new(Mutex::new(connection)));
+        Self { connection }
     }
 
-    pub fn connection(&self) -> Arc<Mutex<Connection>> {
-        Arc::clone(&self.connection)
+    pub fn connection(&self) -> Result<Arc<Mutex<Connection>>, String> {
+        self.connection
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(Clone::clone)
     }
 }
 
@@ -50,7 +52,7 @@ pub fn open_vec_connection(db_path: &PathBuf) -> RusqliteResult<Connection> {
 
 #[tauri::command]
 pub fn vec_ping(database: State<'_, VectorDatabase>) -> Result<String, String> {
-    let database_connection = database.connection();
+    let database_connection = database.connection()?;
     let connection = database_connection
         .lock()
         .map_err(|_| "Vector database connection is unavailable".to_string())?;
@@ -73,13 +75,29 @@ mod tests {
     #[test]
     fn reuses_the_same_connection_handle() -> RusqliteResult<()> {
         let database = VectorDatabase {
-            connection: Arc::new(Mutex::new(Connection::open_in_memory()?)),
+            connection: Ok(Arc::new(Mutex::new(Connection::open_in_memory()?))),
         };
 
-        let first = database.connection();
-        let second = database.connection();
+        let first = database
+            .connection()
+            .expect("in-memory connection is available");
+        let second = database
+            .connection()
+            .expect("in-memory connection is available");
 
         assert!(Arc::ptr_eq(&first, &second));
         Ok(())
+    }
+
+    #[test]
+    fn retains_initialization_error_without_aborting_setup() {
+        let database = VectorDatabase {
+            connection: Err("cannot open database".to_string()),
+        };
+
+        assert_eq!(
+            database.connection().err().as_deref(),
+            Some("cannot open database")
+        );
     }
 }

--- a/src/hooks/pipeline/runJudge.ts
+++ b/src/hooks/pipeline/runJudge.ts
@@ -1,6 +1,7 @@
 import { toast } from 'sonner';
 import { usePipelineStore } from '../../stores/pipelineStore';
-import { llmService } from '../../services/llmService';
+import { useChunksStore } from '../../stores/chunksStore';
+import { isStreamCancelledError, llmService } from '../../services/llmService';
 import { withRetry, friendlyError } from '../../utils/retry';
 import { qualityDefault, qualityFailure } from '../../utils';
 import { pipelineLog } from '../../utils/pipelineLogging';
@@ -31,6 +32,7 @@ export async function runJudgeForChunk(
 ): Promise<ChunkOutcome> {
   const config = effectiveConfig ?? usePipelineStore.getState().config;
   if (!textToAudit) return 'skipped';
+  if (useChunksStore.getState().cancelRequested) return 'cancelled';
 
   actions.updateChunkStatus(chunk.id, 'processing');
   const judgeRef = {
@@ -54,6 +56,7 @@ export async function runJudgeForChunk(
       ),
       {
         label: 'Audit',
+        shouldCancel: () => useChunksStore.getState().cancelRequested,
         onRetry: (attempt, total, error, delayMs) =>
           pipelineLog.auditRetry(chunk.id, attempt, total, error, delayMs),
       },
@@ -79,6 +82,16 @@ export async function runJudgeForChunk(
     pipelineLog.auditEnd(chunk.id, judgeRef, Date.now() - auditStartedAt, judgeTokenUsage);
     return 'completed';
   } catch (error: unknown) {
+    if (isStreamCancelledError(error)) {
+      actions.updateChunkJudge(chunk.id, {
+        content: textToAudit,
+        status: 'idle',
+        rating: qualityDefault(),
+        issues: [],
+      });
+      actions.updateChunkStatus(chunk.id, 'ready');
+      return 'cancelled';
+    }
     const msg = friendlyError(error instanceof Error ? error.message : String(error));
     actions.updateChunkJudge(chunk.id, {
       content: textToAudit,

--- a/src/hooks/usePipeline.test.ts
+++ b/src/hooks/usePipeline.test.ts
@@ -428,6 +428,45 @@ describe('usePipeline', () => {
     expect(toast.message).toHaveBeenCalledWith('pipeline.stopConfirmed');
   });
 
+  it('does not start the next stage or audit after cancellation between stages', async () => {
+    usePipelineStore.setState((state) => ({
+      ...state,
+      config: {
+        ...state.config,
+        stages: [
+          { id: 'stg-1', name: 'Stage 1', prompt: 'Translate', model: 'gemini-3-flash-preview', provider: 'gemini', enabled: true },
+          { id: 'stg-2', name: 'Stage 2', prompt: 'Refine', model: 'gemini-3-flash-preview', provider: 'gemini', enabled: true },
+        ],
+      },
+    }));
+    llmMocks.runStage.mockImplementationOnce(async () => {
+      useChunksStore.getState().requestCancel();
+      return { content: 'First output' };
+    });
+
+    const { result } = renderHook(() => usePipeline());
+    await act(async () => {
+      await result.current.runPipeline();
+    });
+
+    expect(llmMocks.runStage).toHaveBeenCalledTimes(1);
+    expect(llmMocks.judgeTranslation).not.toHaveBeenCalled();
+    expect(useChunksStore.getState().chunks[0].status).toBe('ready');
+  });
+
+  it('marks an empty translation stage as an error instead of silently skipping it', async () => {
+    llmMocks.runStage.mockResolvedValue({ content: ' \n ' });
+
+    const { result } = renderHook(() => usePipeline());
+    await act(async () => {
+      await result.current.runPipeline();
+    });
+
+    expect(llmMocks.judgeTranslation).not.toHaveBeenCalled();
+    expect(useChunksStore.getState().chunks[0].status).toBe('error');
+    expect(useChunksStore.getState().chunks[0].stageResults['stg-1']?.status).toBe('error');
+  });
+
   it('blocks the run when Ollama is offline', async () => {
     usePipelineStore.setState((state) => ({
       ...state,

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -338,6 +338,7 @@ export function usePipeline() {
           },
           {
             label: `Stage "${stage.name}"`,
+            shouldCancel: () => useChunksStore.getState().cancelRequested,
             onRetry: (attempt, total, error, delayMs) => {
               if (is429Error(error)) {
                 updateChunkStage(chunk.id, stage.id, { content: '', status: 'retrying', retryInfo: { attempt, total, delayMs } });
@@ -347,6 +348,14 @@ export function usePipeline() {
           },
         );
         const rawResult = stageResult.content;
+        if (!isFormatStage && !rawResult.trim()) {
+          throw new Error('Stage returned empty output');
+        }
+        if (useChunksStore.getState().cancelRequested) {
+          updateChunkStage(chunk.id, stage.id, { content: '', status: 'idle' });
+          updateChunkStatus(chunk.id, 'ready');
+          return 'cancelled';
+        }
         const result = isFormatStage && !rawResult.trim() ? stageText : rawResult;
         if (isFormatStage && !rawResult.trim() && stageText.trim()) {
           pipelineLog.stageNote(chunk.id, stage.id, 'warn', 'Format stage returned empty output; using previous stage output');
@@ -389,13 +398,17 @@ export function usePipeline() {
     }
 
     if (!producedOutput) {
-      updateChunkStatus(chunk.id, 'ready');
-      return 'skipped';
+      updateChunkStatus(chunk.id, 'error');
+      return 'failed';
     }
 
     updateChunkDraft(chunk.id, lastResult);
 
     if (lastResult) {
+      if (useChunksStore.getState().cancelRequested) {
+        updateChunkStatus(chunk.id, 'ready');
+        return 'cancelled';
+      }
       const auditOutcome = await runJudgeForChunk(chunk, lastResult, judgeActions, lastEffectiveConfig);
       if (auditOutcome === 'failed') return 'failed';
       if (auditOutcome === 'cancelled') return 'cancelled';

--- a/src/hooks/usePipeline.ts
+++ b/src/hooks/usePipeline.ts
@@ -354,6 +354,7 @@ export function usePipeline() {
         if (useChunksStore.getState().cancelRequested) {
           updateChunkStage(chunk.id, stage.id, { content: '', status: 'idle' });
           updateChunkStatus(chunk.id, 'ready');
+          pipelineLog.stageCancelled(chunk.id, stage.id, stage.name, Date.now() - stageStartedAt);
           return 'cancelled';
         }
         const result = isFormatStage && !rawResult.trim() ? stageText : rawResult;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -535,6 +535,8 @@
   "errors": {
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred.",
+    "databaseInitTitle": "Could not open the database",
+    "databaseInitDescription": "Restart Glossa. If the problem persists, close any other running instance of the app and try again.",
     "tryAgain": "Try Again",
     "unknownError": "Unknown error",
     "stageFailed": "Stage \"{{name}}\" failed",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -535,6 +535,8 @@
   "errors": {
     "somethingWentWrong": "Qualcosa è andato storto",
     "unexpectedError": "Si è verificato un errore imprevisto.",
+    "databaseInitTitle": "Impossibile aprire il database",
+    "databaseInitDescription": "Riavvia Glossa. Se il problema persiste, chiudi ogni altra istanza dell'app eventualmente rimasta aperta e riprova.",
     "tryAgain": "Riprova",
     "unknownError": "Errore sconosciuto",
     "stageFailed": "Fase \"{{name}}\" fallita",

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initDatabase = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock('./App.tsx', () => ({ default: () => <div>Glossa</div> }));
+vi.mock('./services/dbService.ts', () => ({ initDatabase }));
+
+type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown };
+
+async function loadMain() {
+  document.body.innerHTML = '<div id="root"></div>';
+  vi.resetModules();
+  return import('./main.tsx');
+}
+
+describe('database initialization failure', () => {
+  beforeEach(() => {
+    initDatabase.mockClear();
+    delete (window as TauriWindow).__TAURI_INTERNALS__;
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as TauriWindow).__TAURI_INTERNALS__;
+  });
+
+  it('identifies the Tauri webview without treating browser development as the app', async () => {
+    const { isTauriRuntime } = await loadMain();
+
+    expect(isTauriRuntime()).toBe(false);
+    (window as TauriWindow).__TAURI_INTERNALS__ = {};
+    expect(isTauriRuntime()).toBe(true);
+  });
+
+  it('shows a translated recovery screen without raw database details', async () => {
+    const { DatabaseInitError } = await loadMain();
+    const { default: i18n } = await import('./i18n');
+    await i18n.changeLanguage('en');
+
+    render(<DatabaseInitError />);
+
+    expect(screen.getByText('Could not open the database')).toBeInTheDocument();
+    expect(screen.getByText(/Restart Glossa/)).toBeInTheDocument();
+    expect(screen.queryByText(/glossa\.db/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,28 +2,25 @@ import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App.tsx';
 import { initDatabase } from './services/dbService.ts';
-import './i18n';
+import i18n from './i18n';
 import './index.css';
 
 // Tauri v2 injects this global into the webview; absent when running under
 // plain `vite dev` in a browser (no Rust backend, no real database file).
-function isTauriRuntime(): boolean {
+export function isTauriRuntime(): boolean {
   return '__TAURI_INTERNALS__' in window;
 }
 
-function DatabaseInitError({ error }: { error: unknown }) {
-  const message = error instanceof Error ? error.message : String(error);
+export function DatabaseInitError() {
   return (
     <div className="flex h-screen items-center justify-center bg-editorial-bg px-6 font-sans text-editorial-ink">
       <div className="max-w-md text-center">
         <p className="text-lg font-display italic text-editorial-danger">
-          Impossibile aprire il database
+          {i18n.t('errors.databaseInitTitle')}
         </p>
         <p className="mt-2 text-sm text-editorial-muted">
-          Riavvia Glossa. Se il problema persiste, chiudi ogni altra istanza dell'app eventualmente
-          rimasta aperta e riprova.
+          {i18n.t('errors.databaseInitDescription')}
         </p>
-        <p className="mt-4 text-xs text-editorial-muted">{message}</p>
       </div>
     </div>
   );
@@ -46,7 +43,7 @@ initDatabase()
       // render a UI that will hit "no such table" on first database access.
       root.render(
         <StrictMode>
-          <DatabaseInitError error={err} />
+          <DatabaseInitError />
         </StrictMode>,
       );
     } else {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,30 @@ import { initDatabase } from './services/dbService.ts';
 import './i18n';
 import './index.css';
 
+// Tauri v2 injects this global into the webview; absent when running under
+// plain `vite dev` in a browser (no Rust backend, no real database file).
+function isTauriRuntime(): boolean {
+  return '__TAURI_INTERNALS__' in window;
+}
+
+function DatabaseInitError({ error }: { error: unknown }) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    <div className="flex h-screen items-center justify-center bg-editorial-bg px-6 font-sans text-editorial-ink">
+      <div className="max-w-md text-center">
+        <p className="text-lg font-display italic text-editorial-danger">
+          Impossibile aprire il database
+        </p>
+        <p className="mt-2 text-sm text-editorial-muted">
+          Riavvia Glossa. Se il problema persiste, chiudi ogni altra istanza dell'app eventualmente
+          rimasta aperta e riprova.
+        </p>
+        <p className="mt-4 text-xs text-editorial-muted">{message}</p>
+      </div>
+    </div>
+  );
+}
+
 // Initialize SQLite database, then render
 initDatabase()
   .then(() => {
@@ -16,10 +40,21 @@ initDatabase()
   })
   .catch((err) => {
     console.error('[Glossa] Failed to initialize database:', err);
-    // Render anyway (DB may not be available in browser dev mode)
-    createRoot(document.getElementById('root')!).render(
-      <StrictMode>
-        <App />
-      </StrictMode>,
-    );
+    const root = createRoot(document.getElementById('root')!);
+    if (isTauriRuntime()) {
+      // Real app, real failure: schema may be incomplete — don't silently
+      // render a UI that will hit "no such table" on first database access.
+      root.render(
+        <StrictMode>
+          <DatabaseInitError error={err} />
+        </StrictMode>,
+      );
+    } else {
+      // Browser dev mode: no Tauri backend, no database file — expected to fail, render anyway.
+      root.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
+    }
   });

--- a/src/services/dbService.test.ts
+++ b/src/services/dbService.test.ts
@@ -72,6 +72,9 @@ const dbState = vi.hoisted(() => {
     setWorkspaceCount: (value: number) => {
       workspaceCount = value;
     },
+    setColumns: (table: string, columns: string[]) => {
+      columnsByTable.set(table, columns);
+    },
     db: { execute, select },
     load: vi.fn(async () => ({ execute, select })),
   };
@@ -205,6 +208,7 @@ describe('initDatabase migrations', () => {
     dbState.columnsByTable.set('translations', ['id', 'project_id', 'original_text', 'final_translation', 'stage_results', 'judge_issues', 'created_at']);
     dbState.columnsByTable.set('prompt_templates', []);
     dbState.columnsByTable.set('operation_logs', []);
+    dbState.setColumns('phrase_memory', []);
   });
 
   it('backs up and resets a beta database with an old schema version', async () => {
@@ -278,7 +282,7 @@ describe('initDatabase migrations', () => {
     );
   });
 
-  it('creates phrase memory schema tables and workspace_id column', async () => {
+  it('creates and migrates the complete phrase memory schema at startup', async () => {
     const { initDatabase } = await import('./dbService');
 
     await initDatabase();
@@ -303,6 +307,21 @@ describe('initDatabase migrations', () => {
     expect(dbState.db.execute).toHaveBeenCalledWith(
       expect.stringContaining('confidence REAL NOT NULL DEFAULT 1.0'),
     );
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('embedding_model TEXT'),
+    );
+    expect(dbState.db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('ALTER TABLE phrase_memory ADD COLUMN embedding_model TEXT'),
+    );
+    for (const index of [
+      'idx_phrase_memory_workspace_id',
+      'idx_phrase_memory_chunk_project',
+      'idx_source_phrase_embeddings_chunk_project',
+    ]) {
+      expect(dbState.db.execute).toHaveBeenCalledWith(
+        expect.stringContaining(`CREATE INDEX IF NOT EXISTS ${index}`),
+      );
+    }
   });
 
   it('inserts active_workspace_id key into app_settings on fresh database', async () => {

--- a/src/services/dbService.ts
+++ b/src/services/dbService.ts
@@ -51,7 +51,9 @@ function serializeWrite<T>(fn: () => Promise<T>): Promise<T> {
 // Any call with values outside this set is rejected to prevent SQL injection.
 // Columns baked into the initial CREATE TABLE statements don't need an entry here —
 // add one only when a future schema change adds a column via ensureColumn().
-const ALLOWED_MIGRATIONS = new Set<string>([]);
+const ALLOWED_MIGRATIONS = new Set<string>([
+  'phrase_memory.embedding_model',
+]);
 
 const VALID_COLUMN_DEFINITION = /^(INTEGER|TEXT|REAL|BLOB|NUMERIC)(\s+NOT\s+NULL)?(\s+DEFAULT\s+('[^']*'|NULL|-?\d+(\.\d+)?))?$/i;
 
@@ -403,9 +405,12 @@ export async function initDatabase(): Promise<void> {
       chunk_id TEXT,
       project_id TEXT REFERENCES projects(id),
       embedding BLOB NOT NULL,
+      embedding_model TEXT,
       created_at TEXT NOT NULL
     )
   `);
+
+  await ensureColumn('phrase_memory', 'embedding_model', 'TEXT');
 
   await conn.execute(`
     CREATE TABLE IF NOT EXISTS source_phrase_embeddings (
@@ -416,6 +421,21 @@ export async function initDatabase(): Promise<void> {
       embedding BLOB NOT NULL,
       created_at TEXT NOT NULL
     )
+  `);
+
+  await conn.execute(`
+    CREATE INDEX IF NOT EXISTS idx_phrase_memory_workspace_id
+    ON phrase_memory(workspace_id)
+  `);
+
+  await conn.execute(`
+    CREATE INDEX IF NOT EXISTS idx_phrase_memory_chunk_project
+    ON phrase_memory(chunk_id, project_id)
+  `);
+
+  await conn.execute(`
+    CREATE INDEX IF NOT EXISTS idx_source_phrase_embeddings_chunk_project
+    ON source_phrase_embeddings(chunk_id, project_id)
   `);
 
   await conn.execute(`

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { withRetry, classifyError, friendlyError } from './retry';
 
 describe('classifyError', () => {
@@ -86,6 +86,11 @@ describe('withRetry', () => {
     vi.useFakeTimers();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it('returns result on first success', async () => {
     const fn = vi.fn().mockResolvedValue('ok');
     const result = await withRetry(fn, { maxRetries: 3, baseDelayMs: 10 });
@@ -121,6 +126,38 @@ describe('withRetry', () => {
     const fn = vi.fn().mockRejectedValue(new Error('network error'));
     await expect(withRetry(fn, { maxRetries: 2, baseDelayMs: 1 })).rejects.toThrow('network error');
     expect(fn).toHaveBeenCalledTimes(3);
-    vi.restoreAllMocks();
+  });
+
+  it('does not retry malformed model output', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('Failed to parse judge JSON'));
+
+    await expect(withRetry(fn, { baseDelayMs: 10 })).rejects.toThrow('parse judge JSON');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timeout only once', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const fn = vi.fn().mockRejectedValue(new Error('request timed out'));
+
+    const promise = withRetry(fn, { maxRetries: 3, baseDelayMs: 10 });
+    const result = expect(promise).rejects.toThrow('timed out');
+    await vi.advanceTimersByTimeAsync(20);
+    await result;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the server retry delay when available', async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('rate limited; retry-after-ms=250'))
+      .mockResolvedValue('recovered');
+
+    const promise = withRetry(fn, { baseDelayMs: 10, onRetry });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe('recovered');
+    expect(onRetry).toHaveBeenCalledWith(1, 4, expect.any(String), 250);
   });
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -31,7 +31,7 @@ export async function withRetry<T>(
 
       const retryAfterMs = retryAfterDelay(message);
       const delay = retryAfterMs ?? baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
-      const delayMs = Math.round(delay);
+      const delayMs = Math.max(1, Math.ceil(delay));
       console.warn(
         `[Glossa] ${label} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delayMs}ms: ${message}`,
       );
@@ -89,10 +89,11 @@ function throwIfCancelled(shouldCancel: (() => boolean) | undefined): void {
 }
 
 function sleep(ms: number, shouldCancel?: () => boolean): Promise<void> {
-  if (!shouldCancel) return new Promise((resolve) => setTimeout(resolve, ms));
+  const delayMs = Math.max(1, Math.ceil(ms));
+  if (!shouldCancel) return new Promise((resolve) => setTimeout(resolve, delayMs));
 
   return new Promise((resolve, reject) => {
-    const intervalMs = Math.min(100, ms);
+    const intervalMs = Math.min(100, delayMs);
     let elapsed = 0;
     const timer = setInterval(() => {
       if (shouldCancel()) {
@@ -101,7 +102,7 @@ function sleep(ms: number, shouldCancel?: () => boolean): Promise<void> {
         return;
       }
       elapsed += intervalMs;
-      if (elapsed >= ms) {
+      if (elapsed >= delayMs) {
         clearInterval(timer);
         resolve();
       }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -11,26 +11,32 @@ export async function withRetry<T>(
     baseDelayMs?: number;
     label?: string;
     onRetry?: (attempt: number, total: number, error: string, delayMs: number) => void;
+    shouldCancel?: () => boolean;
   } = {},
 ): Promise<T> {
-  const { maxRetries = 3, baseDelayMs = 1000, label = 'operation', onRetry } = opts;
+  const { maxRetries = 3, baseDelayMs = 1000, label = 'operation', onRetry, shouldCancel } = opts;
+  let timeoutRetried = false;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
+      throwIfCancelled(shouldCancel);
       return await fn();
-    } catch (err: any) {
-      const message: string = err?.message ?? String(err);
+    } catch (err: unknown) {
+      const message = errorMessage(err);
 
-      if (isConfigError(message) || message.includes(STREAM_CANCELLED_ERROR) || isTimeoutError(message)) throw err;
+      if (isConfigError(message) || isParseError(message) || message.includes(STREAM_CANCELLED_ERROR)) throw err;
       if (attempt === maxRetries) throw err;
+      if (isTimeoutError(message) && timeoutRetried) throw err;
+      if (isTimeoutError(message)) timeoutRetried = true;
 
-      const delay = baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
+      const retryAfterMs = retryAfterDelay(message);
+      const delay = retryAfterMs ?? baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
       const delayMs = Math.round(delay);
       console.warn(
         `[Glossa] ${label} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delayMs}ms: ${message}`,
       );
       onRetry?.(attempt + 1, maxRetries + 1, message, delayMs);
-      await sleep(delay);
+      await sleep(delay, shouldCancel);
     }
   }
 
@@ -57,12 +63,50 @@ function isConfigError(message: string): boolean {
     'Unsupported provider',
     'Keyring error',
     'Set it in Settings',
+    'not authorized',
+    'unauthorized',
+    'forbidden',
+    'invalid api key',
   ];
-  return configPatterns.some((p) => message.includes(p));
+  return /\b(401|403)\b/.test(message) || configPatterns.some((p) => message.toLowerCase().includes(p.toLowerCase()));
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+function isParseError(message: string): boolean {
+  return /parse|JSON|unexpected token|invalid judge response/i.test(message);
+}
+
+function retryAfterDelay(message: string): number | undefined {
+  const match = message.match(/retry-after-ms=(\d+)/i);
+  return match ? Number(match[1]) : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function throwIfCancelled(shouldCancel: (() => boolean) | undefined): void {
+  if (shouldCancel?.()) throw new Error(STREAM_CANCELLED_ERROR);
+}
+
+function sleep(ms: number, shouldCancel?: () => boolean): Promise<void> {
+  if (!shouldCancel) return new Promise((resolve) => setTimeout(resolve, ms));
+
+  return new Promise((resolve, reject) => {
+    const intervalMs = Math.min(100, ms);
+    let elapsed = 0;
+    const timer = setInterval(() => {
+      if (shouldCancel()) {
+        clearInterval(timer);
+        reject(new Error(STREAM_CANCELLED_ERROR));
+        return;
+      }
+      elapsed += intervalMs;
+      if (elapsed >= ms) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, intervalMs);
+  });
 }
 
 /** Classify an error string into a user-friendly category */


### PR DESCRIPTION
## Cosa cambia

- interrompe davvero stage, judge e attese di retry dopo Stop
- rifiuta output vuoti o troncati invece di salvarli come completati, incluso l'ultimo messaggio senza ritorno a capo
- evita retry su errori non recuperabili e rispetta `Retry-After`
- valida le frasi segnalate dal judge prima di evidenziarle
- prepara schema e indici della memoria frasi all'avvio e riusa una sola connessione durante la sessione
- se il database non si apre, mostra una schermata chiara nella lingua scelta invece di caricare un'interfaccia incompleta

## Perché

La pipeline poteva avviare lavoro a pagamento dopo Stop, salvare testo parziale e ripetere errori deterministici. La memoria frasi inoltre ricreava inutilmente connessioni e schema a ogni operazione; un errore d'avvio poteva invece lasciare l'app apparentemente aperta ma inutilizzabile.

## Verifiche

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 132 test verdi
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `npm run lint`
- suite Vitest completa
- `cargo fmt` e `git diff --check`

Refs #319