### PR TITLE
feat(326): anteprima messaggio pipeline per chunk prima del lancio

### DIFF
--- a/docs-dev/UI_DESIGN_SYSTEM.md
+++ b/docs-dev/UI_DESIGN_SYSTEM.md
@@ -375,7 +375,7 @@ Gerarchia obbligatoria, dall'alto:
 5. **Footer progetto**: azioni globali ancorate in basso (workspace, libreria, config, import/export).
 
 Regole:
-- Rail aperta: default 300px, minimo 280px, massimo 420px. Larghezze salvate vanno clamped in questo intervallo.
+- Rail aperta: default 300px, minimo 280px, massimo 520px. Larghezze salvate vanno clamped in questo intervallo.
 - Rail collassata: solo icone con tooltip; no label visibile, tranne micro valori necessari (es. contatore frammento).
 - Comandi icon-only: sempre `IconButton`, tooltip obbligatorio, `ariaPressed` solo per toggle (`Chunk/Tutto`), `aria-selected` solo per tab.
 - Stop/errori/distruttive: `editorial-danger`; accento attivo/selezione: `editorial-accent`.
@@ -388,7 +388,7 @@ Regole:
 ### Resize (drag + tastiera) — pannelli progetto
 
 Vista progetto usa `react-resizable-panels`. Larghezze e stato collapse persistiti in `uiStore`.
-- Rail sinistra: default 300px, collapsed 64px, min 280px, max 420px.
+- Rail sinistra: default 300px, collapsed 64px, min 280px, max 520px.
 - Ispettore destro: default 430px, collapsed 56px, min 300px, max 620px.
 - Durante drag transizione disattivata (movimento 1:1); allo snap/chiusura riprende animazione tramite token motion condiviso.
 - Grip sottile sempre visibile, accentuato in hover/drag/focus. No larghezze hard-coded nei consumer: leggere da `uiStore`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             llm::pipeline::compute_blobs,
             llm::pipeline::run_stage,
             llm::pipeline::run_stage_stream,
+            llm::pipeline::preview_stage_prompt,
             llm::pipeline::cancel_stream,
             llm::pipeline::judge_translation,
             llm::pipeline::refine_prompt,

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -237,6 +237,36 @@ pub async fn run_stage(
     })
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagePromptPreview {
+    pub system_prompt: String,
+    pub user_prompt: String,
+}
+
+/// Builds the exact prompt a stage would send, without contacting any provider.
+/// Lets the UI show the user what will be sent before they launch the pipeline.
+#[tauri::command]
+pub fn preview_stage_prompt(
+    text: String,
+    stage: StageConfig,
+    config: PipelineConfig,
+    previous_result: Option<String>,
+    audit_context: Option<String>,
+) -> StagePromptPreview {
+    let structured = build_stage_prompts(
+        &text,
+        &stage,
+        &config,
+        previous_result.as_deref(),
+        audit_context.as_deref(),
+    );
+    StagePromptPreview {
+        system_prompt: structured.flatten_system(),
+        user_prompt: structured.user.clone(),
+    }
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn run_stage_stream(

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -261,9 +261,10 @@ pub fn preview_stage_prompt(
         previous_result.as_deref(),
         audit_context.as_deref(),
     );
+    let system_prompt = structured.flatten_system();
     StagePromptPreview {
-        system_prompt: structured.flatten_system(),
-        user_prompt: structured.user.clone(),
+        system_prompt,
+        user_prompt: structured.user,
     }
 }
 

--- a/src/components/document/InsightsDrawer.tsx
+++ b/src/components/document/InsightsDrawer.tsx
@@ -2,6 +2,7 @@ import {
   BarChart2,
   BookText,
   Brain,
+  Eye,
   Layers,
   Link2,
   List,
@@ -15,6 +16,7 @@ import { useUiStore, type InsightsDrawerTab, type ChunkRailTab } from '../../sto
 import { useChunksStore } from '../../stores/chunksStore';
 import { MemoryTab } from './tabs/MemoryTab';
 import { ReferencesTab } from './tabs/ReferencesTab';
+import { ChunkPromptPreviewTab } from './tabs/ChunkPromptPreviewTab';
 import { usePipelineStore } from '../../stores/pipelineStore';
 import { useChunkWatchdog } from '../../hooks/useChunkWatchdog';
 import { SearchTab } from './SearchTab';
@@ -27,7 +29,7 @@ import { NotesTab } from './tabs/NotesTab';
 import { GlossaryTab } from './tabs/GlossaryTab';
 
 const DOC_TAB_ORDER: InsightsDrawerTab[] = ['index', 'search', 'stats', 'coherence', 'glossary'];
-const CHUNK_RAIL_TAB_ORDER: ChunkRailTab[] = ['audit', 'notes', 'memory', 'references'];
+const CHUNK_RAIL_TAB_ORDER: ChunkRailTab[] = ['audit', 'notes', 'memory', 'references', 'promptPreview'];
 
 const DOC_TAB_BUTTON_IDS: Record<InsightsDrawerTab, string> = {
   index: 'insights-tab-button-index',
@@ -50,6 +52,7 @@ const CHUNK_RAIL_TAB_BUTTON_IDS: Record<ChunkRailTab, string> = {
   notes: 'chunk-rail-tab-button-notes',
   memory: 'chunk-rail-tab-button-memory',
   references: 'chunk-rail-tab-button-references',
+  promptPreview: 'chunk-rail-tab-button-prompt-preview',
 };
 
 const CHUNK_RAIL_TAB_PANEL_IDS: Record<ChunkRailTab, string> = {
@@ -57,6 +60,7 @@ const CHUNK_RAIL_TAB_PANEL_IDS: Record<ChunkRailTab, string> = {
   notes: 'chunk-rail-tab-panel-notes',
   memory: 'chunk-rail-tab-panel-memory',
   references: 'chunk-rail-tab-panel-references',
+  promptPreview: 'chunk-rail-tab-panel-prompt-preview',
 };
 
 /** Stato condiviso letto da entrambi i pannelli del fly-out. */
@@ -95,12 +99,14 @@ export function ChunkInspectorPanel({ onReauditChunk }: ChunkInspectorPanelProps
     notes: <NotebookText size={16} />,
     memory: <Brain size={16} />,
     references: <Layers size={16} />,
+    promptPreview: <Eye size={16} />,
   };
   const CHUNK_RAIL_TAB_LABEL: Record<ChunkRailTab, string> = {
     audit: t('document.insightsTabAudit'),
     notes: t('document.insightsTabNotes'),
     memory: t('document.insightsTabMemory'),
     references: t('document.insightsTabReferences'),
+    promptPreview: t('document.insightsTabPromptPreview'),
   };
 
   const activateTab = (tab: ChunkRailTab) => {
@@ -169,10 +175,16 @@ export function ChunkInspectorPanel({ onReauditChunk }: ChunkInspectorPanelProps
             labelledBy={CHUNK_RAIL_TAB_BUTTON_IDS.memory}
             currentChunk={currentChunk}
           />
-        ) : (
+        ) : chunkRailTab === 'references' ? (
           <ReferencesTab
             panelId={CHUNK_RAIL_TAB_PANEL_IDS.references}
             labelledBy={CHUNK_RAIL_TAB_BUTTON_IDS.references}
+            currentChunk={currentChunk}
+          />
+        ) : (
+          <ChunkPromptPreviewTab
+            panelId={CHUNK_RAIL_TAB_PANEL_IDS.promptPreview}
+            labelledBy={CHUNK_RAIL_TAB_BUTTON_IDS.promptPreview}
             currentChunk={currentChunk}
           />
         )}

--- a/src/components/document/tabs/ChunkPromptPreviewTab.test.tsx
+++ b/src/components/document/tabs/ChunkPromptPreviewTab.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChunkPromptPreviewTab } from './ChunkPromptPreviewTab';
+import { useChunkPromptPreview } from '../../../hooks/useChunkPromptPreview';
+import { makeTranslationChunk } from '../../../test/chunkFactory';
+
+vi.mock('../../../hooks/useChunkPromptPreview', () => ({
+  useChunkPromptPreview: vi.fn(),
+}));
+vi.mock('../../../stores/pipelineStore', () => ({
+  usePipelineStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      config: {
+        stages: [
+          { id: 'stage-1', name: 'Traduzione', enabled: true, provider: 'openai' },
+          { id: 'stage-2', name: 'DeepL', enabled: true, provider: 'deepl' },
+        ],
+      },
+    }),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockUsePreview = vi.mocked(useChunkPromptPreview);
+
+function basePreviewState() {
+  return {
+    preview: null,
+    isBuilding: false,
+    error: null,
+    isDeeplStage: false,
+    build: vi.fn(),
+    reset: vi.fn(),
+  };
+}
+
+describe('ChunkPromptPreviewTab', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mostra lo stato vuoto quando non c\'è un chunk selezionato', () => {
+    mockUsePreview.mockReturnValue(basePreviewState());
+    render(<ChunkPromptPreviewTab panelId="p" labelledBy="l" currentChunk={null} />);
+    expect(screen.getByText('promptPreview.emptyNoChunk')).toBeInTheDocument();
+  });
+
+  it('avvisa che la fase DeepL non genera un messaggio testuale', () => {
+    mockUsePreview.mockReturnValue({ ...basePreviewState(), isDeeplStage: true });
+    const chunk = makeTranslationChunk({ id: 'c1' });
+    render(<ChunkPromptPreviewTab panelId="p" labelledBy="l" currentChunk={chunk} />);
+    expect(screen.getByText('promptPreview.deeplNotice')).toBeInTheDocument();
+  });
+
+  it('mostra i blocchi sistema e utente quando l\'anteprima è pronta', () => {
+    mockUsePreview.mockReturnValue({
+      ...basePreviewState(),
+      preview: { systemPrompt: 'SYS TEXT', userPrompt: 'USER TEXT' },
+    });
+    const chunk = makeTranslationChunk({ id: 'c1' });
+    render(<ChunkPromptPreviewTab panelId="p" labelledBy="l" currentChunk={chunk} />);
+    expect(screen.getByText('SYS TEXT')).toBeInTheDocument();
+    expect(screen.getByText('USER TEXT')).toBeInTheDocument();
+  });
+
+  it('chiama build con la fase selezionata quando si preme il pulsante', async () => {
+    const build = vi.fn();
+    mockUsePreview.mockReturnValue({ ...basePreviewState(), build });
+    const chunk = makeTranslationChunk({ id: 'c1' });
+    const user = userEvent.setup();
+    render(<ChunkPromptPreviewTab panelId="p" labelledBy="l" currentChunk={chunk} />);
+    await user.click(screen.getByRole('button', { name: 'promptPreview.buildButton' }));
+    expect(build).toHaveBeenCalledWith('stage-1');
+  });
+});

--- a/src/components/document/tabs/ChunkPromptPreviewTab.tsx
+++ b/src/components/document/tabs/ChunkPromptPreviewTab.tsx
@@ -1,0 +1,115 @@
+import { Check, Clipboard, Eye, Wand2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { usePipelineStore } from '../../../stores/pipelineStore';
+import { useChunkPromptPreview } from '../../../hooks/useChunkPromptPreview';
+import { EmptyState, IconButton, Select, Spinner } from '../../ui';
+import type { TranslationChunk } from '../../../types';
+
+interface ChunkPromptPreviewTabProps {
+  panelId: string;
+  labelledBy: string;
+  currentChunk: TranslationChunk | null;
+}
+
+function PromptBlockView({ title, body }: { title: string; body: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(body);
+      setCopied(true);
+      toast.success(t('promptPreview.copiedToClipboard'));
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t('errors.clipboardFailed'));
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-sans uppercase tracking-[0.1em] text-editorial-muted">{title}</p>
+        <IconButton size="md" title={t('promptPreview.copyBlock')} onClick={() => void handleCopy()} tooltipSide="left">
+          {copied ? <Check size={13} className="text-editorial-success" /> : <Clipboard size={13} />}
+        </IconButton>
+      </div>
+      <pre className="max-h-80 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-editorial-textbox/45 px-3 py-2 text-xs leading-relaxed text-editorial-charcoal custom-scrollbar">
+        {body}
+      </pre>
+    </div>
+  );
+}
+
+export function ChunkPromptPreviewTab({ panelId, labelledBy, currentChunk }: ChunkPromptPreviewTabProps) {
+  const { t } = useTranslation();
+  const stages = usePipelineStore((s) => s.config.stages);
+  const enabledStages = useMemo(() => stages.filter((stage) => stage.enabled), [stages]);
+  const [selectedStageId, setSelectedStageId] = useState(enabledStages[0]?.id ?? '');
+  const { preview, isBuilding, error, isDeeplStage, build, reset } = useChunkPromptPreview(currentChunk);
+
+  useEffect(() => {
+    if (!enabledStages.some((stage) => stage.id === selectedStageId)) {
+      setSelectedStageId(enabledStages[0]?.id ?? '');
+    }
+  }, [enabledStages, selectedStageId]);
+
+  useEffect(() => {
+    reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset() è stabile, va rieseguito solo al cambio chunk/fase
+  }, [currentChunk?.id, selectedStageId]);
+
+  return (
+    <div id={panelId} role="tabpanel" aria-labelledby={labelledBy} className="flex min-h-0 flex-1 flex-col">
+      <div className="sticky top-0 z-10 shrink-0 space-y-3 border-b border-editorial-border bg-editorial-bg px-4 py-3">
+        <div className="flex items-center gap-1.5">
+          <Eye size={13} className="text-editorial-accent shrink-0" />
+          <p className="text-xs font-sans uppercase tracking-[0.22em] text-editorial-muted">
+            {t('promptPreview.title')}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            id="prompt-preview-stage"
+            value={selectedStageId}
+            onChange={setSelectedStageId}
+            options={enabledStages.map((stage) => ({ value: stage.id, label: stage.name || stage.id }))}
+            ariaLabel={t('promptPreview.stageLabel')}
+            className="flex-1"
+          />
+          <IconButton
+            size="md"
+            tone="default"
+            title={t('promptPreview.buildButton')}
+            disabled={!currentChunk || !selectedStageId || isBuilding}
+            onClick={() => void build(selectedStageId)}
+            tooltipSide="left"
+          >
+            <Wand2 size={13} />
+          </IconButton>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 custom-scrollbar">
+        {!currentChunk ? (
+          <EmptyState icon={<Eye size={28} />} message={t('promptPreview.emptyNoChunk')} />
+        ) : isBuilding ? (
+          <Spinner label={t('promptPreview.building')} />
+        ) : isDeeplStage ? (
+          <EmptyState icon={<Eye size={28} />} message={t('promptPreview.deeplNotice')} />
+        ) : error ? (
+          <EmptyState icon={<Eye size={28} />} message={t('promptPreview.buildFailed')} hint={error} />
+        ) : preview ? (
+          <div className="space-y-4">
+            <PromptBlockView title={t('promptPreview.systemLabel')} body={preview.systemPrompt} />
+            <PromptBlockView title={t('promptPreview.userLabel')} body={preview.userPrompt} />
+          </div>
+        ) : (
+          <EmptyState icon={<Eye size={28} />} message={t('promptPreview.emptyBeforeBuild')} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/help/HelpGuide.tsx
+++ b/src/components/help/HelpGuide.tsx
@@ -445,6 +445,9 @@ function ContextSection() {
 
       <SubTitle>{t('help.context.cacheRetentionTitle')}</SubTitle>
       <P>{t('help.context.cacheRetentionDesc')}</P>
+
+      <SubTitle>{t('help.context.previewTitle')}</SubTitle>
+      <P>{t('help.context.previewDesc')}</P>
     </>
   );
 }

--- a/src/components/layout/shell-next/ShellNext.tsx
+++ b/src/components/layout/shell-next/ShellNext.tsx
@@ -19,7 +19,7 @@ import { useResizeDragging } from './useResizeDragging';
 const SIDEBAR_DEFAULT = 300;
 const SIDEBAR_COLLAPSED = 64;
 const SIDEBAR_MIN = 280;
-const SIDEBAR_MAX = 420;
+const SIDEBAR_MAX = 520;
 
 // Ispettore destro (eredita le larghezze del vecchio fly-out).
 const INSPECTOR_DEFAULT = 430;

--- a/src/components/layout/shell-next/WorkspaceShellNext.tsx
+++ b/src/components/layout/shell-next/WorkspaceShellNext.tsx
@@ -16,7 +16,7 @@ import { useResizeDragging } from './useResizeDragging';
 const SIDEBAR_DEFAULT = 300;
 const SIDEBAR_COLLAPSED = 64;
 const SIDEBAR_MIN = 280;
-const SIDEBAR_MAX = 420;
+const SIDEBAR_MAX = 520;
 
 function clampPanelWidth(width: number, min: number, max: number) {
   return Math.min(Math.max(width, min), max);

--- a/src/hooks/useChunkPromptPreview.ts
+++ b/src/hooks/useChunkPromptPreview.ts
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useChunksStore } from '../stores/chunksStore';
+import { usePipelineStore } from '../stores/pipelineStore';
+import { usePhraseMemoryStore } from '../stores/phraseMemoryStore';
+import { buildMemoryInjection } from '../services/phraseMemoryInjection';
+import { buildBlobContext } from './pipeline/blobContext';
+import { stripFootnoteMarkers } from '../utils/footnoteExtractor';
+import { llmService } from '../services/llmService';
+import type { PipelineStageConfig, PromptInfo, TranslationChunk } from '../types';
+
+interface ChunkPromptPreviewResult {
+  preview: PromptInfo | null;
+  isBuilding: boolean;
+  error: string | null;
+  isDeeplStage: boolean;
+  build: (stageId: string) => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * Builds the literal prompt for one pipeline stage on a specific chunk, mirroring the
+ * per-stage context assembly in usePipeline's executePipelineForChunk (blob context,
+ * phrase-memory injection, previous-stage chaining) but only up to the point of building
+ * the message — it never calls a provider.
+ */
+export function useChunkPromptPreview(chunk: TranslationChunk | null): ChunkPromptPreviewResult {
+  const [preview, setPreview] = useState<PromptInfo | null>(null);
+  const [isBuilding, setIsBuilding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isDeeplStage, setIsDeeplStage] = useState(false);
+
+  const reset = () => {
+    setPreview(null);
+    setError(null);
+    setIsDeeplStage(false);
+  };
+
+  const build = async (stageId: string) => {
+    if (!chunk) return;
+    const config = usePipelineStore.getState().config;
+    const stage = config.stages.find((s) => s.id === stageId);
+    if (!stage) return;
+
+    setPreview(null);
+    setError(null);
+    setIsDeeplStage(false);
+
+    if (stage.provider === 'deepl') {
+      setIsDeeplStage(true);
+      return;
+    }
+
+    setIsBuilding(true);
+    try {
+      const enabledStages = config.stages.filter((s) => s.enabled);
+      const stageIndex = enabledStages.findIndex((s) => s.id === stageId);
+      const previousStage = stageIndex > 0 ? enabledStages[stageIndex - 1] : undefined;
+      const previousResult = previousStage ? chunk.stageResults[previousStage.id]?.content : undefined;
+
+      const isFormatStage = (stage.role ?? 'translation') === 'format';
+      const liveChunks = useChunksStore.getState().chunks;
+      const blobContext = isFormatStage
+        ? undefined
+        : buildBlobContext(liveChunks, chunk.id, (c) => c.sourceProcessingText || undefined);
+
+      const effectiveConfig = {
+        ...config,
+        ...(!config.persona && stage.sourceLanguage ? { sourceLanguage: stage.sourceLanguage } : {}),
+        ...(!config.persona && stage.targetLanguage ? { targetLanguage: stage.targetLanguage } : {}),
+        ...(blobContext ? { blobContext, blobCurrentChunkId: chunk.id } : {}),
+      };
+
+      const memoryEntry = config.usePhraseMemory
+        ? usePhraseMemoryStore.getState().matchesByChunk.get(chunk.id)
+        : undefined;
+      const memoryBlock = memoryEntry
+        ? buildMemoryInjection(memoryEntry.matches.filter((m) => memoryEntry.enabledMatchIds.has(m.id))) ?? undefined
+        : undefined;
+      const effectiveStage: PipelineStageConfig = memoryBlock
+        ? { ...stage, prompt: `${stage.prompt}\n\n${memoryBlock}` }
+        : stage;
+
+      const stageText = isFormatStage
+        ? (previousResult ?? '')
+        : stripFootnoteMarkers(chunk.sourceProcessingText);
+      const stagePrevious = isFormatStage ? undefined : previousResult;
+
+      const result = await llmService.previewStagePrompt(stageText, effectiveStage, effectiveConfig, stagePrevious);
+      setPreview(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsBuilding(false);
+    }
+  };
+
+  return { preview, isBuilding, error, isDeeplStage, build, reset };
+}

--- a/src/hooks/useChunkPromptPreview.ts
+++ b/src/hooks/useChunkPromptPreview.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useChunksStore } from '../stores/chunksStore';
 import { usePipelineStore } from '../stores/pipelineStore';
 import { usePhraseMemoryStore } from '../stores/phraseMemoryStore';
@@ -28,8 +28,13 @@ export function useChunkPromptPreview(chunk: TranslationChunk | null): ChunkProm
   const [isBuilding, setIsBuilding] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isDeeplStage, setIsDeeplStage] = useState(false);
+  // Bumped on every reset()/build() so a build() that resolves after the user
+  // already switched chunk/stage (or started a newer build) can detect it's
+  // stale and discard its result instead of overwriting the current view.
+  const requestIdRef = useRef(0);
 
   const reset = () => {
+    requestIdRef.current += 1;
     setPreview(null);
     setError(null);
     setIsDeeplStage(false);
@@ -41,6 +46,7 @@ export function useChunkPromptPreview(chunk: TranslationChunk | null): ChunkProm
     const stage = config.stages.find((s) => s.id === stageId);
     if (!stage) return;
 
+    const requestId = ++requestIdRef.current;
     setPreview(null);
     setError(null);
     setIsDeeplStage(false);
@@ -86,11 +92,13 @@ export function useChunkPromptPreview(chunk: TranslationChunk | null): ChunkProm
       const stagePrevious = isFormatStage ? undefined : previousResult;
 
       const result = await llmService.previewStagePrompt(stageText, effectiveStage, effectiveConfig, stagePrevious);
+      if (requestIdRef.current !== requestId) return; // stale: chunk/fase è già cambiata
       setPreview(result);
     } catch (err) {
+      if (requestIdRef.current !== requestId) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setIsBuilding(false);
+      if (requestIdRef.current === requestId) setIsBuilding(false);
     }
   };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1005,7 +1005,22 @@
     "watchdogStuck": "Stuck",
     "watchdogCancel": "Cancel & retry",
     "insightsTabMemory": "Memory",
-    "insightsTabReferences": "References"
+    "insightsTabReferences": "References",
+    "insightsTabPromptPreview": "Preview"
+  },
+  "promptPreview": {
+    "title": "Message preview",
+    "stageLabel": "Stage to preview",
+    "buildButton": "Build preview",
+    "building": "Building…",
+    "systemLabel": "System instructions",
+    "userLabel": "User message",
+    "copyBlock": "Copy this block",
+    "copiedToClipboard": "Copied to clipboard",
+    "emptyNoChunk": "Select a chunk to build the preview.",
+    "emptyBeforeBuild": "Press \"Build preview\" to see the full message for this stage.",
+    "deeplNotice": "This stage uses DeepL: it doesn't generate a text message for a language model.",
+    "buildFailed": "Couldn't build the preview."
   },
   "help": {
     "title": "User Guide",
@@ -1157,7 +1172,9 @@
       "tipTitle": "What this means in practice",
       "tipDesc": "After the first chunk in a group is processed, subsequent chunks in the same group cost less because the provider reuses the cached layers. On long documents with many chunks the savings are significant, especially in editorial mode where three stages run per chunk.",
       "cacheRetentionTitle": "Cache retention per model",
-      "cacheRetentionDesc": "OpenAI uses two different cache policies. Full models (gpt-5.4 and above) use extended retention: the prefix stays cached for up to 24 hours, so each subsequent chunk benefits from the previous run's warm cache. Mini and nano models use in-memory retention only: the prefix expires after 5–10 minutes of inactivity. This explains why Refine (typically on gpt-5.4-mini) can show 0% cache hit even when the prompt is identical: if more than ~10 minutes passed between chunks, the cache has already expired."
+      "cacheRetentionDesc": "OpenAI uses two different cache policies. Full models (gpt-5.4 and above) use extended retention: the prefix stays cached for up to 24 hours, so each subsequent chunk benefits from the previous run's warm cache. Mini and nano models use in-memory retention only: the prefix expires after 5–10 minutes of inactivity. This explains why Refine (typically on gpt-5.4-mini) can show 0% cache hit even when the prompt is identical: if more than ~10 minutes passed between chunks, the cache has already expired.",
+      "previewTitle": "Previewing the message for a chunk",
+      "previewDesc": "In the Chunk panel, the Preview tab shows the actual, complete message that would be sent to the engine for the open chunk: pick a pipeline stage and build it on demand. Nothing runs and nothing is charged — useful for checking exactly what the model will receive before launching the translation."
     },
     "streaming": {
       "title": "Real-time streaming",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1005,7 +1005,22 @@
     "watchdogStuck": "Bloccato",
     "watchdogCancel": "Annulla e riprova",
     "insightsTabMemory": "Memoria",
-    "insightsTabReferences": "Riferimenti"
+    "insightsTabReferences": "Riferimenti",
+    "insightsTabPromptPreview": "Anteprima"
+  },
+  "promptPreview": {
+    "title": "Anteprima messaggio",
+    "stageLabel": "Fase da vedere in anteprima",
+    "buildButton": "Costruisci anteprima",
+    "building": "Costruzione in corso…",
+    "systemLabel": "Istruzioni di sistema",
+    "userLabel": "Messaggio utente",
+    "copyBlock": "Copia questo blocco",
+    "copiedToClipboard": "Copiato negli appunti",
+    "emptyNoChunk": "Seleziona un chunk per costruire l'anteprima.",
+    "emptyBeforeBuild": "Premi \"Costruisci anteprima\" per vedere il messaggio completo di questa fase.",
+    "deeplNotice": "Questa fase usa DeepL: non genera un messaggio testuale per un modello linguistico.",
+    "buildFailed": "Non sono riuscito a costruire l'anteprima."
   },
   "help": {
     "title": "Guida Utente",
@@ -1157,7 +1172,9 @@
       "tipTitle": "Cosa significa in pratica",
       "tipDesc": "Dopo che il primo chunk di un gruppo viene elaborato, i chunk successivi dello stesso gruppo costano meno perché il provider riusa gli strati cachati. Su documenti lunghi con molti chunk il risparmio è significativo, specialmente in modalità editoriale dove tre stage vengono eseguiti per chunk.",
       "cacheRetentionTitle": "Cache retention per modello",
-      "cacheRetentionDesc": "OpenAI distingue due politiche di cache. I modelli completi (gpt-5.4 e superiori) usano la extended retention: il prefisso rimane in cache fino a 24 ore, quindi ogni chunk successivo beneficia del riscaldamento del run precedente. I modelli mini e nano usano invece la in-memory retention: il prefisso scade dopo 5–10 minuti di inattività. Questo spiega perché Refine (tipicamente su gpt-5.4-mini) può mostrare 0% di cache hit anche quando il prompt è identico: se sono passati più di 10 minuti tra un chunk e il successivo, la cache è già scaduta."
+      "cacheRetentionDesc": "OpenAI distingue due politiche di cache. I modelli completi (gpt-5.4 e superiori) usano la extended retention: il prefisso rimane in cache fino a 24 ore, quindi ogni chunk successivo beneficia del riscaldamento del run precedente. I modelli mini e nano usano invece la in-memory retention: il prefisso scade dopo 5–10 minuti di inattività. Questo spiega perché Refine (tipicamente su gpt-5.4-mini) può mostrare 0% di cache hit anche quando il prompt è identico: se sono passati più di 10 minuti tra un chunk e il successivo, la cache è già scaduta.",
+      "previewTitle": "Anteprima del messaggio per un chunk",
+      "previewDesc": "Nel pannello Chunk, la scheda Anteprima mostra il messaggio completo e reale che verrebbe inviato al motore per il chunk aperto: scegli una fase della pipeline e costruiscilo a comando. Non parte nessuna elaborazione né alcun costo — utile per controllare cosa riceverà davvero il modello prima di lanciare la traduzione."
     },
     "streaming": {
       "title": "Streaming in tempo reale",

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -146,6 +146,27 @@ export const llmService = {
   },
 
   /**
+   * Builds the exact prompt a stage would send, without running it — no provider
+   * call, no cost, no result written anywhere. Used for the prompt preview tab.
+   */
+  async previewStagePrompt(
+    text: string,
+    stage: PipelineStageConfig,
+    config: PipelineConfig,
+    previousResult: string | undefined,
+    auditContext?: string,
+  ): Promise<PromptInfo> {
+    const result = await invoke<{ systemPrompt: string; userPrompt: string }>('preview_stage_prompt', {
+      text,
+      stage,
+      config,
+      previousResult: previousResult || null,
+      auditContext: auditContext || null,
+    });
+    return { systemPrompt: result.systemPrompt, userPrompt: result.userPrompt };
+  },
+
+  /**
    * Streaming stage execution — sets up event listener, invokes backend,
    * calls onToken for each token, cleans up listener, returns full text.
    */

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -7,7 +7,7 @@ import type {
 
 export type InsightsDrawerTab = 'index' | 'search' | 'stats' | 'coherence' | 'glossary';
 export type ChunkDrawerTab = 'summary' | 'audit' | 'notes' | 'operations' | 'memory';
-export type ChunkRailTab = 'audit' | 'notes' | 'memory' | 'references';
+export type ChunkRailTab = 'audit' | 'notes' | 'memory' | 'references' | 'promptPreview';
 export type DocumentPaneFocus = 'both' | 'source' | 'translation';
 export type HelpSection = 'overview' | 'pipeline' | 'features' | 'context' | 'audit' | 'projects' | 'providers' | 'ollama' | 'glossary' | 'shortcuts' | 'troubleshooting' | 'design';
 export type ActivePanel = 'config' | 'insights' | 'chunk' | 'settings' | 'help' | null;


### PR DESCRIPTION
## Riassunto
Primo passo dell'issue #326 (milestone v1.2 stabilization) + richiesta di Niki: una scheda "Anteprima" nel pannello Chunk (dopo Riferimenti) che mostra il messaggio letterale — sistema + utente — che verrebbe inviato al motore per la fase scelta sul chunk aperto, senza contattare alcun provider (nessun costo, nessun risultato scritto).

- Nuovo comando Rust `preview_stage_prompt`: riusa `build_stage_prompts` esistente, si ferma prima della chiamata al provider.
- Nuovo hook `useChunkPromptPreview` che specchia l'assemblaggio contesto per-fase di `usePipeline` (blob context, iniezione memoria frasi, incatenamento fase precedente) senza toccare il percorso di esecuzione reale.
- Nuova scheda `ChunkPromptPreviewTab`, registrata dopo "Riferimenti" nel pannello Chunk (`InsightsDrawer`/`uiStore`).
- Distinta dall'anteprima strutturale/segnaposto già esistente nelle impostazioni pipeline (`components/pipeline/PromptPreviewTab.tsx`) — quella resta invariata.
- Tetto di ridimensionamento del pannello Chunk alzato da 420px a 520px (testo lungo era illeggibile allo stretto).
- Voce aggiunta nella guida in-app (sezione "Contesto e caching").

## Test plan
- [x] `tsc --noEmit` pulito
- [x] `cargo check` + `cargo clippy -- -D warnings` puliti
- [ ] Verifica manuale in app: aprire un progetto, selezionare un chunk, scheda Anteprima dopo Riferimenti, scegliere fase, costruire anteprima, controllare che non parta nessuna chiamata reale
- [ ] Verificare ridimensionamento pannello fino al nuovo massimo (520px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)