### PR TITLE
fix(security): tighten production content security policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Verify release CSP has no unsafe-eval
+      - name: Verify release CSP has no unsafe-eval or unsafe-inline scripts
         run: |
           if grep -q "unsafe-eval" src-tauri/tauri.release.conf.json; then
             echo "ERROR: 'unsafe-eval' found in tauri.release.conf.json — remove it before merging"
             exit 1
           fi
-          echo "CSP check passed: no unsafe-eval in release config"
+          if grep -oP "script-src[^;]*" src-tauri/tauri.release.conf.json | grep -q "unsafe-inline"; then
+            echo "ERROR: 'unsafe-inline' found in script-src of tauri.release.conf.json — remove it before merging"
+            exit 1
+          fi
+          echo "CSP check passed: no unsafe-eval, no unsafe-inline script-src in release config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,12 @@ jobs:
             echo "ERROR: 'unsafe-eval' found in tauri.release.conf.json — remove it before merging"
             exit 1
           fi
-          if grep -oP "script-src[^;]*" src-tauri/tauri.release.conf.json | grep -q "unsafe-inline"; then
+          script_src=$(grep -oE "script-src[^;]*" src-tauri/tauri.release.conf.json)
+          if [ -z "$script_src" ]; then
+            echo "ERROR: 'script-src' directive not found in tauri.release.conf.json — cannot verify it's safe"
+            exit 1
+          fi
+          if echo "$script_src" | grep -q "unsafe-inline"; then
             echo "ERROR: 'unsafe-inline' found in script-src of tauri.release.conf.json — remove it before merging"
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",
     "tauri:dev:linux": "node scripts/tauri-dev.mjs",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build --config src-tauri/tauri.release.conf.json"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.17",


### PR DESCRIPTION
## Summary
- `tauri.release.conf.json` already had `script-src 'self'` with no `unsafe-eval`/`unsafe-inline`, but the local `npm run tauri:build` script never passed `--config` to use it — only the GitHub Actions release workflow did. A locally-built package still shipped the dev CSP (needed for Vite HMR).
- Fixed `tauri:build` to always use the release config.
- Extended the existing CI guard (`security-checks` job) to also fail if `unsafe-inline` reappears in `script-src` specifically — `style-src` keeps `unsafe-inline` since Framer Motion injects `<style>` tags at runtime (verified no CSS-in-JS/Tailwind runtime injection needs it beyond that).

Closes #357

## Test plan
- [x] `grep -oP "script-src[^;]*"` on release config confirms no `unsafe-inline`/`unsafe-eval`
- [ ] Run `npm run tauri:build` locally and confirm the packaged app's CSP matches `tauri.release.conf.json`
- [ ] CI `security-checks` job still passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>