### PR TITLE
fix(security): limit document imports to user-selected files

### DIFF
--- a/src-tauri/src/documents/mod.rs
+++ b/src-tauri/src/documents/mod.rs
@@ -5,7 +5,7 @@ use tauri::Manager;
 const MAX_DOCX_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
 
-fn check_file_size(path: &str, limit: u64) -> Result<(), String> {
+fn check_file_size(path: &std::path::Path, limit: u64) -> Result<(), String> {
     let size = fs::metadata(path)
         .map_err(|e| format!("Failed to read file metadata: {e}"))?
         .len();
@@ -23,14 +23,9 @@ fn is_within_allowed_roots(canonical: &std::path::Path, allowed_roots: &[PathBuf
     allowed_roots.iter().any(|root| canonical.starts_with(root))
 }
 
-/// Restricts document imports to the same directories granted to the frontend
-/// file-selection dialog (see `capabilities/default.json`), so a compromised
-/// webview cannot use these commands to read arbitrary files (e.g. `/etc/passwd`,
-/// SSH keys) via a raw `fs::read` that bypasses the Tauri fs-plugin scope.
-fn validate_document_path(app: &tauri::AppHandle, path: &str) -> Result<PathBuf, String> {
-    let canonical = fs::canonicalize(path).map_err(|e| format!("Failed to read file: {e}"))?;
+fn resolve_allowed_roots(app: &tauri::AppHandle) -> Vec<PathBuf> {
     let resolver = app.path();
-    let allowed_roots: Vec<PathBuf> = [
+    [
         resolver.document_dir(),
         resolver.download_dir(),
         resolver.desktop_dir(),
@@ -41,13 +36,27 @@ fn validate_document_path(app: &tauri::AppHandle, path: &str) -> Result<PathBuf,
     .into_iter()
     .filter_map(Result::ok)
     .filter_map(|dir| fs::canonicalize(&dir).ok())
-    .collect();
+    .collect()
+}
 
-    if is_within_allowed_roots(&canonical, &allowed_roots) {
+/// Canonicalizes `path` and checks it against `allowed_roots`, rejecting
+/// anything outside them (and any path that doesn't resolve, e.g. via a
+/// symlink to a missing target) before it is ever read from disk.
+fn validate_path_against_roots(path: &str, allowed_roots: &[PathBuf]) -> Result<PathBuf, String> {
+    let canonical = fs::canonicalize(path).map_err(|e| format!("Failed to read file: {e}"))?;
+    if is_within_allowed_roots(&canonical, allowed_roots) {
         Ok(canonical)
     } else {
         Err("File location not permitted".to_string())
     }
+}
+
+/// Restricts document imports to the same directories granted to the frontend
+/// file-selection dialog (see `capabilities/default.json`), so a compromised
+/// webview cannot use these commands to read arbitrary files (e.g. `/etc/passwd`,
+/// SSH keys) via a raw `fs::read` that bypasses the Tauri fs-plugin scope.
+fn validate_document_path(app: &tauri::AppHandle, path: &str) -> Result<PathBuf, String> {
+    validate_path_against_roots(path, &resolve_allowed_roots(app))
 }
 
 pub mod docx_export;
@@ -67,7 +76,7 @@ pub(crate) use pdf_extract::normalize_pdf_text;
 #[tauri::command]
 pub async fn extract_docx_text(app: tauri::AppHandle, path: String) -> Result<String, String> {
     let canonical = validate_document_path(&app, &path)?;
-    check_file_size(&path, MAX_DOCX_BYTES)?;
+    check_file_size(&canonical, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_text_from_bytes(&bytes)
@@ -79,7 +88,7 @@ pub async fn extract_docx_text(app: tauri::AppHandle, path: String) -> Result<St
 #[tauri::command]
 pub async fn extract_docx_markdown(app: tauri::AppHandle, path: String) -> Result<String, String> {
     let canonical = validate_document_path(&app, &path)?;
-    check_file_size(&path, MAX_DOCX_BYTES)?;
+    check_file_size(&canonical, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_markdown_from_bytes(&bytes)
@@ -91,7 +100,7 @@ pub async fn extract_docx_markdown(app: tauri::AppHandle, path: String) -> Resul
 #[tauri::command]
 pub async fn extract_pdf_text(app: tauri::AppHandle, path: String) -> Result<String, String> {
     let canonical = validate_document_path(&app, &path)?;
-    check_file_size(&path, MAX_PDF_BYTES)?;
+    check_file_size(&canonical, MAX_PDF_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
         let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_pdf_text_from_bytes(&bytes)
@@ -149,7 +158,7 @@ mod tests {
     fn check_file_size_accepts_file_within_limit() {
         let path = std::env::temp_dir().join("glossa_test_size_ok.bin");
         std::fs::write(&path, b"small content").unwrap();
-        assert!(check_file_size(path.to_str().unwrap(), MAX_DOCX_BYTES).is_ok());
+        assert!(check_file_size(&path, MAX_DOCX_BYTES).is_ok());
         let _ = std::fs::remove_file(&path);
     }
 
@@ -157,7 +166,7 @@ mod tests {
     fn check_file_size_rejects_file_over_limit() {
         let path = std::env::temp_dir().join("glossa_test_size_over.bin");
         std::fs::write(&path, b"data").unwrap();
-        let result = check_file_size(path.to_str().unwrap(), 1);
+        let result = check_file_size(&path, 1);
         let _ = std::fs::remove_file(&path);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("File too large"));
@@ -165,7 +174,10 @@ mod tests {
 
     #[test]
     fn check_file_size_rejects_missing_file() {
-        let result = check_file_size("/nonexistent_glossa_test_path_xyz.docx", MAX_DOCX_BYTES);
+        let result = check_file_size(
+            std::path::Path::new("/nonexistent_glossa_test_path_xyz.docx"),
+            MAX_DOCX_BYTES,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to read file metadata"));
     }
@@ -198,6 +210,43 @@ mod tests {
     fn is_within_allowed_roots_rejects_when_no_roots_resolved() {
         let file = std::env::temp_dir().join("glossa_test.docx");
         assert!(!is_within_allowed_roots(&file, &[]));
+    }
+
+    #[test]
+    fn validate_path_against_roots_accepts_real_file_inside_allowed_root() {
+        let root = std::env::temp_dir();
+        let file = root.join("glossa_test_validate_ok.docx");
+        std::fs::write(&file, b"content").unwrap();
+
+        let result = validate_path_against_roots(file.to_str().unwrap(), &[root]);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), std::fs::canonicalize(&file).unwrap());
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn validate_path_against_roots_rejects_real_file_outside_allowed_roots() {
+        let allowed_root = std::env::temp_dir().join("glossa_allowed_only");
+        let file = std::env::temp_dir().join("glossa_test_validate_reject.docx");
+        std::fs::write(&file, b"content").unwrap();
+
+        let result = validate_path_against_roots(file.to_str().unwrap(), &[allowed_root]);
+
+        let _ = std::fs::remove_file(&file);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "File location not permitted");
+    }
+
+    #[test]
+    fn validate_path_against_roots_rejects_missing_file() {
+        let root = std::env::temp_dir();
+        let result = validate_path_against_roots(
+            root.join("glossa_does_not_exist.docx").to_str().unwrap(),
+            &[root],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read file"));
     }
 
     #[test]

--- a/src-tauri/src/documents/mod.rs
+++ b/src-tauri/src/documents/mod.rs
@@ -1,4 +1,6 @@
 use std::fs;
+use std::path::PathBuf;
+use tauri::Manager;
 
 const MAX_DOCX_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_PDF_BYTES: u64 = 50 * 1024 * 1024;
@@ -17,6 +19,37 @@ fn check_file_size(path: &str, limit: u64) -> Result<(), String> {
     Ok(())
 }
 
+fn is_within_allowed_roots(canonical: &std::path::Path, allowed_roots: &[PathBuf]) -> bool {
+    allowed_roots.iter().any(|root| canonical.starts_with(root))
+}
+
+/// Restricts document imports to the same directories granted to the frontend
+/// file-selection dialog (see `capabilities/default.json`), so a compromised
+/// webview cannot use these commands to read arbitrary files (e.g. `/etc/passwd`,
+/// SSH keys) via a raw `fs::read` that bypasses the Tauri fs-plugin scope.
+fn validate_document_path(app: &tauri::AppHandle, path: &str) -> Result<PathBuf, String> {
+    let canonical = fs::canonicalize(path).map_err(|e| format!("Failed to read file: {e}"))?;
+    let resolver = app.path();
+    let allowed_roots: Vec<PathBuf> = [
+        resolver.document_dir(),
+        resolver.download_dir(),
+        resolver.desktop_dir(),
+        resolver.app_data_dir(),
+        resolver.app_config_dir(),
+        resolver.temp_dir(),
+    ]
+    .into_iter()
+    .filter_map(Result::ok)
+    .filter_map(|dir| fs::canonicalize(&dir).ok())
+    .collect();
+
+    if is_within_allowed_roots(&canonical, &allowed_roots) {
+        Ok(canonical)
+    } else {
+        Err("File location not permitted".to_string())
+    }
+}
+
 pub mod docx_export;
 pub mod docx_extract;
 pub mod pdf_extract;
@@ -32,10 +65,11 @@ pub(crate) use docx_extract::read_docx_entry;
 pub(crate) use pdf_extract::normalize_pdf_text;
 
 #[tauri::command]
-pub async fn extract_docx_text(path: String) -> Result<String, String> {
+pub async fn extract_docx_text(app: tauri::AppHandle, path: String) -> Result<String, String> {
+    let canonical = validate_document_path(&app, &path)?;
     check_file_size(&path, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
-        let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+        let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_text_from_bytes(&bytes)
     })
     .await
@@ -43,10 +77,11 @@ pub async fn extract_docx_text(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn extract_docx_markdown(path: String) -> Result<String, String> {
+pub async fn extract_docx_markdown(app: tauri::AppHandle, path: String) -> Result<String, String> {
+    let canonical = validate_document_path(&app, &path)?;
     check_file_size(&path, MAX_DOCX_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
-        let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+        let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_docx_markdown_from_bytes(&bytes)
     })
     .await
@@ -54,10 +89,11 @@ pub async fn extract_docx_markdown(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn extract_pdf_text(path: String) -> Result<String, String> {
+pub async fn extract_pdf_text(app: tauri::AppHandle, path: String) -> Result<String, String> {
+    let canonical = validate_document_path(&app, &path)?;
     check_file_size(&path, MAX_PDF_BYTES)?;
     tauri::async_runtime::spawn_blocking(move || {
-        let bytes = fs::read(&path).map_err(|e| format!("Failed to read file: {}", e))?;
+        let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read file: {}", e))?;
         extract_pdf_text_from_bytes(&bytes)
     })
     .await
@@ -142,6 +178,26 @@ mod tests {
     #[test]
     fn pdf_limit_is_50mb() {
         assert_eq!(MAX_PDF_BYTES, 50 * 1024 * 1024);
+    }
+
+    #[test]
+    fn is_within_allowed_roots_accepts_path_inside_root() {
+        let root = std::env::temp_dir();
+        let file = root.join("glossa_test_inside.docx");
+        assert!(is_within_allowed_roots(&file, &[root]));
+    }
+
+    #[test]
+    fn is_within_allowed_roots_rejects_path_outside_roots() {
+        let root = std::env::temp_dir().join("glossa_allowed_subdir");
+        let outside = std::path::PathBuf::from("/etc/passwd");
+        assert!(!is_within_allowed_roots(&outside, &[root]));
+    }
+
+    #[test]
+    fn is_within_allowed_roots_rejects_when_no_roots_resolved() {
+        let file = std::env::temp_dir().join("glossa_test.docx");
+        assert!(!is_within_allowed_roots(&file, &[]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `extract_docx_text`/`extract_docx_markdown`/`extract_pdf_text` read the given path via a raw `fs::read`, bypassing the Tauri fs-plugin scope that already restricts `readTextFile` to common user directories (`$DOCUMENT`, `$DOWNLOAD`, `$DESKTOP`, `$APPDATA`, `$APPCONFIG`, `$TEMP`).
- A compromised webview (e.g. XSS) could `invoke()` these commands directly with an arbitrary path and exfiltrate any readable file.
- Added `validate_document_path` — canonicalizes the path and rejects anything outside the same allowed directories, consistent with the existing capability scope.

Closes #356

## Test plan
- [x] `cargo test documents::` — 23 passed (added 3 tests for the new path-scope check)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: import a docx/pdf from Documents/Downloads (should work), verify a crafted `invoke('extract_pdf_text', {path: '/etc/passwd'})` from devtools console is rejected

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>