### PR TITLE
fix(326): 3 correzioni pipeline a basso sforzo (cache, giudice, token)

### DIFF
--- a/src-tauri/src/llm/blobs.rs
+++ b/src-tauri/src/llm/blobs.rs
@@ -19,10 +19,17 @@ pub struct BlobAssignment {
     pub reference_chunk_ids: Arc<[String]>,
 }
 
-/// Rough token estimate: ~1.33 tokens per word (works for Latin-script languages).
+/// Rough token estimate. Word-based (~1.33 tokens/word) approximates common
+/// Latin-script text well, but undercounts dense/inflected languages (German
+/// compounds, Latin) where a single whitespace-separated "word" is unusually
+/// long — those need more subword tokens than the word count alone implies.
+/// A character-based floor (~4 chars/token) catches that case without
+/// changing the estimate for ordinary text.
 pub fn estimate_tokens(text: &str) -> usize {
     let words = text.split_whitespace().count();
-    words + words / 3
+    let word_based = words + words / 3;
+    let char_based = text.chars().count() / 4;
+    word_based.max(char_based)
 }
 
 /// Groups chunks into static reference blobs for prompt caching.
@@ -245,5 +252,16 @@ mod tests {
         assert_eq!(estimate_tokens("one two three"), 4);
         let text = words(30);
         assert_eq!(estimate_tokens(&text), 40);
+    }
+
+    #[test]
+    fn estimate_tokens_uses_char_floor_for_long_compound_words() {
+        // A single very long compound word (German-style) has a tiny word count,
+        // so the word-based formula alone would badly undercount it.
+        let compound = "Rindfleischetikettierungsueberwachungsaufgabenuebertragungsgesetz";
+        let word_based_only = 1 + 1 / 3;
+        assert_eq!(word_based_only, 1);
+        assert!(estimate_tokens(compound) > word_based_only);
+        assert_eq!(estimate_tokens(compound), compound.chars().count() / 4);
     }
 }

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -428,9 +428,9 @@ pub async fn judge_translation(
         cache_miss_input_tokens: usage.as_ref().and_then(|u| u.cache_miss_input),
         system_prompt: None,
         user_prompt: None,
-        checked_sentences: parsed["checkedSentences"].as_array().map(|arr| {
+        checked_sentence_indices: parsed["checkedSentenceIndices"].as_array().map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v.as_u64().map(|n| n as u32))
                 .collect()
         }),
     })

--- a/src-tauri/src/llm/pipeline.rs
+++ b/src-tauri/src/llm/pipeline.rs
@@ -430,7 +430,9 @@ pub async fn judge_translation(
         user_prompt: None,
         checked_sentence_indices: parsed["checkedSentenceIndices"].as_array().map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_u64().map(|n| n as u32))
+                .filter_map(|v| v.as_u64())
+                .filter_map(|n| u32::try_from(n).ok())
+                .filter(|&n| n >= 1)
                 .collect()
         }),
     })

--- a/src-tauri/src/llm/prompts.rs
+++ b/src-tauri/src/llm/prompts.rs
@@ -256,7 +256,8 @@ pub(crate) fn build_judge_prompts(
          Report EVERY issue you find and EVERY occurrence separately — do not merge, suppress, or \
          limit repeated issues.\n\n\
          You MUST respond with a valid JSON object containing:\n\
-         - checkedSentences: array of source sentences you verified (list them verbatim as you scanned them)\n\
+         - checkedSentenceIndices: array of 1-based source sentence numbers you verified, in scan order \
+           (e.g. [1, 2, 3] for a 3-sentence source) — indices only, never the sentence text itself\n\
          - rating: one of 'critical', 'poor', 'fair', 'good', 'excellent' \
            (semantic translation quality: critical=unusable, poor=weak, fair=usable with revision, \
            good=solid, excellent=publication-ready)\n\
@@ -325,9 +326,7 @@ pub(crate) fn build_coherence_prompts(
     };
 
     // Block 1 (cacheable): static coherence context — role, instructions, glossary, format spec.
-    // Constant for the whole project run. blob_context stays in the user turn, but is
-    // placed before the current segment so provider prefix caches can reuse the stable
-    // reference block for every chunk in the same blob.
+    // Constant for the whole project run.
     let system_block = format!(
         "You are a translation coherence auditor for {src}→{tgt} translations.\n\
          Your task: identify cross-segment inconsistencies between a translated segment and its surrounding context.\n\
@@ -342,6 +341,9 @@ pub(crate) fn build_coherence_prompts(
          \"phrase\": \"exact verbatim substring of the WRONG text as it appears in the target translation, not the source term nor the correction; first occurrence only\"}}]}}",
     );
 
+    // Block 2 (cacheable): reference document block. Identical for every chunk in the same
+    // blob, so it's a second cache breakpoint — placed in system, not the user turn, so
+    // providers actually cache it instead of rebilling it at full price on every chunk.
     let context_block = input
         .blob_context
         .as_deref()
@@ -351,9 +353,8 @@ pub(crate) fn build_coherence_prompts(
              This block may include the current chunk. Use it to compare terminology and continuity across the document block.\n\
              The current chunk to audit is identified below.\n\
              {ctx}\n\
-             [End reference translated document block]\n\n"
-        ))
-        .unwrap_or_default();
+             [End reference translated document block]"
+        ));
 
     let current_chunk_line = input
         .current_chunk_id
@@ -363,20 +364,25 @@ pub(crate) fn build_coherence_prompts(
         .unwrap_or_default();
 
     let user = format!(
-        "{context_block}{current_chunk_line}[Current segment]\nOriginal: {original}\nTranslation: {translation}\n\
+        "{current_chunk_line}[Current segment]\nOriginal: {original}\nTranslation: {translation}\n\
          [End of current segment]\n\n\
          Identify cross-segment coherence issues and return the JSON. If no issues, return {{\"issues\": []}}.",
         original = input.original,
         translation = input.translation,
     );
 
-    StructuredPrompt {
-        system: vec![PromptBlock {
-            text: system_block,
+    let mut system = vec![PromptBlock {
+        text: system_block,
+        cacheable: true,
+    }];
+    if let Some(ctx) = context_block {
+        system.push(PromptBlock {
+            text: ctx,
             cacheable: true,
-        }],
-        user,
+        });
     }
+
+    StructuredPrompt { system, user }
 }
 
 /// Strips markdown code fences and any preamble text that LLMs sometimes wrap around JSON output.
@@ -508,17 +514,24 @@ mod tests {
     fn user_omits_reference_block_when_no_blob_context() {
         let prompt = build_coherence_prompts(&simple_input(), &en_it_config());
         assert!(!prompt.user.contains("Reference translated document block"));
+        assert_eq!(prompt.system.len(), 1);
     }
 
+    // The reference block lives in `system` (not `user`) so it forms a second cache
+    // breakpoint reused across every chunk in the same blob, instead of being rebilled
+    // at full price on every coherence call.
     #[test]
-    fn user_includes_reference_block_when_blob_context_provided() {
+    fn system_includes_cacheable_reference_block_when_blob_context_provided() {
         let input = CoherenceChunkInput {
             blob_context: Some("Adjacent chunk translation".to_string()),
             ..simple_input()
         };
         let prompt = build_coherence_prompts(&input, &en_it_config());
-        assert!(prompt.user.contains("Reference translated document block"));
-        assert!(prompt.user.contains("Adjacent chunk translation"));
+        assert_eq!(prompt.system.len(), 2);
+        assert!(prompt.system[1].text.contains("Reference translated document block"));
+        assert!(prompt.system[1].text.contains("Adjacent chunk translation"));
+        assert!(prompt.system[1].cacheable);
+        assert!(!prompt.user.contains("Reference translated document block"));
     }
 
     #[test]
@@ -545,6 +558,7 @@ mod tests {
         };
         let prompt = build_coherence_prompts(&input, &en_it_config());
         assert!(!prompt.user.contains("Reference translated document block"));
+        assert_eq!(prompt.system.len(), 1);
     }
 
     // ── build_stage_prompts audit_context ─────────────────────────────

--- a/src-tauri/src/llm/providers/openai.rs
+++ b/src-tauri/src/llm/providers/openai.rs
@@ -86,7 +86,7 @@ fn judge_json_schema() -> serde_json::Value {
                 },
                 "checkedSentenceIndices": {
                     "anyOf": [
-                        {"type": "array", "items": {"type": "integer"}},
+                        {"type": "array", "items": {"type": "integer", "minimum": 1}},
                         {"type": "null"}
                     ]
                 }

--- a/src-tauri/src/llm/providers/openai.rs
+++ b/src-tauri/src/llm/providers/openai.rs
@@ -84,14 +84,14 @@ fn judge_json_schema() -> serde_json::Value {
                         "additionalProperties": false
                     }
                 },
-                "checkedSentences": {
+                "checkedSentenceIndices": {
                     "anyOf": [
-                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "array", "items": {"type": "integer"}},
                         {"type": "null"}
                     ]
                 }
             },
-            "required": ["rating", "issues", "checkedSentences"],
+            "required": ["rating", "issues", "checkedSentenceIndices"],
             "additionalProperties": false
         }
     })

--- a/src-tauri/src/llm/types.rs
+++ b/src-tauri/src/llm/types.rs
@@ -188,9 +188,11 @@ pub struct JudgeResponse {
     pub system_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_prompt: Option<String>,
-    /// Sentences the model checked during the audit scan (self-verification list).
+    /// 1-based source sentence indices the model checked during the audit scan
+    /// (self-verification list — indices instead of full text to avoid billing
+    /// the whole source back at output-token rates).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checked_sentences: Option<Vec<String>>,
+    pub checked_sentence_indices: Option<Vec<u32>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,8 +204,8 @@ export interface PipelineResult {
 export interface JudgeResult extends PipelineResult {
   rating: QualityRating;
   issues: Issue[];
-  // Self-verification list from the judge model (sentences it scanned). Not displayed in UI.
-  checkedSentences?: string[];
+  // Self-verification list from the judge model (1-based sentence indices it scanned). Not displayed in UI.
+  checkedSentenceIndices?: number[];
 }
 
 export interface Issue {


### PR DESCRIPTION
…ce, stima token)

- build_coherence_prompts: il blocco di riferimento documentale ora sta nel system prompt (cacheable) invece che nel turno utente, così forma un secondo breakpoint di cache riusato per ogni chunk dello stesso blob invece di essere rifatturato per intero ad ogni chiamata
- giudice qualita: checkedSentences (eco verbatim delle frasi sorgente, pagato a tariffa output) sostituito con checkedSentenceIndices (indici 1-based) — stesso effetto di forzare la scansione completa, niente piu eco del testo intero
- estimate_tokens: aggiunto un floor char-based (~4 char/token) accanto alla stima a parole, per non sottostimare lingue con parole molto lunghe (composti tedeschi, forme latine) dove il conteggio parole da solo sballa la stima

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [ ] `npm run lint:all` passes (typecheck + ESLint)
- [ ] `cargo check` passes (if Rust changes)
- [ ] Tested locally
- [ ] i18n keys added for both EN and IT (if UI changes)
