### PR TITLE
fix(security): require HTTPS for custom provider endpoints

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 1.0.69",
  "tokio",
+ "url",
  "wiremock",
  "zip",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-log = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-updater = "2"
 reqwest = { version = "0.12", features = ["json"] }
+url = "2"
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/src/llm/custom_profiles.rs
+++ b/src-tauri/src/llm/custom_profiles.rs
@@ -27,7 +27,7 @@ fn validate_base_url(base_url: &str) -> Result<(), String> {
             if is_loopback_host(&host) {
                 Ok(())
             } else {
-                Err("Non-local HTTP endpoints are not allowed — use HTTPS, or point to a loopback address (localhost/127.0.0.1) for local providers".to_string())
+                Err("Non-local HTTP endpoints are not allowed — use HTTPS, or point to a loopback address (localhost/127.0.0.1/::1) for local providers".to_string())
             }
         }
         other => Err(format!("Unsupported provider URL scheme: {other}")),

--- a/src-tauri/src/llm/custom_profiles.rs
+++ b/src-tauri/src/llm/custom_profiles.rs
@@ -1,7 +1,38 @@
 use rusqlite::{params, Connection};
 use tauri::Manager;
+use url::Url;
 
 use crate::llm::provider::LlmProvider;
+
+fn is_loopback_host(host: &url::Host<&str>) -> bool {
+    match host {
+        url::Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        url::Host::Ipv4(ip) => ip.is_loopback(),
+        url::Host::Ipv6(ip) => ip.is_loopback(),
+    }
+}
+
+/// Rejects custom endpoints that would send credentials over an unencrypted
+/// connection to anything other than the local machine (e.g. a self-hosted
+/// Ollama instance on 127.0.0.1). A plain-HTTP endpoint reachable over the
+/// network could leak the API key to anyone able to observe the traffic.
+fn validate_base_url(base_url: &str) -> Result<(), String> {
+    let parsed = Url::parse(base_url).map_err(|e| format!("Invalid provider URL: {e}"))?;
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" => {
+            let host = parsed
+                .host()
+                .ok_or_else(|| "Provider URL is missing a host".to_string())?;
+            if is_loopback_host(&host) {
+                Ok(())
+            } else {
+                Err("Non-local HTTP endpoints are not allowed — use HTTPS, or point to a loopback address (localhost/127.0.0.1) for local providers".to_string())
+            }
+        }
+        other => Err(format!("Unsupported provider URL scheme: {other}")),
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -47,19 +78,22 @@ fn verify_schema(conn: &Connection) -> Result<(), String> {
 
 pub fn get_profile(app: &tauri::AppHandle, id: &str) -> Result<CustomProviderProfile, String> {
     let conn = open_db(app)?;
-    conn.query_row(
-        "SELECT id, name, base_url, requires_api_key FROM custom_providers WHERE id = ?1",
-        params![id],
-        |row| {
-            Ok(CustomProviderProfile {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                base_url: row.get(2)?,
-                requires_api_key: row.get::<_, i64>(3)? != 0,
-            })
-        },
-    )
-    .map_err(|e| format!("Profile not found ({id}): {e}"))
+    let profile = conn
+        .query_row(
+            "SELECT id, name, base_url, requires_api_key FROM custom_providers WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(CustomProviderProfile {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    base_url: row.get(2)?,
+                    requires_api_key: row.get::<_, i64>(3)? != 0,
+                })
+            },
+        )
+        .map_err(|e| format!("Profile not found ({id}): {e}"))?;
+    validate_base_url(&profile.base_url)?;
+    Ok(profile)
 }
 
 #[tauri::command]
@@ -97,6 +131,7 @@ pub async fn save_custom_provider_profile(
     api_key: Option<String>,
     requires_api_key: bool,
 ) -> Result<(), String> {
+    validate_base_url(&base_url)?;
     let _write_guard = write_coordinator.lock().await;
     let conn = open_db(&app)?;
     conn.execute(
@@ -171,5 +206,56 @@ pub async fn test_custom_provider_connection(
     match provider.call(&client, &req).await {
         Ok(_) => Ok(true),
         Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_https_endpoint() {
+        assert!(validate_base_url("https://api.example.com/v1").is_ok());
+    }
+
+    #[test]
+    fn accepts_http_localhost() {
+        assert!(validate_base_url("http://localhost:11434/v1").is_ok());
+    }
+
+    #[test]
+    fn accepts_http_loopback_ipv4() {
+        assert!(validate_base_url("http://127.0.0.1:11434/v1").is_ok());
+    }
+
+    #[test]
+    fn accepts_http_loopback_ipv6() {
+        assert!(validate_base_url("http://[::1]:11434/v1").is_ok());
+    }
+
+    #[test]
+    fn rejects_http_public_host() {
+        let result = validate_base_url("http://api.example.com/v1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Non-local HTTP"));
+    }
+
+    #[test]
+    fn rejects_http_public_ip() {
+        assert!(validate_base_url("http://93.184.216.34/v1").is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_scheme() {
+        let result = validate_base_url("ftp://example.com/v1");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Unsupported provider URL scheme"));
+    }
+
+    #[test]
+    fn rejects_malformed_url() {
+        assert!(validate_base_url("not a url").is_err());
     }
 }


### PR DESCRIPTION
## Summary
`save_custom_provider_profile` stored `base_url` with no validation, and the API key is sent as a plain `Authorization` header on every request. A non-local `http://` endpoint would leak the key to anyone able to observe the traffic.

## Fix
- Added `validate_base_url`: accepts `https://` unconditionally, accepts `http://` only for loopback hosts (`localhost`, `127.0.0.1`, `::1`) — covers self-hosted providers like a local Ollama instance — and rejects anything else with a clear message.
- Called on `save_custom_provider_profile` (primary gate) and on `get_profile` (defense in depth, so profiles saved by an older build before this fix still get caught before a request goes out).
- Added `url` as an explicit dependency (was already present transitively via `reqwest`) for robust scheme/host parsing instead of hand-rolled string checks.

Closes #359

## Test plan
- [x] New unit tests: accepts https, accepts http+localhost/127.0.0.1/::1, rejects http+public host/IP, rejects unsupported scheme, rejects malformed URL
- [x] `cargo test` — 170 passed; `cargo clippy -- -D warnings` — clean
- [ ] Manual: try saving a custom provider with `http://example.com` in Settings → should show the save-failed toast with the new message

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>