### PR TITLE
fix: traduce in italiano il nome della sezione Phrase Memory (#323)

### DIFF
--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -485,7 +485,7 @@
     "contextWindowBadge": "{{count}} ctx",
     "panelTitle": "Configurazione",
     "providerTab": "Provider",
-    "phraseMemoryTab": "Phrase Memory",
+    "phraseMemoryTab": "Memoria frasi",
     "phraseMemoryToggle": "Memoria",
     "phraseMemoryAutoSearch": "Ricerca automatica",
     "phraseMemoryMaxResults": "Risultati massimi",


### PR DESCRIPTION
## Sommario
Restava "Phrase Memory" (inglese) anche nel file di traduzione italiano, notato da Niki durante il test della PR #349. Corretto in "Memoria frasi".

## Test plan
- [x] `tsc --noEmit` pulito