### PR TITLE
feat: indicatori chunk e navigazione

### DIFF
--- a/docs/en/guides/projects-and-workspace.md
+++ b/docs/en/guides/projects-and-workspace.md
@@ -29,6 +29,12 @@ Glossa separates application settings, workspace resources, and per-project pipe
 5. Import a document and run test chunks.
 6. Save as you iterate.
 
+## Compact navigation
+
+You can collapse the side rail to leave more room for the content. Inside a project, the previous/next chunk controls and the translation action remain available; the technical chunk number no longer occupies space in the rail. On the collapsed Dashboard, Dashboard and every area remain visible: areas that are not available yet are visible but cannot be selected; reopen the rail to see the workspace list.
+
+At the top, the Glossa mark opens the rail on hover. The closed rail therefore remains recognisable without permanently showing another command.
+
 ## Shared versus local resources
 
 | Resource | Scope |

--- a/docs/guides/projects-and-workspace.md
+++ b/docs/guides/projects-and-workspace.md
@@ -29,6 +29,12 @@ Glossa separa impostazioni applicative, risorse del workspace e configurazione d
 5. Importa un documento ed esegui i chunk di test.
 6. Salva mentre iteri.
 
+## Navigazione compatta
+
+La barra laterale si può richiudere per lasciare più spazio al contenuto. Nel progetto restano disponibili le frecce per passare al frammento precedente o successivo e il comando di traduzione; il numero tecnico del frammento non occupa più spazio nella barra. Nella Dashboard chiusa restano Dashboard e tutte le aree: quelle non ancora disponibili sono visibili ma non selezionabili; l'elenco dei workspace torna visibile riaprendo la barra.
+
+In alto, il marchio Glossa apre la barra al passaggio del mouse: così la barra chiusa resta riconoscibile ma non aggiunge un comando visibile in permanenza.
+
 ## Risorse condivise e locali
 
 | Risorsa | Ambito |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4047,16 +4047,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -8492,9 +8492,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8847,9 +8847,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8866,7 +8866,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10165,9 +10165,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/document/DocumentView.tsx
+++ b/src/components/document/DocumentView.tsx
@@ -51,11 +51,16 @@ const STAGE_TONE_MAP: Record<string, IconButtonTone> = {
 
 function buildChunkMinimapLabel(
   t: (key: string, options?: Record<string, unknown>) => string,
-  chunk: { status: string; translationLocked?: boolean },
+  chunk: {
+    status: string;
+    translationLocked?: boolean;
+    translationStale?: boolean;
+  },
   index: number,
   total: number,
   isCurrent: boolean,
   annotationCount: number,
+  unresolvedIssueCount: number,
 ): string {
   const parts = [
     `${t('document.chunkLabel')} ${index + 1}/${total}`,
@@ -63,6 +68,8 @@ function buildChunkMinimapLabel(
   ];
   if (chunk.translationLocked) parts.push(t('document.translationLockedBadge'));
   if (annotationCount > 0) parts.push(t('annotations.badgeCount', { count: annotationCount }));
+  if (unresolvedIssueCount > 0) parts.push(t('audit.issuesCount', { count: unresolvedIssueCount }));
+  if (chunk.translationStale) parts.push(t('document.translationStaleBadge'));
   if (isCurrent) parts.push(t('document.currentChunkBadge'));
   return parts.join(' · ');
 }
@@ -340,16 +347,19 @@ export function DocumentView({
   const chunkMinimapDots =
     chunks.length > 1
       ? chunks.map((chunk, idx) => {
-          const segmentTone =
+          const statusDotClass =
             chunk.status === 'completed'
-              ? 'bg-editorial-success/18 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-success)_16%,transparent)]'
+              ? 'h-1.5 w-1.5 rounded-full bg-editorial-success'
               : chunk.status === 'error'
-                ? 'bg-editorial-danger/18 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-danger)_18%,transparent)]'
+                ? 'h-2 w-2 rounded-[2px] bg-editorial-danger'
                 : chunk.status === 'processing'
-                  ? 'bg-editorial-running/24 animate-pulse shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-editorial-running)_22%,transparent)]'
-                  : 'bg-editorial-border/40';
+                  ? 'h-1 w-2.5 rounded-full bg-editorial-running animate-pulse'
+                  : 'h-2.5 w-2.5 rounded-full border border-editorial-border bg-transparent';
           const isCurrent = idx === currentIndex;
           const chunkAnnotations = annotationsByChunkId.get(chunk.id) ?? [];
+          const unresolvedIssueCount = chunk.judgeResult.status === 'completed'
+            ? chunk.judgeResult.issues.filter((issue) => !issue.resolved && !issue.rejected).length
+            : 0;
           const annotDotColor = chunkAnnotations.some((a) => a.type === 'problem')
             ? 'bg-editorial-danger'
             : chunkAnnotations.some((a) => a.type === 'doubt')
@@ -357,7 +367,15 @@ export function DocumentView({
               : chunkAnnotations.length > 0
                 ? 'bg-editorial-charcoal/70'
                 : null;
-          const buttonLabel = buildChunkMinimapLabel(t, chunk, idx, chunks.length, isCurrent, chunkAnnotations.length);
+          const buttonLabel = buildChunkMinimapLabel(
+            t,
+            chunk,
+            idx,
+            chunks.length,
+            isCurrent,
+            chunkAnnotations.length,
+            unresolvedIssueCount,
+          );
           return (
             <Tooltip key={chunk.id} label={buttonLabel}>
               <button
@@ -366,18 +384,21 @@ export function DocumentView({
                 onClick={() => setSelectedChunkId(chunk.id)}
                 aria-label={buttonLabel}
                 aria-current={isCurrent ? 'true' : undefined}
-                className={`relative h-4 w-4 shrink-0 rounded-full transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent ${segmentTone} hover:-translate-y-px`}
+                className="relative grid h-8 w-8 shrink-0 place-items-center rounded-lg transition-transform duration-150 ease-out hover:-translate-y-px focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent"
               >
-                {chunk.translationLocked ? (
-                  <span className="absolute left-1/2 top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-editorial-success" />
-                ) : null}
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-editorial-border bg-surface-elevated">
+                  <span aria-hidden="true" className={statusDotClass} />
+                </span>
+                {unresolvedIssueCount > 0 && <span aria-hidden="true" className="absolute left-1 top-1 h-2 w-2 rounded-full bg-editorial-danger ring-1 ring-editorial-page" />}
                 {annotDotColor && (
-                  <span className={`absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ${annotDotColor} ring-1 ring-editorial-bg`} />
+                  <span aria-hidden="true" className={`absolute right-1 top-1 h-2 w-2 rounded-full ${annotDotColor} ring-1 ring-editorial-page`} />
                 )}
+                {chunk.translationLocked && <span aria-hidden="true" className="absolute bottom-1 left-1 h-2 w-2 rounded-full bg-editorial-success ring-1 ring-editorial-page" />}
+                {chunk.translationStale && <span aria-hidden="true" className="absolute bottom-1 right-1 h-2 w-2 rounded-full bg-editorial-running ring-1 ring-editorial-page" />}
                 {isCurrent && (
                   <span
                     aria-hidden="true"
-                    className="absolute -bottom-2 left-1/2 h-0 w-0 -translate-x-1/2 border-x-[3.5px] border-b-[4.5px] border-x-transparent border-b-editorial-ink"
+                    className="absolute -bottom-1.5 left-1/2 h-0 w-0 -translate-x-1/2 border-x-[3.5px] border-b-[4.5px] border-x-transparent border-b-editorial-accent"
                   />
                 )}
               </button>
@@ -444,11 +465,11 @@ export function DocumentView({
           {/* Barra di navigazione a filo (border-b, allineata alle testate dei pannelli
               laterali). Stati del chunk sopra, minimap pallini sotto; a destra token/costo
               del frammento corrente (spazio altrimenti vuoto — #296 follow-up). */}
-          <div className="w-full h-24 flex items-stretch gap-5 border-b border-editorial-border bg-editorial-page px-6 py-3">
-            <div className="flex min-w-0 flex-1 flex-col justify-center gap-2.5">
+          <div className="w-full h-28 flex items-stretch gap-5 border-b border-editorial-border bg-editorial-page px-6 py-2">
+            <div className="flex min-w-0 flex-1 flex-col justify-center gap-1.5">
               {stageStatusButtons}
               {chunkMinimapDots ? (
-                <div className="flex items-center gap-2 overflow-x-auto custom-scrollbar pt-1 pb-2.5">
+                <div className="flex items-center gap-2 overflow-x-auto overflow-y-visible custom-scrollbar py-1.5">
                   {chunkMinimapDots}
                 </div>
               ) : null}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,7 +8,6 @@ import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useChunksStore } from '../../stores/chunksStore';
 import { EASE_EDITORIAL } from './motion';
 import { ShellNavFooter } from './ShellNav';
-import glossaAppIcon from '../../assets/glossa-app-icon.png';
 import { Tooltip } from '../ui';
 
 const HelpGuide = lazy(() =>
@@ -63,15 +62,8 @@ export function Header() {
   return (
     <header className="border-b border-editorial-border bg-[linear-gradient(180deg,var(--header-bg-from)_0%,var(--header-bg-to)_100%)] px-5 py-4 md:px-8">
       <div className="flex items-center justify-between gap-4">
-        <div className="flex min-w-0 items-end gap-3">
-          <img
-            src={glossaAppIcon}
-            alt=""
-            aria-hidden="true"
-            className="mb-1.5 h-12 w-12 shrink-0 object-contain md:mb-2 md:h-14 md:w-14"
-          />
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-baseline gap-2.5">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-baseline gap-2.5">
               <span className="shrink-0 font-display text-4xl italic text-editorial-ink md:text-5xl">
                 {t('app.brand')}
               </span>
@@ -117,7 +109,6 @@ export function Header() {
                   </motion.span>
                 ) : null}
               </AnimatePresence>
-            </div>
           </div>
         </div>
 

--- a/src/components/layout/PipelineSidebarSections/PipelineSidebarRunSection.tsx
+++ b/src/components/layout/PipelineSidebarSections/PipelineSidebarRunSection.tsx
@@ -333,27 +333,6 @@ export function PipelineSidebarRunSection({
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col items-end gap-1.5">
-        <Tooltip label={t('pipeline.repeatModeLabel')} side="bottom">
-          <button
-            type="button"
-            role="switch"
-            aria-label={t('pipeline.repeatModeLabel')}
-            aria-checked={workMode === 'all'}
-            disabled={isProcessing}
-            onClick={() => setWorkMode(workMode === 'all' ? 'chunk' : 'all')}
-            className={`relative inline-flex h-8 w-14 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${
-              workMode === 'all' ? 'bg-editorial-accent' : 'bg-editorial-border'
-            }`}
-          >
-            <span
-              className={`inline-flex h-7 w-7 transform items-center justify-center rounded-full bg-white shadow-sm transition-transform ${
-                workMode === 'all' ? 'translate-x-6' : 'translate-x-0'
-              }`}
-            >
-              <Repeat size={14} className={workMode === 'all' ? 'text-editorial-accent' : 'text-editorial-muted'} />
-            </span>
-          </button>
-        </Tooltip>
         {/* Altezza fissa: sempre presente per non spostare il pulsante
             principale quando si accende/spegne il toggle sopra. */}
         <div className="flex h-7 items-center gap-1.5">
@@ -392,6 +371,27 @@ export function PipelineSidebarRunSection({
             </>
           ) : null}
         </div>
+        <Tooltip label={t('pipeline.repeatModeLabel')} side="bottom">
+          <button
+            type="button"
+            role="switch"
+            aria-label={t('pipeline.repeatModeLabel')}
+            aria-checked={workMode === 'all'}
+            disabled={isProcessing}
+            onClick={() => setWorkMode(workMode === 'all' ? 'chunk' : 'all')}
+            className={`relative inline-flex h-8 w-14 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-editorial-accent disabled:cursor-not-allowed disabled:opacity-40 ${
+              workMode === 'all' ? 'bg-editorial-accent' : 'bg-editorial-border'
+            }`}
+          >
+            <span
+              className={`inline-flex h-7 w-7 transform items-center justify-center rounded-full bg-white shadow-sm transition-transform ${
+                workMode === 'all' ? 'translate-x-6' : 'translate-x-0'
+              }`}
+            >
+              <Repeat size={14} className={workMode === 'all' ? 'text-editorial-accent' : 'text-editorial-muted'} />
+            </span>
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/layout/ShellNav.tsx
+++ b/src/components/layout/ShellNav.tsx
@@ -204,7 +204,7 @@ export function ShellNavItem({
   const labelClassName = labelFont === 'display' ? 'font-display text-sm italic' : 'font-sans text-sm';
 
   const toneClassName = active
-    ? 'bg-editorial-accent/10 text-editorial-accent'
+    ? collapsed ? 'text-editorial-accent' : 'bg-editorial-accent/10 text-editorial-accent'
     : disabled
       ? 'text-editorial-muted opacity-50'
       : 'text-editorial-muted hover:bg-editorial-textbox/30 hover:text-editorial-accent';

--- a/src/components/layout/shell-next/ProjectRailNext.tsx
+++ b/src/components/layout/shell-next/ProjectRailNext.tsx
@@ -8,7 +8,6 @@ import {
   FileOutput,
   LibraryBig,
   PanelLeftClose,
-  PanelLeftOpen,
   Plus,
   Settings2,
   Upload,
@@ -28,6 +27,7 @@ import { useConfigStore } from '../../../stores/configStore';
 import { indexPad } from '../../../utils';
 import { IconButton } from '../../ui';
 import { ChunkInspectorPanel } from '../../document/InsightsDrawer';
+import { RailBrandToggle } from './RailBrandToggle';
 
 export interface ProjectRailNextProps {
   collapsed: boolean;
@@ -54,11 +54,12 @@ function PipelineNameSlot({ children }: { children?: ReactNode }) {
     t('pipeline.pipelineNumber', { number: 1 });
 
   return (
-    <div className="border-b border-editorial-border/70 px-4 pt-4 pb-6">
-      <div className="flex items-center gap-2">
-        <span className="min-w-0 flex-1 truncate font-display text-2xl italic leading-tight text-editorial-ink">
-          {activeName}
-        </span>
+    <div className="border-b border-editorial-border/70 px-4 pt-5 pb-4">
+      <span className="block min-w-0 truncate font-display text-2xl italic leading-tight text-editorial-ink">
+        {activeName}
+      </span>
+      <div className="mt-6 flex min-w-0 items-center justify-between gap-3">
+        <ChunkRailNavigator collapsed={false} />
         {pipelines.length > 0 && (
           <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
             <Popover.Trigger asChild>
@@ -125,7 +126,7 @@ function PipelineNameSlot({ children }: { children?: ReactNode }) {
           </Popover.Root>
         )}
       </div>
-      {children ? <div className="mt-5">{children}</div> : null}
+      {children ? <div className="mt-4 border-t border-editorial-border/50 pt-4">{children}</div> : null}
     </div>
   );
 }
@@ -159,12 +160,6 @@ function ChunkRailNavigator({ collapsed }: { collapsed: boolean }) {
         >
           <ChevronUp size={14} />
         </IconButton>
-        <span className="font-display text-base italic leading-none text-editorial-ink tabular-nums">
-          {indexPad(currentIndex + 1)}
-        </span>
-        <span className="font-display text-base italic leading-none text-editorial-ink tabular-nums">
-          /{indexPad(chunks.length)}
-        </span>
         <IconButton
           size="md"
           tone="default"
@@ -319,18 +314,12 @@ export function ProjectRailNext({
   if (collapsed) {
     return (
       <div className="flex h-full min-h-0 flex-col items-center">
-        {/* Top: espandi */}
+        {/* Top: marchio; il comando di espansione appare all'hover. */}
         <div className="flex h-20 w-full shrink-0 items-center justify-center">
-          <IconButton
-            size="md"
-            tone="default"
-            onClick={() => setProjectContextCollapsed(false)}
+          <RailBrandToggle
+            onExpand={() => setProjectContextCollapsed(false)}
             title={t('sidebar.expand')}
-            tooltipSide="right"
-            className="h-9 w-9 bg-editorial-bg"
-          >
-            <PanelLeftOpen size={14} />
-          </IconButton>
+          />
         </div>
 
         {/* Contenuto: azione primaria */}
@@ -366,9 +355,8 @@ export function ProjectRailNext({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Header: navigazione frammento a sx, collassa a dx, allineato al global header */}
-      <div className="flex h-20 shrink-0 items-center gap-3 px-3">
-        <ChunkRailNavigator collapsed={false} />
+      {/* Header: solo controllo della rail; titolo e navigazione hanno fasce dedicate sotto. */}
+      <div className="flex h-20 shrink-0 items-center justify-end px-3">
         <IconButton
           size="md"
           tone="default"

--- a/src/components/layout/shell-next/RailBrandToggle.tsx
+++ b/src/components/layout/shell-next/RailBrandToggle.tsx
@@ -22,7 +22,7 @@ export function RailBrandToggle({ onExpand, title }: RailBrandToggleProps) {
         src={glossaAppIcon}
         alt=""
         aria-hidden="true"
-        className="h-6 w-6 transition-all duration-150 group-hover:scale-75 group-hover:opacity-0"
+        className="h-7 w-7 transition-all duration-150 group-hover:scale-75 group-hover:opacity-0"
       />
       <PanelLeftOpen
         size={15}

--- a/src/components/layout/shell-next/RailBrandToggle.tsx
+++ b/src/components/layout/shell-next/RailBrandToggle.tsx
@@ -1,0 +1,34 @@
+import { PanelLeftOpen } from 'lucide-react';
+import glossaAppIcon from '../../../assets/glossa-app-icon.png';
+import { IconButton } from '../../ui';
+
+interface RailBrandToggleProps {
+  onExpand: () => void;
+  title: string;
+}
+
+/** Brand mark keeps the collapsed rail quiet; its expand affordance appears on hover. */
+export function RailBrandToggle({ onExpand, title }: RailBrandToggleProps) {
+  return (
+    <IconButton
+      size="md"
+      tone="default"
+      onClick={onExpand}
+      title={title}
+      tooltipSide="right"
+      className="group relative h-9 w-9 overflow-hidden border-transparent bg-transparent hover:border-editorial-accent/40 hover:bg-editorial-textbox/45"
+    >
+      <img
+        src={glossaAppIcon}
+        alt=""
+        aria-hidden="true"
+        className="h-6 w-6 transition-all duration-150 group-hover:scale-75 group-hover:opacity-0"
+      />
+      <PanelLeftOpen
+        size={15}
+        aria-hidden="true"
+        className="absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+      />
+    </IconButton>
+  );
+}

--- a/src/components/layout/shell-next/RailBrandToggle.tsx
+++ b/src/components/layout/shell-next/RailBrandToggle.tsx
@@ -22,12 +22,12 @@ export function RailBrandToggle({ onExpand, title }: RailBrandToggleProps) {
         src={glossaAppIcon}
         alt=""
         aria-hidden="true"
-        className="h-7 w-7 transition-all duration-150 group-hover:scale-75 group-hover:opacity-0"
+        className="h-7 w-7 transition-all duration-150 group-hover:scale-75 group-hover:opacity-0 group-focus-visible:scale-75 group-focus-visible:opacity-0"
       />
       <PanelLeftOpen
         size={15}
         aria-hidden="true"
-        className="absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+        className="absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
       />
     </IconButton>
   );

--- a/src/components/layout/shell-next/ShellNext.tsx
+++ b/src/components/layout/shell-next/ShellNext.tsx
@@ -159,7 +159,11 @@ export function ShellNext({
     >
       <span
         aria-hidden="true"
-        className={`h-7 w-px rounded-full transition-colors ${
+        className="pointer-events-none absolute inset-x-0 top-0 h-28 border-b border-editorial-border bg-editorial-page"
+      />
+      <span
+        aria-hidden="true"
+        className={`relative h-7 w-px rounded-full transition-colors ${
           dragging ? 'bg-editorial-accent' : 'bg-editorial-border group-hover/sep:bg-editorial-accent/60'
         }`}
       />

--- a/src/components/layout/shell-next/WorkspaceRailNext.tsx
+++ b/src/components/layout/shell-next/WorkspaceRailNext.tsx
@@ -6,7 +6,6 @@ import {
   LayoutDashboard,
   LibraryBig,
   PanelLeftClose,
-  PanelLeftOpen,
   Plus,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -17,6 +16,7 @@ import type { Workspace } from '../../../types';
 import { IconButton } from '../../ui';
 import { CreateWorkspaceDialog } from '../../workspace/CreateWorkspaceDialog';
 import { ShellNavItem, ShellNavSection } from '../ShellNav';
+import { RailBrandToggle } from './RailBrandToggle';
 
 const AREA_ITEMS = [
   { id: 'translations', icon: BookOpenText, enabled: true },
@@ -46,8 +46,8 @@ function DashboardItem({ collapsed }: { collapsed: boolean }) {
               collapsed ? 'h-9 w-9' : 'h-7 w-7'
             } ${
               active
-                ? 'border-editorial-accent/60 bg-editorial-accent/15 text-editorial-accent'
-                : 'border-editorial-accent/35 bg-editorial-accent/5 text-editorial-accent'
+                ? 'border-editorial-accent text-editorial-accent'
+                : 'border-editorial-border bg-editorial-textbox/30 text-editorial-muted'
             }`}
           >
             <LayoutDashboard size={collapsed ? 16 : 14} />
@@ -88,7 +88,7 @@ function AreaSection({ collapsed }: { collapsed: boolean }) {
                   collapsed ? 'h-9 w-9' : 'h-6 w-6'
                 } ${
                   active
-                    ? 'border-editorial-accent/45 bg-editorial-accent/10 text-editorial-accent'
+                    ? 'border-editorial-accent text-editorial-accent'
                     : enabled
                       ? 'border-editorial-border bg-editorial-textbox/30 text-editorial-muted hover:border-editorial-accent/30 hover:text-editorial-accent'
                       : 'border-editorial-border bg-editorial-textbox/30 text-editorial-muted'
@@ -196,21 +196,11 @@ export function WorkspaceRailNext({ collapsed }: WorkspaceRailNextProps) {
     return (
       <div className="flex h-full min-h-0 flex-col items-center">
         <div className="flex h-20 w-full shrink-0 items-center justify-center">
-          <IconButton
-            size="md"
-            tone="default"
-            onClick={() => setCollapsed(false)}
-            title={t('sidebar.expand')}
-            tooltipSide="right"
-            className="h-9 w-9 bg-editorial-bg"
-          >
-            <PanelLeftOpen size={14} />
-          </IconButton>
+          <RailBrandToggle onExpand={() => setCollapsed(false)} title={t('sidebar.expand')} />
         </div>
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden custom-scrollbar pb-4">
           <DashboardItem collapsed />
           <AreaSection collapsed />
-          <WorkspaceSection collapsed />
         </div>
       </div>
     );

--- a/src/components/layout/shell-next/WorkspaceShellNext.test.tsx
+++ b/src/components/layout/shell-next/WorkspaceShellNext.test.tsx
@@ -68,15 +68,15 @@ describe('WorkspaceShellNext (#294)', () => {
     expect(useWorkspaceStore.getState().setActive).not.toHaveBeenCalled();
   });
 
-  it('keeps the workspace list reachable when the rail is collapsed', () => {
+  it('shows Dashboard and every area, but not workspaces, when the rail is collapsed', () => {
     renderShell();
 
     fireEvent.click(screen.getByRole('button', { name: 'sidebar.collapse' }));
-    fireEvent.click(screen.getByRole('button', { name: /Beta/ }));
-
-    expect(useWorkspaceStore.getState().setActive).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'ws-2' }),
-    );
+    expect(screen.queryByRole('button', { name: /Beta/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dashboard\.title/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /workspace\.areas\.translations\.title/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /workspace\.areas\.library\.title/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /workspace\.areas\.transcriptions\.title/ })).toBeDisabled();
   });
 
   it('selects the translations area and keeps it selected on a second click (radio, no toggle)', () => {


### PR DESCRIPTION
## Cosa cambia

- Indicatori dei frammenti più leggibili: stato centrale e segnali compatti per note, problemi, blocco e testo da aggiornare.
- Barra progetto riordinata e barra Dashboard chiusa ridotta alle sole aree.
- Marchio della barra chiusa più evidente; documentazione aggiornata.

## Verifiche

- Test mirati delle shell
- Controllo tipi TypeScript
- Lint senza errori (10 avvisi preesistenti nei test)

Closes #360
