### PR TITLE
feat: componente Select condiviso, migra i 30 select grezzi (#323)

### DIFF
--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -375,7 +375,7 @@ export function MarkdownEditor({
   const preview = (
     <div
       data-scroll-sync="true"
-      className={`${fillHeight ? 'flex-1 min-h-0 overflow-y-auto custom-scrollbar' : minHeightClassName} rounded-2xl border border-editorial-border bg-editorial-textbox/60 p-4 ${previewClassName}`}
+      className={`${fillHeight ? 'flex-1 min-h-0 overflow-y-auto custom-scrollbar' : minHeightClassName} rounded-xl border border-editorial-border bg-editorial-textbox/60 p-4 ${previewClassName}`}
       style={effectiveStyle}
     >
       {value.trim() ? (
@@ -492,7 +492,7 @@ export function MarkdownEditor({
         <div className={`sticky top-0 z-20 bg-editorial-page/95 backdrop-blur${fillHeight ? ' shrink-0' : ''}${
           flatToolbar
             ? ' border-b border-editorial-border/60 px-1 py-2'
-            : ' rounded-2xl border border-editorial-border/70 px-3 py-3 shadow-sm'
+            : ' rounded-xl border border-editorial-border/70 px-3 py-3 shadow-sm'
         }`}>
           <div className="flex items-center gap-1.5">
             {markdownEnabled && (

--- a/src/components/document/ConfigDrawer.tsx
+++ b/src/components/document/ConfigDrawer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Check, LibraryBig, Pencil, Save, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { Dialog, DialogCancelButton, IconButton, PillButton } from '../ui';
+import { Dialog, DialogCancelButton, IconButton, PillButton, Select } from '../ui';
 import { PipelineConfig } from '../pipeline/PipelineConfig';
 import { useUiStore } from '../../stores/uiStore';
 import { useConfigStore } from '../../stores/configStore';
@@ -115,17 +115,16 @@ export function ConfigDrawer({
           <LibraryBig size={16} />
         </IconButton>
       </div>
-      <select
+      <Select
         value={config.assignedGlossaryId ?? ''}
-        onChange={(e) => handleDictChange(e.target.value)}
-        className="w-full rounded-md border border-editorial-border/60 bg-editorial-bg px-3 py-2 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent text-editorial-ink"
-        aria-label={t('library.assignedDictionary')}
-      >
-        <option value="">{t('library.noDictionaryAssigned')}</option>
-        {glossaries.map((g) => (
-          <option key={g.id} value={g.id}>{g.name}</option>
-        ))}
-      </select>
+        onChange={handleDictChange}
+        className="w-full font-mono"
+        ariaLabel={t('library.assignedDictionary')}
+        options={[
+          { value: '', label: t('library.noDictionaryAssigned') },
+          ...glossaries.map((g) => ({ value: g.id, label: g.name })),
+        ]}
+      />
       {config.assignedGlossaryId && (
         <DictionaryEntryEditor
           entries={config.glossary}

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -342,11 +342,11 @@ export function DocumentView({
       ? chunks.map((chunk, idx) => {
           const segmentTone =
             chunk.status === 'completed'
-              ? 'bg-editorial-success/18 shadow-[inset_0_0_0_1px_rgba(58,122,101,0.16)]'
+              ? 'bg-editorial-success/18 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-success)_16%,transparent)]'
               : chunk.status === 'error'
-                ? 'bg-editorial-danger/18 shadow-[inset_0_0_0_1px_rgba(166,78,66,0.18)]'
+                ? 'bg-editorial-danger/18 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-danger)_18%,transparent)]'
                 : chunk.status === 'processing'
-                  ? 'bg-editorial-running/24 animate-pulse shadow-[inset_0_0_0_1px_rgba(196,155,42,0.22)]'
+                  ? 'bg-editorial-running/24 animate-pulse shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-running)_22%,transparent)]'
                   : 'bg-editorial-border/40';
           const isCurrent = idx === currentIndex;
           const chunkAnnotations = annotationsByChunkId.get(chunk.id) ?? [];

--- a/src/components/document/ExtractTermDialog.tsx
+++ b/src/components/document/ExtractTermDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { Dialog, DialogConfirmButton, DialogCancelButton } from '../ui';
+import { Dialog, DialogConfirmButton, DialogCancelButton, Select } from '../ui';
 import { listGlossaries, addGlossaryEntry, createGlossary } from '../../services/glossaryService';
 import { extractTermFromPhrase } from '../../services/llmService';
 import { usePipelineStore } from '../../stores/pipelineStore';
@@ -159,14 +159,16 @@ export function ExtractTermDialog({ sourcePhrase, targetPhrase, onClose, onSucce
               className="mb-1 block text-[11px] font-sans uppercase tracking-[0.1em] text-editorial-muted">
               {t('glossary.selectGlossary')}
             </label>
-            <select id="extract-glossary-select" value={selectedGlossaryId ?? ''}
-              onChange={(e) => setSelectedGlossaryId(e.target.value || null)}
-              aria-label={t('glossary.selectGlossary')}
-              className="w-full rounded-md border border-editorial-border bg-editorial-textbox/60 px-3 py-2 text-sm text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent">
-              <option value="">{t('glossary.noGlossarySelected')}</option>
-              {glossaries.map((g) => <option key={g.id} value={g.id}>{g.name}</option>)}
-              <option value={CREATE_NEW_GLOSSARY}>{t('glossary.createNewInline')}</option>
-            </select>
+            <Select id="extract-glossary-select" value={selectedGlossaryId ?? ''}
+              onChange={(value) => setSelectedGlossaryId(value || null)}
+              ariaLabel={t('glossary.selectGlossary')}
+              className="w-full"
+              options={[
+                { value: '', label: t('glossary.noGlossarySelected') },
+                ...glossaries.map((g) => ({ value: g.id, label: g.name })),
+                { value: CREATE_NEW_GLOSSARY, label: t('glossary.createNewInline') },
+              ]}
+            />
             {isCreatingNew && (
               <input type="text" value={newGlossaryName}
                 onChange={(e) => setNewGlossaryName(e.target.value)}

--- a/src/components/document/ImportPreviewDialog.tsx
+++ b/src/components/document/ImportPreviewDialog.tsx
@@ -28,7 +28,7 @@ import { LANGUAGES } from '../../constants';
 import { getSelectableModelIds, LLM_PROVIDER_ORDER } from '../../models/catalog';
 import { useConfigStore } from '../../stores/configStore';
 import type { ModelProvider } from '../../types';
-import { IconButton, DialogConfirmButton, DialogCancelButton, Tooltip } from '../ui';
+import { IconButton, DialogConfirmButton, DialogCancelButton, Select, Tooltip } from '../ui';
 import { ChunkCard, BoundaryDivider, SegmentEditor } from './ChunkEditor';
 import { type ParagraphChunks, toParagraphChunks, countWords, toFlatModel, fromFlatModel } from '../../utils/paragraphChunks';
 
@@ -531,16 +531,13 @@ export function ImportPreviewDialog({
               {/* Language pair */}
               <Globe size={11} className="text-editorial-accent shrink-0" />
               <div className="flex items-center gap-1.5">
-                <select
+                <Select
                   value={sourceLanguage}
-                  onChange={(e) => handleSourceLanguageChange(e.target.value)}
-                  className="w-32 rounded-md border border-editorial-border bg-editorial-bg px-2 py-1.5 text-xs font-mono outline-none focus:border-editorial-ink/40 appearance-none"
-                  aria-label={t('pipeline.sourceLanguage')}
-                >
-                  {LANGUAGES.map((lang) => (
-                    <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-                  ))}
-                </select>
+                  onChange={handleSourceLanguageChange}
+                  options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+                  className="w-32 font-mono appearance-none"
+                  ariaLabel={t('pipeline.sourceLanguage')}
+                />
                 <Tooltip label={t('pipeline.swapLanguages')}>
                   <button
                     type="button"
@@ -551,43 +548,36 @@ export function ImportPreviewDialog({
                     <ArrowLeftRight size={12} />
                   </button>
                 </Tooltip>
-                <select
+                <Select
                   value={targetLanguage}
-                  onChange={(e) => handleTargetLanguageChange(e.target.value)}
-                  className="w-32 rounded-md border border-editorial-border bg-editorial-bg px-2 py-1.5 text-xs font-mono outline-none focus:border-editorial-ink/40 appearance-none"
-                  aria-label={t('pipeline.targetLanguage')}
-                >
-                  {LANGUAGES.map((lang) => (
-                    <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-                  ))}
-                </select>
+                  onChange={handleTargetLanguageChange}
+                  options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+                  className="w-32 font-mono appearance-none"
+                  ariaLabel={t('pipeline.targetLanguage')}
+                />
               </div>
               {/* Model */}
               <Cpu size={11} className="text-editorial-accent shrink-0" />
               <div className="flex items-center gap-1.5">
-                <select
+                <Select
                   value={selectedProvider}
-                  onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
-                  className="w-24 rounded-md border border-editorial-border bg-editorial-bg px-2 py-1.5 text-xs font-bold uppercase outline-none focus:border-editorial-ink/40 appearance-none"
-                  aria-label={t('pipeline.source')}
-                >
-                  {LLM_PROVIDER_ORDER.map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-                <select
+                  onChange={(value) => handleProviderChange(value as ModelProvider)}
+                  options={LLM_PROVIDER_ORDER.map((p) => ({ value: p, label: p }))}
+                  className="w-24 font-bold uppercase appearance-none"
+                  ariaLabel={t('pipeline.source')}
+                />
+                <Select
                   value={selectedModel}
-                  onChange={(e) => handleModelChange(e.target.value)}
+                  onChange={handleModelChange}
                   disabled={availableModels.length === 0}
-                  className="flex-1 min-w-0 rounded-md border border-editorial-border bg-editorial-bg px-2 py-1.5 text-xs font-mono outline-none focus:border-editorial-ink/40 appearance-none disabled:opacity-40"
-                  aria-label={t('pipeline.stageModelLabel')}
-                >
-                  {availableModels.length === 0 ? (
-                    <option value="">{t('ollama.noModels')}</option>
-                  ) : (
-                    availableModels.map((m) => <option key={m} value={m}>{m}</option>)
-                  )}
-                </select>
+                  className="flex-1 min-w-0 font-mono appearance-none"
+                  ariaLabel={t('pipeline.stageModelLabel')}
+                  options={
+                    availableModels.length === 0
+                      ? [{ value: '', label: t('ollama.noModels') }]
+                      : availableModels.map((m) => ({ value: m, label: m }))
+                  }
+                />
               </div>
             </div>
           </div>

--- a/src/components/library/CsvImportDialog.tsx
+++ b/src/components/library/CsvImportDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { open } from '@tauri-apps/plugin-dialog';
 import { readTextFile, readFile } from '@tauri-apps/plugin-fs';
 import Papa from 'papaparse';
-import { Dialog, DialogConfirmButton, DialogCancelButton } from '../ui';
+import { Dialog, DialogConfirmButton, DialogCancelButton, Select } from '../ui';
 import { useLibraryStore } from '../../stores/libraryStore';
 import {
   importEntriesFromCsv,
@@ -203,17 +203,16 @@ export function CsvImportDialog({ workspaceId, onImported, onClose }: Props) {
                     <label htmlFor={`csv-map-${key}`} className="w-36 shrink-0 text-[11px] font-bold uppercase tracking-[0.14em] text-editorial-muted">
                       {label}
                     </label>
-                    <select
+                    <Select
                       id={`csv-map-${key}`}
                       value={columnMap[key] ?? ''}
-                      onChange={(e) => setColumnMap((m) => ({ ...m, [key]: e.target.value || undefined }))}
-                      className="flex-1 rounded-md border border-editorial-border bg-editorial-bg px-3 py-2 text-xs text-editorial-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                    >
-                      {!required && <option value="">{t('library.xlsxNoneOption')}</option>}
-                      {headers.map((h) => (
-                        <option key={h} value={h}>{h}</option>
-                      ))}
-                    </select>
+                      onChange={(value) => setColumnMap((m) => ({ ...m, [key]: value || undefined }))}
+                      className="flex-1"
+                      options={[
+                        ...(!required ? [{ value: '', label: t('library.xlsxNoneOption') }] : []),
+                        ...headers.map((h) => ({ value: h, label: h })),
+                      ]}
+                    />
                   </div>
                 ))}
               </div>

--- a/src/components/library/MemoriesTab.tsx
+++ b/src/components/library/MemoriesTab.tsx
@@ -18,7 +18,7 @@ import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useLibraryStore } from '../../stores/libraryStore';
 import { confirm } from '../../stores/confirmStore';
 import { generateId } from '../../utils';
-import { EmptyState, IconButton, SectionLabel, Spinner } from '../ui';
+import { EmptyState, IconButton, SectionLabel, Select, Spinner } from '../ui';
 import type { Workspace } from '../../types';
 
 export function MemoriesTab() {
@@ -205,18 +205,15 @@ export function MemoriesTab() {
             <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-editorial-muted">
               {t('library.workspaceFilter')}
             </span>
-            <select
+            <Select
               value={workspaceFilter}
-              onChange={(event) => setWorkspaceFilter(event.target.value)}
-              className="max-w-[220px] rounded-md border border-editorial-border bg-editorial-bg px-3 py-2 text-xs text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            >
-              <option value="all">{t('library.allWorkspaces')}</option>
-              {workspaces.map((workspace) => (
-                <option key={workspace.id} value={workspace.id}>
-                  {workspace.name}
-                </option>
-              ))}
-            </select>
+              onChange={setWorkspaceFilter}
+              className="max-w-[220px]"
+              options={[
+                { value: 'all', label: t('library.allWorkspaces') },
+                ...workspaces.map((workspace) => ({ value: workspace.id, label: workspace.name })),
+              ]}
+            />
           </label>
           <IconButton
             size="md"
@@ -457,17 +454,14 @@ function GlossaryPicker({ glossaries, selectedId, isAdding, onSelect, onConfirm,
   const { t } = useTranslation();
   return (
     <div className="mt-3 flex items-center gap-2 border-t border-editorial-accent/30 pt-3">
-      <select
+      <Select
         value={selectedId}
-        onChange={(e) => onSelect(e.target.value)}
+        onChange={onSelect}
         disabled={isAdding}
-        className="min-w-0 flex-1 rounded-md border border-editorial-border bg-editorial-bg px-3 py-1.5 text-xs text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-50"
-        aria-label={t('glossary.selectGlossary')}
-      >
-        {glossaries.map((g) => (
-          <option key={g.id} value={g.id}>{g.name}</option>
-        ))}
-      </select>
+        className="min-w-0 flex-1"
+        ariaLabel={t('glossary.selectGlossary')}
+        options={glossaries.map((g) => ({ value: g.id, label: g.name }))}
+      />
       <IconButton
         size="sm"
         tone="accent"

--- a/src/components/library/PromptTemplatesTab.tsx
+++ b/src/components/library/PromptTemplatesTab.tsx
@@ -10,7 +10,7 @@ import type { ModelProvider, PromptTemplateContext, PromptTemplateWorkflow } fro
 import { llmService } from '../../services/llmService';
 import { getSelectableModelIds, LLM_PROVIDER_ORDER } from '../../models/catalog';
 import { canRefineWithProvider, formatProviderModelLabel, useProviderKeyStatus } from '../../hooks/useProviderKeyStatus';
-import { IconButton } from '../ui';
+import { IconButton, Select } from '../ui';
 
 const WORKFLOW_OPTIONS = ['translation', 'transcription'] as const;
 
@@ -179,29 +179,28 @@ export function PromptTemplatesTab() {
               placeholder={t('library.templateNamePlaceholder')}
               className="rounded-md border border-editorial-border bg-editorial-bg/80 px-4 py-2.5 text-sm font-display italic text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
             />
-            <select
+            <Select
               value={newContext}
-              onChange={(e) => setNewContext(e.target.value as PromptTemplateContext)}
-              className="rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('library.templateContextLabel')}
-            >
-              <option value="stage">{t('pipeline.tabStages')}</option>
-              <option value="audit">{t('pipeline.tabAudit')}</option>
-              <option value="persona">{t('pipeline.tabPersona')}</option>
-              <option value="memory">{t('workspace.settings.memoryTab')}</option>
-            </select>
-            <select
+              onChange={(value) => setNewContext(value as PromptTemplateContext)}
+              className="font-mono"
+              ariaLabel={t('library.templateContextLabel')}
+              options={[
+                { value: 'stage', label: t('pipeline.tabStages') },
+                { value: 'audit', label: t('pipeline.tabAudit') },
+                { value: 'persona', label: t('pipeline.tabPersona') },
+                { value: 'memory', label: t('workspace.settings.memoryTab') },
+              ]}
+            />
+            <Select
               value={newWorkflow}
-              onChange={(e) => setNewWorkflow(e.target.value as PromptTemplateWorkflow)}
-              className="rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('library.templateWorkflowLabel')}
-            >
-              {WORKFLOW_OPTIONS.map((w) => (
-                <option key={w} value={w}>
-                  {w === 'translation' ? t('workflow.translation') : t('workflow.transcription')}
-                </option>
-              ))}
-            </select>
+              onChange={(value) => setNewWorkflow(value as PromptTemplateWorkflow)}
+              className="font-mono"
+              ariaLabel={t('library.templateWorkflowLabel')}
+              options={WORKFLOW_OPTIONS.map((w) => ({
+                value: w,
+                label: w === 'translation' ? t('workflow.translation') : t('workflow.transcription'),
+              }))}
+            />
           </div>
           <p className="text-xs leading-relaxed text-editorial-muted">
             {newContext === 'audit'
@@ -219,30 +218,24 @@ export function PromptTemplatesTab() {
                 {t('pipeline.prompt')}
               </span>
               <div className="flex flex-wrap items-center gap-2">
-                <select
+                <Select
                   value={refineProvider}
-                  onChange={(e) => {
-                    const p = e.target.value as ModelProvider;
+                  onChange={(value) => {
+                    const p = value as ModelProvider;
                     setRefineProvider(p);
                     setRefineModel(getProviderModels(p)[0] ?? '');
                   }}
-                  className="rounded-md border border-editorial-border bg-editorial-bg px-3 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                  aria-label={t('library.templateRefineProviderLabel')}
-                >
-                  {LLM_PROVIDER_ORDER.map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-                <select
+                  className="font-mono"
+                  ariaLabel={t('library.templateRefineProviderLabel')}
+                  options={LLM_PROVIDER_ORDER.map((p) => ({ value: p, label: p }))}
+                />
+                <Select
                   value={refineModel}
-                  onChange={(e) => setRefineModel(e.target.value)}
-                  className="max-w-[160px] rounded-md border border-editorial-border bg-editorial-bg px-3 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                  aria-label={t('pipeline.stageModelLabel')}
-                >
-                  {modelOptions.map((m) => (
-                    <option key={m} value={m}>{m}</option>
-                  ))}
-                </select>
+                  onChange={setRefineModel}
+                  className="max-w-[160px] font-mono"
+                  ariaLabel={t('pipeline.stageModelLabel')}
+                  options={modelOptions.map((m) => ({ value: m, label: m }))}
+                />
                 <IconButton
                   onClick={handleRefine}
                   disabled={isRefining || !newPrompt.trim() || !canRefine}

--- a/src/components/pipeline/AuditTabPanel.tsx
+++ b/src/components/pipeline/AuditTabPanel.tsx
@@ -6,7 +6,7 @@ import type { ProviderKeyStatusMap } from '../../hooks/useProviderKeyStatus';
 import type { SaveTemplateFn } from '../../stores/promptTemplateStore';
 import { ensureModelInList, getKnownModelIds, getModelStatus, getResolvedModelReasoning, LLM_PROVIDER_ORDER } from '../../models/catalog';
 import { DEFAULT_COHERENCE_PROMPT, DEFAULT_JUDGE_PROMPT } from '../../constants';
-import { SectionLabel, ToggleRow, FieldLabel } from '../ui';
+import { SectionLabel, ToggleRow, FieldLabel, Select } from '../ui';
 import { DeprecatedModelBadge } from '../models/DeprecatedModelBadge';
 import { ReasoningPicker } from '../models/ReasoningPicker';
 import { ProviderRuntimeEditor } from './ProviderRuntimeEditor';
@@ -107,32 +107,29 @@ export function AuditTabPanel({
       <div className="space-y-3 border-l-4 border-l-editorial-charcoal/30 border-y border-editorial-border/70 bg-editorial-bg/65 px-5 py-4">
         <SectionLabel icon={Cpu} label={t('pipeline.auditModelLabel')} />
         <div className="flex gap-2">
-          <select
+          <Select
             value={config.judgeProvider}
-            onChange={(e) => handleJudgeProviderChange(e.target.value as ModelProvider)}
-            className="rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            aria-label={t('models.provider')}
-          >
-            {LLM_PROVIDER_ORDER.map((p) => (
-              <option key={p} value={p} disabled={p !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[p] === false}>{p}</option>
-            ))}
-          </select>
+            onChange={(value) => handleJudgeProviderChange(value as ModelProvider)}
+            className="font-bold uppercase"
+            ariaLabel={t('models.provider')}
+            options={LLM_PROVIDER_ORDER.map((p) => ({
+              value: p,
+              label: p,
+              disabled: p !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[p] === false,
+            }))}
+          />
           {effectiveJudgeModels.length > 0 ? (
             <div className="flex flex-1 items-center gap-1.5">
-              <select
+              <Select
                 value={config.judgeModel}
-                onChange={(e) => handleJudgeModelChange(e.target.value)}
-                className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                aria-label={t('pipeline.auditModelLabel')}
-              >
-                {effectiveJudgeModels.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                    {getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}
-                    {getModelStatus(config.judgeProvider, m) === 'deprecated' ? ' (superato)' : ''}
-                  </option>
-                ))}
-              </select>
+                onChange={handleJudgeModelChange}
+                className="flex-1"
+                ariaLabel={t('pipeline.auditModelLabel')}
+                options={effectiveJudgeModels.map((m) => ({
+                  value: m,
+                  label: `${m}${getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}${getModelStatus(config.judgeProvider, m) === 'deprecated' ? ' (superato)' : ''}`,
+                }))}
+              />
               <DeprecatedModelBadge provider={config.judgeProvider} model={config.judgeModel} />
             </div>
           ) : config.judgeProvider === 'ollama' ? (
@@ -144,18 +141,16 @@ export function AuditTabPanel({
               aria-label={t('pipeline.auditModelLabel')}
             />
           ) : (
-            <select
+            <Select
               value={config.judgeModel}
-              onChange={(e) => handleJudgeModelChange(e.target.value)}
-              className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-              aria-label={t('pipeline.auditModelLabel')}
-            >
-              {getKnownModelIds(config.judgeProvider).map((m) => (
-                <option key={m} value={m}>
-                  {m}{getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}
-                </option>
-              ))}
-            </select>
+              onChange={handleJudgeModelChange}
+              className="flex-1"
+              ariaLabel={t('pipeline.auditModelLabel')}
+              options={getKnownModelIds(config.judgeProvider).map((m) => ({
+                value: m,
+                label: `${m}${getModelStatus(config.judgeProvider, m) === 'preview' ? ' (preview)' : ''}`,
+              }))}
+            />
           )}
         </div>
         {judgeResolvedReasoning !== undefined && judgeResolvedReasoning !== 'non_reasoning' && config.judgeProvider !== 'ollama' && (

--- a/src/components/pipeline/DeeplStageConfig.tsx
+++ b/src/components/pipeline/DeeplStageConfig.tsx
@@ -5,7 +5,7 @@ import { deeplService } from '../../services/deeplService';
 import type { DeeplConfig, DeeplLanguageInfo, GlossaryEntry } from '../../types';
 import type { DeeplGlossaryInfo } from '../../services/deeplService';
 import { DEFAULT_DEEPL_STAGE_OPTIONS, toDeeplCode } from '../../constants';
-import { IconButton, SectionLabel, ToggleRow } from '../ui';
+import { IconButton, SectionLabel, Select, ToggleRow } from '../ui';
 import { confirm } from '../../stores/confirmStore';
 
 interface DeeplStageConfigProps {
@@ -120,16 +120,17 @@ export function DeeplStageConfig({
           <label htmlFor="deepl-model-type" className="text-xs font-sans uppercase tracking-[0.1em] text-editorial-muted">
             {t('pipeline.deepl.modelType', 'Modalità traduzione')}
           </label>
-          <select
+          <Select
             id="deepl-model-type"
-            className="w-full rounded-md border border-editorial-border bg-editorial-textbox px-2 py-1.5 text-xs font-sans text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            className="w-full"
             value={config.modelType ?? 'prefer_quality_optimized'}
-            onChange={(e) => update({ modelType: e.target.value as DeeplConfig['modelType'] })}
-          >
-            <option value="prefer_quality_optimized">{t('pipeline.deepl.preferQuality', 'Qualità (raccomandato)')}</option>
-            <option value="quality_optimized">{t('pipeline.deepl.qualityOnly', 'Solo qualità')}</option>
-            <option value="latency_optimized">{t('pipeline.deepl.latency', 'Velocità')}</option>
-          </select>
+            onChange={(value) => update({ modelType: value as DeeplConfig['modelType'] })}
+            options={[
+              { value: 'prefer_quality_optimized', label: t('pipeline.deepl.preferQuality', 'Qualità (raccomandato)') },
+              { value: 'quality_optimized', label: t('pipeline.deepl.qualityOnly', 'Solo qualità') },
+              { value: 'latency_optimized', label: t('pipeline.deepl.latency', 'Velocità') },
+            ]}
+          />
         </div>
 
         {/* 3. Registro formalità (condizionale) */}
@@ -138,18 +139,19 @@ export function DeeplStageConfig({
             <label htmlFor="deepl-formality" className="text-xs font-sans uppercase tracking-[0.1em] text-editorial-muted">
               {t('pipeline.deepl.formality', 'Registro')}
             </label>
-            <select
+            <Select
               id="deepl-formality"
-              className="w-full rounded-md border border-editorial-border bg-editorial-textbox px-2 py-1.5 text-xs font-sans text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+              className="w-full"
               value={config.formality ?? 'default'}
-              onChange={(e) => update({ formality: e.target.value as DeeplConfig['formality'] })}
-            >
-              <option value="default">{t('pipeline.deepl.formalityDefault', 'Predefinito')}</option>
-              <option value="prefer_more">{t('pipeline.deepl.formalityPreferMore', 'Formale (se supportato)')}</option>
-              <option value="more">{t('pipeline.deepl.formalityMore', 'Formale')}</option>
-              <option value="prefer_less">{t('pipeline.deepl.formalityPreferLess', 'Informale (se supportato)')}</option>
-              <option value="less">{t('pipeline.deepl.formalityLess', 'Informale')}</option>
-            </select>
+              onChange={(value) => update({ formality: value as DeeplConfig['formality'] })}
+              options={[
+                { value: 'default', label: t('pipeline.deepl.formalityDefault', 'Predefinito') },
+                { value: 'prefer_more', label: t('pipeline.deepl.formalityPreferMore', 'Formale (se supportato)') },
+                { value: 'more', label: t('pipeline.deepl.formalityMore', 'Formale') },
+                { value: 'prefer_less', label: t('pipeline.deepl.formalityPreferLess', 'Informale (se supportato)') },
+                { value: 'less', label: t('pipeline.deepl.formalityLess', 'Informale') },
+              ]}
+            />
           </div>
         )}
       </div>
@@ -159,23 +161,24 @@ export function DeeplStageConfig({
         <div className="space-y-3">
           <SectionLabel icon={BookOpen} label={t('pipeline.deepl.glossary', 'Glossario DeepL')} />
           <div className="flex items-center gap-2">
-            <select
-              className="flex-1 rounded-md border border-editorial-border bg-editorial-textbox px-2 py-1.5 text-xs font-sans text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
+            <Select
+              className="flex-1"
               value={config.glossaryId ?? ''}
-              onChange={(e) => update({ glossaryId: e.target.value || undefined })}
-              aria-label={t('pipeline.deepl.glossary', 'Glossario DeepL')}
-            >
-              <option value="">
-                {glossariesLoading
-                  ? t('common.loading', 'Caricamento…')
-                  : t('pipeline.deepl.noGlossary', 'Nessun glossario')}
-              </option>
-              {filteredGlossaries.map((g) => (
-                <option key={g.glossaryId} value={g.glossaryId}>
-                  {g.name} ({g.entryCount} termini)
-                </option>
-              ))}
-            </select>
+              onChange={(value) => update({ glossaryId: value || undefined })}
+              ariaLabel={t('pipeline.deepl.glossary', 'Glossario DeepL')}
+              options={[
+                {
+                  value: '',
+                  label: glossariesLoading
+                    ? t('common.loading', 'Caricamento…')
+                    : t('pipeline.deepl.noGlossary', 'Nessun glossario'),
+                },
+                ...filteredGlossaries.map((g) => ({
+                  value: g.glossaryId,
+                  label: `${g.name} (${g.entryCount} termini)`,
+                })),
+              ]}
+            />
             {config.glossaryId && (
               <IconButton
                 size="sm"

--- a/src/components/pipeline/PipelineConfig.tsx
+++ b/src/components/pipeline/PipelineConfig.tsx
@@ -19,7 +19,7 @@ import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { useOperationLogStore } from '../../stores/operationLogStore';
 import { PromptPreviewTab } from './PromptPreviewTab';
 import { canRefineWithProvider, formatProviderModelLabel, useProviderKeyStatus } from '../../hooks/useProviderKeyStatus';
-import { IconButton, SectionLabel, Spinner, Tooltip } from '../ui';
+import { IconButton, SectionLabel, Select, Spinner, Tooltip } from '../ui';
 import { PersonaEditor } from './PersonaEditor';
 import { SettingsTabPanel } from './SettingsTabPanel';
 import { TranslationTabPanel } from './TranslationTabPanel';
@@ -316,17 +316,14 @@ export function PipelineConfig({
           <div className="space-y-2">
             <SectionLabel icon={Globe} label={t('pipeline.languagePair')} />
             <div className={`flex items-center gap-3 transition-opacity ${config.persona ? 'opacity-40 pointer-events-none' : ''}`}>
-              <select
+              <Select
                 value={config.sourceLanguage}
-                onChange={(e) => setConfig((prev) => ({ ...prev, sourceLanguage: e.target.value }))}
-                className="w-full rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-                aria-label={t('pipeline.sourceLanguage')}
+                onChange={(value) => setConfig((prev) => ({ ...prev, sourceLanguage: value }))}
+                options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+                className="w-full font-mono appearance-none"
+                ariaLabel={t('pipeline.sourceLanguage')}
                 disabled={!!config.persona}
-              >
-                {LANGUAGES.map((lang) => (
-                  <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-                ))}
-              </select>
+              />
               <IconButton
                 size="md"
                 className="shrink-0"
@@ -342,17 +339,14 @@ export function PipelineConfig({
               >
                 <ArrowRightLeft size={13} />
               </IconButton>
-              <select
+              <Select
                 value={config.targetLanguage}
-                onChange={(e) => setConfig((prev) => ({ ...prev, targetLanguage: e.target.value }))}
-                className="w-full rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-                aria-label={t('pipeline.targetLanguage')}
+                onChange={(value) => setConfig((prev) => ({ ...prev, targetLanguage: value }))}
+                options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+                className="w-full font-mono appearance-none"
+                ariaLabel={t('pipeline.targetLanguage')}
                 disabled={!!config.persona}
-              >
-                {LANGUAGES.map((lang) => (
-                  <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-                ))}
-              </select>
+              />
             </div>
             {!!config.persona && (
               <p className="text-xs leading-relaxed text-editorial-muted/60">

--- a/src/components/pipeline/ProviderRuntimeEditor.tsx
+++ b/src/components/pipeline/ProviderRuntimeEditor.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import type { ModelProvider, OllamaConfig, ProviderRuntimeConfig } from '../../types';
 import { defaultOllamaConfig } from '../../utils/providerOptions';
-import { ToggleRow } from '../ui';
+import { Select, ToggleRow } from '../ui';
 
 interface ProviderRuntimeEditorProps {
   provider: ModelProvider;
@@ -193,26 +193,26 @@ export function ProviderRuntimeEditor({
 
               <div className="grid grid-cols-2 gap-3">
                 <LabeledField label={t('pipeline.providerOptions.think')}>
-                  <select
+                  <Select
                     value={String(ollama.think)}
-                    onChange={(e) => {
-                      const next = e.target.value;
+                    onChange={(value) => {
                       patchOllama({
-                        think: next === 'false'
+                        think: value === 'false'
                           ? false
-                          : next === 'true'
+                          : value === 'true'
                             ? true
-                            : next as 'low' | 'medium' | 'high',
+                            : value as 'low' | 'medium' | 'high',
                       });
                     }}
-                    className="w-full rounded-md border border-editorial-border/60 bg-editorial-bg/80 px-3 py-2 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                  >
-                    <option value="false">{t('pipeline.providerOptions.thinkDisabled')}</option>
-                    <option value="true">{t('pipeline.providerOptions.thinkEnabled')}</option>
-                    <option value="low">{t('pipeline.providerOptions.thinkLow')}</option>
-                    <option value="medium">{t('pipeline.providerOptions.thinkMedium')}</option>
-                    <option value="high">{t('pipeline.providerOptions.thinkHigh')}</option>
-                  </select>
+                    className="w-full"
+                    options={[
+                      { value: 'false', label: t('pipeline.providerOptions.thinkDisabled') },
+                      { value: 'true', label: t('pipeline.providerOptions.thinkEnabled') },
+                      { value: 'low', label: t('pipeline.providerOptions.thinkLow') },
+                      { value: 'medium', label: t('pipeline.providerOptions.thinkMedium') },
+                      { value: 'high', label: t('pipeline.providerOptions.thinkHigh') },
+                    ]}
+                  />
                 </LabeledField>
               </div>
 

--- a/src/components/pipeline/SettingsTabPanel.tsx
+++ b/src/components/pipeline/SettingsTabPanel.tsx
@@ -6,7 +6,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type { PipelineConfig, PipelineMode, PromptTemplate } from '../../types';
 import type { SaveTemplateFn } from '../../stores/promptTemplateStore';
 import { LANGUAGES } from '../../constants';
-import { IconButton, SectionLabel, Tooltip } from '../ui';
+import { IconButton, SectionLabel, Select, Tooltip } from '../ui';
 import { PersonaEditor } from './PersonaEditor';
 import { PhraseMemoryConfig } from './PhraseMemoryConfig';
 
@@ -170,17 +170,14 @@ export function SettingsTabPanel({
       <div className="space-y-2">
         <SectionLabel icon={Globe} label={t('pipeline.languagePair')} />
         <div className={`flex items-center gap-3 transition-opacity ${config.persona ? 'opacity-40 pointer-events-none' : ''}`}>
-          <select
+          <Select
             value={config.sourceLanguage}
-            onChange={(e) => setConfig((prev) => ({ ...prev, sourceLanguage: e.target.value }))}
-            className="w-full rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-            aria-label={t('pipeline.sourceLanguage')}
+            onChange={(value) => setConfig((prev) => ({ ...prev, sourceLanguage: value }))}
+            options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+            className="w-full font-mono appearance-none"
+            ariaLabel={t('pipeline.sourceLanguage')}
             disabled={!!config.persona}
-          >
-            {LANGUAGES.map((lang) => (
-              <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-            ))}
-          </select>
+          />
           <IconButton
             size="md"
             className="shrink-0"
@@ -196,17 +193,14 @@ export function SettingsTabPanel({
           >
             <ArrowRightLeft size={13} />
           </IconButton>
-          <select
+          <Select
             value={config.targetLanguage}
-            onChange={(e) => setConfig((prev) => ({ ...prev, targetLanguage: e.target.value }))}
-            className="w-full rounded-md border border-editorial-border bg-editorial-bg/80 px-3 py-2 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent appearance-none"
-            aria-label={t('pipeline.targetLanguage')}
+            onChange={(value) => setConfig((prev) => ({ ...prev, targetLanguage: value }))}
+            options={LANGUAGES.map((lang) => ({ value: lang, label: t(`languages.${lang}`) }))}
+            className="w-full font-mono appearance-none"
+            ariaLabel={t('pipeline.targetLanguage')}
             disabled={!!config.persona}
-          >
-            {LANGUAGES.map((lang) => (
-              <option key={lang} value={lang}>{t(`languages.${lang}`)}</option>
-            ))}
-          </select>
+          />
         </div>
         {!!config.persona && (
           <p className="text-xs leading-relaxed text-editorial-muted/60">

--- a/src/components/pipeline/StageCard.tsx
+++ b/src/components/pipeline/StageCard.tsx
@@ -31,7 +31,7 @@ import { useUiStore } from '../../stores/uiStore';
 import { confirm } from '../../stores/confirmStore';
 import { STAGE_TEMPLATES } from '../../pipeline/pipelineModes';
 import { DeeplStageConfig } from './DeeplStageConfig';
-import { IconButton, SectionLabel, FieldLabel } from '../ui';
+import { IconButton, SectionLabel, FieldLabel, Select } from '../ui';
 
 interface StageCardProps {
   stage: PipelineStageConfig;
@@ -217,34 +217,36 @@ export function StageCard({
       <div className="space-y-3 border-l-4 border-l-editorial-charcoal/30 border-y border-editorial-border/70 bg-editorial-bg/65 px-5 py-4">
         <SectionLabel icon={Cpu} label={t('pipeline.stageModelLabel')} />
         <div className="flex items-center gap-2">
-          <select
+          <Select
             value={stage.provider}
-            onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
+            onChange={(value) => handleProviderChange(value as ModelProvider)}
             disabled={modelDisabled}
-            className="rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-bold uppercase outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-            aria-label={t('models.provider')}
-          >
-            {LLM_PROVIDER_ORDER.map((p) => (
-              <option key={p} value={p} disabled={p !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[p] === false}>{p}</option>
-            ))}
-            <option key="custom" value="custom">custom</option>
-          </select>
+            className="font-bold uppercase"
+            ariaLabel={t('models.provider')}
+            options={[
+              ...LLM_PROVIDER_ORDER.map((p) => ({
+                value: p,
+                label: p,
+                disabled: p !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[p] === false,
+              })),
+              { value: 'custom', label: 'custom' },
+            ]}
+          />
           {stage.provider === 'custom' ? (
             <div className="flex flex-1 flex-col gap-1.5">
-              <select
+              <Select
                 value={stage.customProviderId ?? ''}
-                onChange={(e) => onUpdate({ customProviderId: e.target.value || undefined })}
+                onChange={(value) => onUpdate({ customProviderId: value || undefined })}
                 disabled={modelDisabled}
-                className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                aria-label={t('settings.customProvider.sectionTitle')}
-              >
-                {customProfiles.length === 0 && (
-                  <option value="">{t('settings.customProvider.add')}</option>
-                )}
-                {customProfiles.map((p) => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
+                className="flex-1"
+                ariaLabel={t('settings.customProvider.sectionTitle')}
+                options={[
+                  ...(customProfiles.length === 0
+                    ? [{ value: '', label: t('settings.customProvider.add') }]
+                    : []),
+                  ...customProfiles.map((p) => ({ value: p.id, label: p.name })),
+                ]}
+              />
               <input
                 value={stage.model}
                 onChange={(e) => handleModelChange(e.target.value)}
@@ -256,21 +258,17 @@ export function StageCard({
             </div>
           ) : effectiveModelOptions.length > 0 ? (
             <div className="flex flex-1 items-center gap-1.5">
-              <select
+              <Select
                 value={stage.model}
-                onChange={(e) => handleModelChange(e.target.value)}
+                onChange={handleModelChange}
                 disabled={modelDisabled}
-                className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:opacity-40 disabled:cursor-not-allowed"
-                aria-label={t('pipeline.stageModelLabel')}
-              >
-                {effectiveModelOptions.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                    {getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}
-                    {getModelStatus(stage.provider, m) === 'deprecated' ? ' (superato)' : ''}
-                  </option>
-                ))}
-              </select>
+                className="flex-1"
+                ariaLabel={t('pipeline.stageModelLabel')}
+                options={effectiveModelOptions.map((m) => ({
+                  value: m,
+                  label: `${m}${getModelStatus(stage.provider, m) === 'preview' ? ' (preview)' : ''}${getModelStatus(stage.provider, m) === 'deprecated' ? ' (superato)' : ''}`,
+                }))}
+              />
               <ModelCapabilityHint provider={stage.provider} model={stage.model} iconOnly />
               <DeprecatedModelBadge provider={stage.provider} model={stage.model} />
             </div>

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -36,7 +36,7 @@ export function Menu({ open, onOpenChange, items, anchorRect }: MenuProps) {
           side="bottom"
           align="start"
           sideOffset={4}
-          className="z-[210] min-w-[200px] overflow-hidden rounded-2xl border border-editorial-border bg-editorial-page py-1.5 shadow-[var(--shadow-warm-md)]"
+          className="z-[210] min-w-[200px] overflow-hidden rounded-xl border border-editorial-border bg-editorial-page py-1.5 shadow-[var(--shadow-warm-md)]"
         >
           {items.map((item) => (
             <DropdownMenu.Item

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Select } from './Select';
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+];
+
+describe('Select', () => {
+  it('renders all options and reflects the current value', () => {
+    render(<Select value="b" onChange={vi.fn()} options={OPTIONS} ariaLabel="Test" />);
+    const select = screen.getByRole('combobox', { name: 'Test' }) as HTMLSelectElement;
+    expect(select.value).toBe('b');
+    expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected value', async () => {
+    const onChange = vi.fn();
+    render(<Select value="a" onChange={onChange} options={OPTIONS} ariaLabel="Test" />);
+
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Test' }), 'b');
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('is disabled when disabled is true', () => {
+    render(<Select value="a" onChange={vi.fn()} options={OPTIONS} ariaLabel="Test" disabled />);
+    expect(screen.getByRole('combobox', { name: 'Test' })).toBeDisabled();
+  });
+});

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,35 @@
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface SelectProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  ariaLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/** Select editoriale condiviso: stesso trattamento visivo su tutta l'app, etichetta sempre esplicita. */
+export function Select({ id, value, onChange, options, ariaLabel, disabled = false, className = '' }: SelectProps) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={`rounded-md border border-editorial-border bg-editorial-textbox px-2 py-1.5 text-xs font-sans text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${className}`}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,6 +7,7 @@ export { PillButton } from './PillButton';
 export { SectionLabel } from './SectionLabel';
 export { FieldLabel } from './FieldLabel';
 export { SegmentedControl, type SegmentedControlOption } from './SegmentedControl';
+export { Select, type SelectOption } from './Select';
 export { ToggleRow } from './ToggleRow';
 export { Tooltip, type TooltipSide } from './Tooltip';
 export { Popover } from './Popover';

--- a/src/components/workspace/MemoryExtractorSettings.tsx
+++ b/src/components/workspace/MemoryExtractorSettings.tsx
@@ -22,7 +22,7 @@ import { llmService } from '../../services/llmService';
 import { usePromptTemplateStore } from '../../stores/promptTemplateStore';
 import { useConfigStore } from '../../stores/configStore';
 import type { ModelProvider, PromptTemplate } from '../../types';
-import { FieldLabel, Tooltip } from '../ui';
+import { FieldLabel, IconButton, Select } from '../ui';
 
 interface MemoryExtractorSettingsProps {
   provider: ModelProvider;
@@ -132,32 +132,29 @@ export function MemoryExtractorSettings({
           {t('workspace.memoryExtractorModel')}
         </FieldLabel>
         <div className="flex gap-2">
-          <select
+          <Select
             value={provider}
-            onChange={(e) => handleProviderChange(e.target.value as ModelProvider)}
-            className="rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-bold uppercase text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-            aria-label={t('models.provider')}
-          >
-            {LLM_PROVIDER_ORDER.map((entry) => (
-              <option key={entry} value={entry} disabled={entry !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[entry] === false}>
-                {entry}
-              </option>
-            ))}
-          </select>
+            onChange={(value) => handleProviderChange(value as ModelProvider)}
+            className="font-bold uppercase"
+            ariaLabel={t('models.provider')}
+            options={LLM_PROVIDER_ORDER.map((entry) => ({
+              value: entry,
+              label: entry,
+              disabled: entry !== 'ollama' && (keyStatuses as Partial<Record<string, boolean>>)[entry] === false,
+            }))}
+          />
           {modelOptions.length > 0 ? (
             <div className="flex flex-1 items-center gap-1.5">
-              <select
+              <Select
                 value={model}
-                onChange={(e) => onModelChange(e.target.value)}
-                className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1.5 text-xs font-mono text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                aria-label={t('workspace.memoryExtractorModel')}
-              >
-                {modelOptions.map((entry) => (
-                  <option key={entry} value={entry}>
-                    {entry}{getModelStatus(provider, entry) === 'preview' ? ' (preview)' : ''}
-                  </option>
-                ))}
-              </select>
+                onChange={onModelChange}
+                className="flex-1 font-mono"
+                ariaLabel={t('workspace.memoryExtractorModel')}
+                options={modelOptions.map((entry) => ({
+                  value: entry,
+                  label: `${entry}${getModelStatus(provider, entry) === 'preview' ? ' (preview)' : ''}`,
+                }))}
+              />
               <ModelCapabilityHint provider={provider} model={model} iconOnly />
             </div>
           ) : (
@@ -187,75 +184,53 @@ export function MemoryExtractorSettings({
           <div className="flex items-center gap-1.5">
             {isEditingPrompt ? (
               <>
-                <Tooltip label={t('pipeline.refinePromptWithModel', { model: refineLabel })}>
-                  <button
-                    type="button"
-                    onClick={() => void handleRefine()}
-                    disabled={isRefining || !prompt.trim() || !canRefine}
-                    aria-label={t('pipeline.refinePromptWithModel', { model: refineLabel })}
-                    className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent disabled:opacity-40"
-                  >
-                    {isRefining ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
-                  </button>
-                </Tooltip>
-                <Tooltip label={t('pipeline.templates.save')}>
-                  <button
-                    type="button"
-                    onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
-                    aria-label={t('pipeline.templates.save')}
-                    className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                  >
-                    <BookmarkPlus size={16} />
-                  </button>
-                </Tooltip>
-                <Tooltip label={t('pipeline.templates.load')}>
-                  <button
-                    type="button"
-                    onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
-                    aria-label={t('pipeline.templates.load')}
-                    className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                  >
-                    <BookOpen size={16} />
-                  </button>
-                </Tooltip>
-                <Tooltip label={t('common.close')}>
-                  <button
-                    type="button"
-                    onClick={() => { setIsEditingPrompt(false); setShowSaveName(false); setShowTemplateList(false); }}
-                    aria-label={t('common.close')}
-                    className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                  >
-                    <X size={16} />
-                  </button>
-                </Tooltip>
+                <IconButton
+                  size="sm"
+                  onClick={() => void handleRefine()}
+                  disabled={isRefining || !prompt.trim() || !canRefine}
+                  title={t('pipeline.refinePromptWithModel', { model: refineLabel })}
+                >
+                  {isRefining ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  onClick={() => { setShowSaveName(!showSaveName); setShowTemplateList(false); }}
+                  title={t('pipeline.templates.save')}
+                >
+                  <BookmarkPlus size={16} />
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  onClick={() => { setShowTemplateList(!showTemplateList); setShowSaveName(false); }}
+                  title={t('pipeline.templates.load')}
+                >
+                  <BookOpen size={16} />
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  onClick={() => { setIsEditingPrompt(false); setShowSaveName(false); setShowTemplateList(false); }}
+                  title={t('common.close')}
+                >
+                  <X size={16} />
+                </IconButton>
               </>
             ) : (
               <>
                 {isCustomPrompt && (
-                  <Tooltip label={t('workspace.resetMemoryExtractorPrompt')}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onProviderChange(DEFAULT_MEMORY_EXTRACTOR_PROVIDER, DEFAULT_MEMORY_EXTRACTOR_MODEL);
-                        onPromptChange(DEFAULT_MEMORY_EXTRACTOR_PROMPT);
-                      }}
-                      aria-label={t('workspace.resetMemoryExtractorPrompt')}
-                      className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
-                    >
-                      <RotateCcw size={16} />
-                    </button>
-                  </Tooltip>
-                )}
-                <Tooltip label={t('pipeline.editPrompt')}>
-                  <button
-                    type="button"
-                    onClick={() => setIsEditingPrompt(true)}
-                    aria-label={t('pipeline.editPrompt')}
-                    className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-editorial-accent"
+                  <IconButton
+                    size="sm"
+                    onClick={() => {
+                      onProviderChange(DEFAULT_MEMORY_EXTRACTOR_PROVIDER, DEFAULT_MEMORY_EXTRACTOR_MODEL);
+                      onPromptChange(DEFAULT_MEMORY_EXTRACTOR_PROMPT);
+                    }}
+                    title={t('workspace.resetMemoryExtractorPrompt')}
                   >
-                    <Pencil size={16} />
-                  </button>
-                </Tooltip>
+                    <RotateCcw size={16} />
+                  </IconButton>
+                )}
+                <IconButton size="sm" onClick={() => setIsEditingPrompt(true)} title={t('pipeline.editPrompt')}>
+                  <Pencil size={16} />
+                </IconButton>
               </>
             )}
           </div>
@@ -276,23 +251,21 @@ export function MemoryExtractorSettings({
               autoFocus
               className="flex-1 rounded border border-editorial-border/60 bg-editorial-textbox/60 px-2 py-1 text-sm font-mono outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
             />
-            <button
-              type="button"
+            <IconButton
+              size="sm"
               onClick={() => void handleSaveTemplate()}
               disabled={!templateName.trim()}
-              className="text-editorial-ink transition-colors hover:text-editorial-accent focus:outline-none disabled:opacity-40"
-              aria-label={t('common.confirm')}
+              title={t('common.confirm')}
             >
               <Check size={16} />
-            </button>
-            <button
-              type="button"
+            </IconButton>
+            <IconButton
+              size="sm"
               onClick={() => { setShowSaveName(false); setTemplateName(''); }}
-              className="text-editorial-muted transition-colors hover:text-editorial-accent focus:outline-none"
-              aria-label={t('common.cancel')}
+              title={t('common.cancel')}
             >
               <X size={16} />
-            </button>
+            </IconButton>
           </div>
         )}
 
@@ -329,14 +302,14 @@ export function MemoryExtractorSettings({
                       <div className="truncate text-sm font-bold text-editorial-ink">{template.name}</div>
                       <div className="mt-0.5 truncate font-mono text-xs text-editorial-muted">{template.prompt}</div>
                     </button>
-                    <button
-                      type="button"
+                    <IconButton
+                      size="sm"
                       onClick={() => void handleDeleteTemplate(template.id)}
-                      className="mt-0.5 shrink-0 text-editorial-muted/40 opacity-0 transition-colors hover:text-editorial-accent focus:opacity-100 focus:outline-none group-hover:opacity-100"
-                      aria-label={t('common.delete')}
+                      title={t('common.delete')}
+                      className="mt-0.5 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                     >
                       <Trash2 size={14} />
-                    </button>
+                    </IconButton>
                   </li>
                 ))
               )}

--- a/src/components/workspace/WorkspaceSettingsModal.tsx
+++ b/src/components/workspace/WorkspaceSettingsModal.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 import { exportWorkspace, importWorkspace } from '../../services/backupService';
 import { regenerateAllEmbeddings } from '../../services/phraseMemoryService';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
-import { Dialog, IconButton, DialogConfirmButton, FieldLabel } from '../ui';
+import { Dialog, IconButton, DialogConfirmButton, FieldLabel, Select } from '../ui';
 import { MemoryExtractorSettings } from './MemoryExtractorSettings';
 import type { EmbeddingModel, ModelProvider } from '../../types';
 
@@ -217,15 +217,16 @@ export function WorkspaceSettingsModal({ open, onClose }: Props) {
                       {t('workspace.embeddingModel')}
                     </FieldLabel>
                     <div className="flex items-center gap-2">
-                      <select
+                      <Select
                         value={embeddingModel}
-                        onChange={(e) => setEmbeddingModel(e.target.value as EmbeddingModel)}
-                        className="flex-1 rounded-md border border-editorial-border/60 bg-editorial-textbox/60 px-3 py-2 text-xs font-mono text-editorial-ink outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
-                        aria-label={t('workspace.embeddingModel')}
-                      >
-                        <option value="text-embedding-3-small">text-embedding-3-small</option>
-                        <option value="text-embedding-3-large">text-embedding-3-large</option>
-                      </select>
+                        onChange={(value) => setEmbeddingModel(value as EmbeddingModel)}
+                        className="flex-1 font-mono"
+                        ariaLabel={t('workspace.embeddingModel')}
+                        options={[
+                          { value: 'text-embedding-3-small', label: 'text-embedding-3-small' },
+                          { value: 'text-embedding-3-large', label: 'text-embedding-3-large' },
+                        ]}
+                      />
                       <IconButton
                         size="md"
                         tone="default"


### PR DESCRIPTION
## Sommario
Blocco 1/2 della chiusura di #323 (audit design system).

- Nuovo componente condiviso `Select` (stesso trattamento visivo di `IconButton`/`SegmentedControl`)
- Migrati tutti i 30 `<select>` HTML grezzi nei 14 file segnalati (settings pipeline/workspace/libreria, dialog import/export, editor documento) — etichetta sempre esplicita, preservata da ogni file originale
- MemoryExtractorSettings: 10 pulsanti icona scritti a mano con tooltip manuale → `IconButton` condiviso
- DocumentView: ombre dei pallini frammento derivate dai token colore reali (`color-mix()`) invece di rgba scritti a mano che duplicavano lo stesso valore
- Menu e MarkdownEditor: angoli arrotondati fuori scala (`rounded-2xl`) riportati a `rounded-xl`, in linea con `Popover`
- Colori di evidenziazione (`uiStore`, `HL_COLORS_*`): verificati e lasciati come sono — palette a parte apposta più satura per restare leggibile sul testo, derivarli dai token editoriali (tutti smorzati) li renderebbe meno distinguibili

## Test plan
- [x] `tsc --noEmit` pulito
- [x] `vitest run` — 644 test passati
- [x] `eslint` pulito (solo warning pre-esistenti non toccati)
- [x] Verificato: zero `<select>` grezzi rimasti in `src/components`