### PR TITLE
test: aggiunge smoke test browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -34,6 +33,28 @@ jobs:
       - run: npm install -g npm@11
       - run: npm ci
       - run: npm test
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm install -g npm@11
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+      - name: Upload browser-test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
 
   cargo-check:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ docs/.vitepress/cache/
 docs/.vitepress/dist/
 dist/
 coverage/
+playwright-report/
+test-results/
 local/
 local/test-data/
 .DS_Store

--- a/docs-dev/ARCHITECTURE.md
+++ b/docs-dev/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 | Frontend | React 19, TypeScript, Tailwind v4, Zustand, Vite |
 | Backend | Rust, Tauri v2, tokio, reqwest |
 | DB | SQLite via SQLx (WAL mode) |
-| Test FE | Vitest + Testing Library |
+| Test FE | Vitest + Testing Library; Playwright (2 smoke E2E Chromium) |
 | Test BE | tokio-test, wiremock |
 
 ---
@@ -26,6 +26,14 @@ devUrl Tauri (`src-tauri/tauri.conf.json`) e porta Vite (`package.json` → `dev
 - Override: `GLOSSA_DEV_PORT=9999 npm run tauri:dev` (PowerShell: `$env:GLOSSA_DEV_PORT=9999; npm run tauri:dev`) — variabile letta sia da Vite (`scripts/dev.mjs`) sia da Tauri (`scripts/tauri-dev.mjs`, inietta stesso valore in `devUrl` via `tauri dev --config`)
 - Script Node (`scripts/dev.mjs`/`scripts/tauri-dev.mjs`), non bash: npm su Windows esegue gli script tramite cmd.exe, che non capisce `${VAR:-default}` né richiede bash disponibile
 - Meccanismo esiste solo in sviluppo: build produzione (`npm run tauri:build`) carica `frontendDist` diretto, no dev server né porta coinvolti
+
+---
+
+## Strategia test
+
+- `npm test` resta la copertura capillare e veloce della logica e dei componenti.
+- `npm run test:e2e` esegue solo due smoke test Chromium: primo avvio/creazione workspace e creazione/apertura progetto. Il bridge locale viene simulato, quindi non avvia provider, import o export reali.
+- La CI esegue gli smoke test su ogni PR e conserva tracce e schermate soltanto quando falliscono. Non serve ripetere l'intera suite manualmente dopo l'apertura della PR.
 
 ---
 

--- a/e2e/support/tauriMock.js
+++ b/e2e/support/tauriMock.js
@@ -1,0 +1,178 @@
+(() => {
+  const state = {
+    settings: {},
+    workspaces: [],
+    projects: [],
+    pipelines: [],
+  };
+
+  const timestamp = '2026-01-01T00:00:00.000Z';
+  const normalize = (query) => query.replace(/\s+/g, ' ').trim().toUpperCase();
+
+  const workspaceRow = (workspace) => ({
+    id: workspace.id,
+    name: workspace.name,
+    description: workspace.description ?? null,
+    embedding_model: workspace.embeddingModel,
+    memory_extractor_provider: workspace.memoryExtractorProvider,
+    memory_extractor_model: workspace.memoryExtractorModel,
+    memory_extractor_prompt: workspace.memoryExtractorPrompt,
+    created_at: workspace.createdAt,
+  });
+
+  const projectRow = (project) => ({
+    id: project.id,
+    name: project.name,
+    workspace_id: project.workspaceId,
+    source_language: project.sourceLanguage,
+    target_language: project.targetLanguage,
+    source_display_text: project.sourceDisplayText,
+    source_processing_text: project.sourceProcessingText,
+    source_footnotes: '[]',
+    document_format: 'plain',
+    render_profile: 'plain-text',
+    markdown_aware: 0,
+    experimental_import: null,
+    created_at: project.createdAt,
+    updated_at: project.updatedAt,
+    pipeline_count: state.pipelines.filter((pipeline) => pipeline.projectId === project.id).length,
+    pipeline_names: 'Default',
+  });
+
+  const pipelineRow = (pipeline) => ({
+    id: pipeline.id,
+    project_id: pipeline.projectId,
+    name: 'Default',
+    source_language: pipeline.sourceLanguage,
+    target_language: pipeline.targetLanguage,
+    pipeline_mode: 'standard',
+    stages: '[]',
+    judge_prompt: '',
+    judge_model: '',
+    judge_provider: '',
+    use_chunking: 1,
+    words_per_chunk: 0,
+    source_display_text: null,
+    source_processing_text: null,
+    source_footnotes: '[]',
+    review_provider_options: null,
+    persona: null,
+    custom_source_language: null,
+    custom_target_language: null,
+    blob_budget_tokens: null,
+    blob_overlap: null,
+    coherence_prompt: null,
+    few_shot_examples: '[]',
+    use_phrase_memory: 0,
+    auto_search_phrase_memory: null,
+    phrase_memory_similarity_threshold: null,
+    phrase_memory_max_results: null,
+    run_status: 'idle',
+    last_run_config: null,
+    created_at: timestamp,
+    updated_at: timestamp,
+  });
+
+  const select = (query, values = []) => {
+    const sql = normalize(query);
+
+    if (sql.includes('FROM SQLITE_MASTER')) return [{ count: 0 }];
+    if (sql.startsWith('PRAGMA')) return [];
+    if (sql.includes('FROM APP_SETTINGS WHERE KEY = $1')) {
+      const value = state.settings[values[0]];
+      return value === undefined ? [] : [{ value }];
+    }
+    if (sql.includes('FROM WORKSPACES')) return state.workspaces.map(workspaceRow);
+    if (sql.includes('FROM PROJECTS WHERE ID = $1')) {
+      const project = state.projects.find((candidate) => candidate.id === values[0]);
+      return project ? [projectRow(project)] : [];
+    }
+    if (sql.includes('FROM PROJECTS P')) {
+      const projects = sql.includes('WHERE P.WORKSPACE_ID = $1')
+        ? state.projects.filter((project) => project.workspaceId === values[0])
+        : state.projects;
+      return projects.map(projectRow);
+    }
+    if (sql.includes('FROM PIPELINES WHERE PROJECT_ID = $1')) {
+      return state.pipelines
+        .filter((pipeline) => pipeline.projectId === values[0])
+        .map(pipelineRow);
+    }
+    if (sql.includes('FROM PIPELINES WHERE ID = $1')) {
+      const pipeline = state.pipelines.find((candidate) => candidate.id === values[0]);
+      return pipeline ? [pipelineRow(pipeline)] : [];
+    }
+    if (sql.includes('COUNT(*)')) return [{ count: 0, total: 0, completed: 0 }];
+    return [];
+  };
+
+  const applyStatement = ({ query, params = [] }) => {
+    const sql = normalize(query);
+
+    if (sql.startsWith('INSERT INTO WORKSPACES')) {
+      state.workspaces.push({
+        id: params[0],
+        name: params[1],
+        description: params[2] ?? undefined,
+        embeddingModel: params[3],
+        memoryExtractorProvider: params[4],
+        memoryExtractorModel: params[5],
+        memoryExtractorPrompt: params[6],
+        createdAt: params[7],
+      });
+      return;
+    }
+    if (sql.startsWith('INSERT INTO PROJECTS')) {
+      state.projects.push({
+        id: params[0],
+        name: params[1],
+        sourceLanguage: params[2],
+        targetLanguage: params[3],
+        workspaceId: params[4],
+        sourceDisplayText: '',
+        sourceProcessingText: '',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return;
+    }
+    if (sql.startsWith('INSERT INTO PIPELINES')) {
+      state.pipelines.push({
+        id: params[0],
+        projectId: params[1],
+        sourceLanguage: params[2],
+        targetLanguage: params[3],
+      });
+      return;
+    }
+    if (sql.startsWith('INSERT INTO APP_SETTINGS')) {
+      state.settings[params[0]] = params[1];
+      return;
+    }
+    if (sql.startsWith('UPDATE PROJECTS SET SOURCE_DISPLAY_TEXT')) {
+      const project = state.projects.find((candidate) => candidate.id === params[9]);
+      if (project) {
+        project.sourceDisplayText = params[0];
+        project.sourceProcessingText = params[1];
+        project.updatedAt = timestamp;
+      }
+    }
+  };
+
+  window.__TAURI_INTERNALS__ = {
+    transformCallback: () => 1,
+    unregisterCallback: () => {},
+    invoke: async (command, args = {}) => {
+      if (command === 'plugin:sql|load') return args.db;
+      if (command === 'plugin:sql|select') return select(args.query, args.values);
+      if (command === 'plugin:sql|execute') return [0, 0];
+      if (command === 'execute_transaction') {
+        args.statements.forEach(applyStatement);
+        return null;
+      }
+      if (command === 'get_api_key_status') return false;
+      if (command.startsWith('plugin:log|')) throw new Error('Logging is unavailable in browser smoke tests');
+      return null;
+    },
+  };
+})();

--- a/e2e/workspace.spec.ts
+++ b/e2e/workspace.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test, type Page } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+const tauriMockPath = fileURLToPath(new URL('./support/tauriMock.js', import.meta.url));
+
+async function openFirstRun(page: Page): Promise<void> {
+  await page.addInitScript({ path: tauriMockPath });
+  await page.addInitScript(() => window.localStorage.setItem('glossa-lang', 'it'));
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Crea il tuo primo workspace' })).toBeVisible();
+}
+
+async function createWorkspace(page: Page): Promise<void> {
+  await page.getByRole('textbox', { name: 'Nome workspace' }).fill('Archivio E2E');
+  await page.getByRole('button', { name: 'Crea workspace' }).click();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+}
+
+test('avvia l’app e crea il primo workspace', async ({ page }) => {
+  await openFirstRun(page);
+  await createWorkspace(page);
+
+  await expect(page.getByRole('button', { name: 'Archivio E2E' })).toBeVisible();
+});
+
+test('crea un progetto e apre la sua schermata di importazione', async ({ page }) => {
+  await openFirstRun(page);
+  await createWorkspace(page);
+
+  await page.getByRole('button', { name: 'Archivio E2E' }).click();
+  await expect(page.getByRole('heading', { name: 'Archivio E2E' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Nuovo libro' }).click();
+  await page.getByPlaceholder('Nome del progetto...').fill('Manoscritto E2E');
+  await page.getByRole('button', { name: 'Crea', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: 'Manoscritto E2E' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Importa documento' })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
+        "@playwright/test": "^1.61.1",
         "@tauri-apps/cli": "^2.10.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1649,6 +1650,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -8769,6 +8786,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:all": "npm run typecheck && npm run lint",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",
     "tauri:dev:linux": "node scripts/tauri-dev.mjs",
@@ -59,11 +60,12 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.5",
+    "@playwright/test": "^1.61.1",
     "@tauri-apps/cli": "^2.10.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@eslint/js": "^9.39.5",
     "@types/node": "^22.14.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCi = Boolean(process.env.CI);
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: isCi,
+  retries: isCi ? 1 : 0,
+  workers: 1,
+  reporter: isCi ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npx vite --host 127.0.0.1 --port 4173 --strictPort',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !isCi,
+    timeout: 120_000,
+  },
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1902,7 +1902,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glossa"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "async-trait",


### PR DESCRIPTION
## Cosa cambia

- aggiunge due smoke test nel browser: primo avvio con creazione workspace e creazione/apertura di un progetto;
- collega i controlli automatici a tutte le PR, anche quando una PR nasce sopra un ramo già in revisione;
- conserva schermate e tracce solo quando un controllo browser fallisce.

## Perché

I percorsi principali dell’interfaccia non avevano ancora una protezione che li attraversasse dall’inizio alla fine. I controlli restano volutamente pochi e rapidi: non avviano provider, import o export reali, già coperti da test mirati.

## Verifiche

- `npm run test:e2e` — 2 smoke test superati
- `npm run typecheck` — superato
- `npm run lint` — nessun errore; 10 avvisi preesistenti in test non toccati

Closes #341