### PR TITLE
feat: shell 2.0, posizione tipizzata + tre aree globali (#210 parziale)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,9 @@ import { WorkspaceWizard } from './components/workspace/WorkspaceWizard';
 import { AppDashboard } from './components/dashboard/AppDashboard';
 import { WorkspaceOverview } from './components/workspace/WorkspaceOverview';
 import { TranslationsArea } from './components/workspace/TranslationsArea';
+import { LibraryCatalogArea } from './components/workspace/LibraryCatalogArea';
+import { TranscriptionsCatalogArea } from './components/workspace/TranscriptionsCatalogArea';
+import { AnalysisArea } from './components/workspace/AnalysisArea';
 import { importTextFile } from './services/fileService';
 import { savePipelineConfig } from './services/pipelineService';
 import { extractFootnotes } from './utils/footnoteExtractor';
@@ -423,7 +426,7 @@ export default function App() {
 
   // La Dashboard è app-level: cambiare workspace non tocca la vista corrente
   // (un'area mostra il contenuto del nuovo workspace, la Dashboard è globale).
-  const activeWorkspaceView = useUiStore((s) => s.activeWorkspaceView);
+  const location = useUiStore((s) => s.location);
 
   useEffect(() => {
     loadWorkspaces().catch((err: unknown) => console.error('[App] loadWorkspaces failed:', err));
@@ -469,20 +472,26 @@ export default function App() {
           <div className="flex flex-1 min-h-0">
             <WorkspaceShellNext>
               <div className="relative flex min-w-0 flex-1">
-                {activeWorkspaceView === 'translations' ? (
+                {location.area === 'translations' ? (
                   <TranslationsArea />
-                ) : activeWorkspaceView === 'workspace' ? (
+                ) : location.area === 'library' ? (
+                  <LibraryCatalogArea />
+                ) : location.area === 'transcriptions' ? (
+                  <TranscriptionsCatalogArea />
+                ) : location.area === 'analysis' ? (
+                  <AnalysisArea />
+                ) : location.area === 'workspace' ? (
                   <WorkspaceOverview />
                 ) : (
                   <AppDashboard />
                 )}
                 <PanelTransitionVeil
                   panelKey={
-                    activeWorkspaceView === 'translations'
-                      ? 'area-translations'
-                      : activeWorkspaceView === 'workspace'
-                        ? `workspace-${activeWorkspace?.id ?? 'none'}`
-                        : 'app-dashboard'
+                    location.area === 'workspace'
+                      ? `workspace-${location.workspaceId}`
+                      : location.area === 'dashboard'
+                        ? 'app-dashboard'
+                        : `area-${location.area}`
                   }
                   tone="paper"
                   variant="workspace"

--- a/src/components/dashboard/AppDashboard.test.tsx
+++ b/src/components/dashboard/AppDashboard.test.tsx
@@ -44,7 +44,7 @@ const WS_BETA = { id: 'ws-2', name: 'Beta' };
 describe('AppDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useUiStore.setState({ activeWorkspaceView: 'dashboard' });
+    useUiStore.setState({ location: { area: 'dashboard' } });
     mockListRecent.mockResolvedValue([]);
     mockListRuns.mockResolvedValue([]);
     mockListAttention.mockResolvedValue([]);

--- a/src/components/layout/AppStatusBar.tsx
+++ b/src/components/layout/AppStatusBar.tsx
@@ -14,6 +14,7 @@ const AREA_KEY: Record<string, string> = {
   translations: 'statusBar.areaTranslations',
   library: 'statusBar.areaLibrary',
   transcriptions: 'statusBar.areaTranscriptions',
+  analysis: 'statusBar.areaAnalysis',
 };
 
 const QUALITY_ICON = {

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -24,7 +24,7 @@ describe('Header', () => {
     useChunksStore.setState({
       isProcessing: false,
     });
-    useUiStore.setState({ activeWorkspaceView: 'dashboard' });
+    useUiStore.setState({ location: { area: 'dashboard' } });
   });
 
   it('hides the workspace breadcrumb on the app dashboard', () => {
@@ -43,11 +43,11 @@ describe('Header', () => {
       activeWorkspace: { id: 'workspace-1', name: 'Scholars' } as never,
       workspaces: [{ id: 'workspace-1', name: 'Scholars' } as never],
     });
-    useUiStore.setState({ activeWorkspaceView: 'translations' });
+    useUiStore.setState({ location: { area: 'translations' } });
 
     render(<Header />);
 
-    expect(screen.getByText('workspace.areas.translations.title')).toBeInTheDocument();
+    expect(screen.getByText('areas.translations.title')).toBeInTheDocument();
     expect(screen.queryByText('Scholars')).not.toBeInTheDocument();
   });
 
@@ -65,14 +65,14 @@ describe('Header', () => {
 
     render(<Header />);
 
-    expect(screen.getByText('workspace.areas.translations.title')).toBeInTheDocument();
+    expect(screen.getByText('areas.translations.title')).toBeInTheDocument();
     expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(screen.queryByText('Scholars')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'workspace.areas.translations.title' }));
+    fireEvent.click(screen.getByRole('button', { name: 'areas.translations.title' }));
 
     expect(closeProject).toHaveBeenCalledTimes(1);
-    expect(useUiStore.getState().activeWorkspaceView).toBe('translations');
+    expect(useUiStore.getState().location).toEqual({ area: 'translations' });
   });
 
   it('renders the project breadcrumb and returns to the workspace dashboard', () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { useUiStore } from '../../stores/uiStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useChunksStore } from '../../stores/chunksStore';
+import { translationsLocation } from '../../navigation/appLocation';
 import { EASE_EDITORIAL } from './motion';
 import { ShellNavFooter } from './ShellNav';
 import { Tooltip } from '../ui';
@@ -15,11 +16,11 @@ const HelpGuide = lazy(() =>
 );
 
 export function Header() {
-  const { setShowHelp, showHelp, setActiveWorkspaceView } = useUiStore(
+  const { setShowHelp, showHelp, navigate } = useUiStore(
     useShallow((state) => ({
       setShowHelp: state.setShowHelp,
       showHelp: state.showHelp,
-      setActiveWorkspaceView: state.setActiveWorkspaceView,
+      navigate: state.navigate,
     })),
   );
   const { currentProjectId, currentProject, closeProject } = useProjectStore(
@@ -35,7 +36,7 @@ export function Header() {
       workspaces: state.workspaces,
     })),
   );
-  const activeWorkspaceView = useUiStore((state) => state.activeWorkspaceView);
+  const location = useUiStore((state) => state.location);
   const isProcessing = useChunksStore((s) => s.isProcessing);
   const { t } = useTranslation();
 
@@ -48,15 +49,15 @@ export function Header() {
     ? workspaces.find((workspace) => workspace.id === currentProject.workspace_id)
     : activeWorkspace;
   const workspaceLabel = projectWorkspace?.name ?? activeWorkspace?.name ?? t('header.brandArea');
-  const translationsLabel = t('workspace.areas.translations.title');
-  const isTranslationsContext = activeWorkspaceView === 'translations' || projectWithoutWorkspace;
+  const translationsLabel = t('areas.translations.title');
+  const isTranslationsContext = location.area === 'translations' || projectWithoutWorkspace;
   const contextLabel = isTranslationsContext ? translationsLabel : workspaceLabel;
-  const showContextBreadcrumb = Boolean(currentProjectId || activeWorkspaceView !== 'dashboard');
+  const showContextBreadcrumb = Boolean(currentProjectId || location.area !== 'dashboard');
   const backToContextLabel = t(projectWithoutWorkspace ? 'sidebar.backToTranslations' : 'sidebar.backToWorkspace');
 
   const handleReturnToProjectContext = () => {
     closeProject();
-    if (projectWithoutWorkspace) setActiveWorkspaceView('translations');
+    if (projectWithoutWorkspace) navigate(translationsLocation());
   };
 
   return (

--- a/src/components/layout/shell-next/WorkspaceRailNext.tsx
+++ b/src/components/layout/shell-next/WorkspaceRailNext.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   Archive,
+  BarChart3,
   BookOpenText,
   FilePen,
   LayoutDashboard,
@@ -22,6 +23,7 @@ const AREA_ITEMS = [
   { id: 'translations', icon: BookOpenText, enabled: true },
   { id: 'library', icon: LibraryBig, enabled: false },
   { id: 'transcriptions', icon: FilePen, enabled: false },
+  { id: 'analysis', icon: BarChart3, enabled: false },
 ] as const;
 
 /** Dashboard: home dell'applicazione — sopra e fuori dalle aree del workspace. */

--- a/src/components/layout/shell-next/WorkspaceRailNext.tsx
+++ b/src/components/layout/shell-next/WorkspaceRailNext.tsx
@@ -13,25 +13,26 @@ import { useTranslation } from 'react-i18next';
 import { useProjectStore } from '../../../stores/projectStore';
 import { useWorkspaceStore } from '../../../stores/workspaceStore';
 import { useUiStore } from '../../../stores/uiStore';
+import { dashboardLocation, workspaceLocation, type GlobalArea } from '../../../navigation/appLocation';
 import type { Workspace } from '../../../types';
 import { IconButton } from '../../ui';
 import { CreateWorkspaceDialog } from '../../workspace/CreateWorkspaceDialog';
 import { ShellNavItem, ShellNavSection } from '../ShellNav';
 import { RailBrandToggle } from './RailBrandToggle';
 
-const AREA_ITEMS = [
+const AREA_ITEMS: ReadonlyArray<{ id: GlobalArea; icon: typeof BookOpenText; enabled: boolean }> = [
   { id: 'translations', icon: BookOpenText, enabled: true },
-  { id: 'library', icon: LibraryBig, enabled: false },
-  { id: 'transcriptions', icon: FilePen, enabled: false },
-  { id: 'analysis', icon: BarChart3, enabled: false },
-] as const;
+  { id: 'library', icon: LibraryBig, enabled: true },
+  { id: 'transcriptions', icon: FilePen, enabled: true },
+  { id: 'analysis', icon: BarChart3, enabled: true },
+];
 
 /** Dashboard: home dell'applicazione — sopra e fuori dalle aree del workspace. */
 function DashboardItem({ collapsed }: { collapsed: boolean }) {
   const { t } = useTranslation();
-  const activeWorkspaceView = useUiStore((state) => state.activeWorkspaceView);
-  const setActiveWorkspaceView = useUiStore((state) => state.setActiveWorkspaceView);
-  const active = activeWorkspaceView === 'dashboard';
+  const location = useUiStore((state) => state.location);
+  const navigate = useUiStore((state) => state.navigate);
+  const active = location.area === 'dashboard';
 
   return (
     <div className="px-2.5 pt-1">
@@ -39,7 +40,7 @@ function DashboardItem({ collapsed }: { collapsed: boolean }) {
         active={active}
         collapsed={collapsed}
         labelFont="display"
-        onClick={() => setActiveWorkspaceView('dashboard')}
+        onClick={() => navigate(dashboardLocation())}
         ariaCurrent={active ? 'page' : undefined}
         icon={
           // Cerchietto sempre in tinta accent: la home dell'app spicca sulle voci di sezione.
@@ -68,13 +69,13 @@ function DashboardItem({ collapsed }: { collapsed: boolean }) {
  */
 function AreaSection({ collapsed }: { collapsed: boolean }) {
   const { t } = useTranslation();
-  const activeWorkspaceView = useUiStore((state) => state.activeWorkspaceView);
-  const setActiveWorkspaceView = useUiStore((state) => state.setActiveWorkspaceView);
+  const location = useUiStore((state) => state.location);
+  const navigate = useUiStore((state) => state.navigate);
 
   return (
     <ShellNavSection icon={BookOpenText} label={t('sidebar.areaLabel')} collapsed={collapsed}>
       {AREA_ITEMS.map(({ id, icon: Icon, enabled }) => {
-        const active = enabled && activeWorkspaceView === id;
+        const active = enabled && location.area === id;
         return (
           <ShellNavItem
             key={id}
@@ -82,7 +83,7 @@ function AreaSection({ collapsed }: { collapsed: boolean }) {
             disabled={!enabled}
             collapsed={collapsed}
             labelFont="display"
-            onClick={enabled ? () => setActiveWorkspaceView(id) : undefined}
+            onClick={enabled ? () => navigate({ area: id }) : undefined}
             ariaCurrent={active ? 'page' : undefined}
             icon={
               <span
@@ -99,8 +100,8 @@ function AreaSection({ collapsed }: { collapsed: boolean }) {
                 <Icon size={collapsed ? 15 : 12} />
               </span>
             }
-            label={t(`workspace.areas.${id}.title`)}
-            hint={t(`workspace.areas.${id}.sidebarHint`)}
+            label={t(`areas.${id}.title`)}
+            hint={t(`areas.${id}.sidebarHint`)}
           />
         );
       })}
@@ -122,8 +123,8 @@ function WorkspaceSection({ collapsed }: { collapsed: boolean }) {
   const setActive = useWorkspaceStore((s) => s.setActive);
   const closeProject = useProjectStore((s) => s.closeProject);
   const loadProjects = useProjectStore((s) => s.loadProjects);
-  const activeWorkspaceView = useUiStore((state) => state.activeWorkspaceView);
-  const setActiveWorkspaceView = useUiStore((state) => state.setActiveWorkspaceView);
+  const location = useUiStore((state) => state.location);
+  const navigate = useUiStore((state) => state.navigate);
 
   const handleOpenWorkspace = async (ws: Workspace) => {
     if (ws.id !== activeWorkspace?.id) {
@@ -131,7 +132,7 @@ function WorkspaceSection({ collapsed }: { collapsed: boolean }) {
       await setActive(ws);
       await loadProjects();
     }
-    setActiveWorkspaceView('workspace');
+    navigate(workspaceLocation(ws.id));
   };
 
   return (
@@ -154,7 +155,7 @@ function WorkspaceSection({ collapsed }: { collapsed: boolean }) {
         }
       >
         {workspaces.map((ws) => {
-          const isCurrentView = ws.id === activeWorkspace?.id && activeWorkspaceView === 'workspace';
+          const isCurrentView = location.area === 'workspace' && location.workspaceId === ws.id;
           return (
             <ShellNavItem
               key={ws.id}

--- a/src/components/layout/shell-next/WorkspaceShellNext.test.tsx
+++ b/src/components/layout/shell-next/WorkspaceShellNext.test.tsx
@@ -64,36 +64,36 @@ describe('WorkspaceShellNext (#294)', () => {
 
     fireEvent.click(screen.getByText('Alpha'));
 
-    expect(useUiStore.getState().activeWorkspaceView).toBe('workspace');
+    expect(useUiStore.getState().location).toEqual({ area: 'workspace', workspaceId: 'ws-1' });
     expect(useWorkspaceStore.getState().setActive).not.toHaveBeenCalled();
   });
 
-  it('shows Dashboard and every area, but not workspaces, when the rail is collapsed', () => {
+  it('shows Dashboard and every area, all enabled, when the rail is collapsed', () => {
     renderShell();
 
     fireEvent.click(screen.getByRole('button', { name: 'sidebar.collapse' }));
     expect(screen.queryByRole('button', { name: /Beta/ })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /dashboard\.title/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /workspace\.areas\.translations\.title/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /workspace\.areas\.library\.title/ })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /workspace\.areas\.transcriptions\.title/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /areas\.translations\.title/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /areas\.library\.title/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /areas\.transcriptions\.title/ })).not.toBeDisabled();
   });
 
   it('selects the translations area and keeps it selected on a second click (radio, no toggle)', () => {
     renderShell();
 
-    fireEvent.click(screen.getByText('workspace.areas.translations.title'));
-    expect(useUiStore.getState().activeWorkspaceView).toBe('translations');
+    fireEvent.click(screen.getByText('areas.translations.title'));
+    expect(useUiStore.getState().location).toEqual({ area: 'translations' });
 
-    fireEvent.click(screen.getByText('workspace.areas.translations.title'));
-    expect(useUiStore.getState().activeWorkspaceView).toBe('translations');
+    fireEvent.click(screen.getByText('areas.translations.title'));
+    expect(useUiStore.getState().location).toEqual({ area: 'translations' });
   });
 
   it('returns to the dashboard from the standalone dashboard nav item', () => {
     renderShell();
 
-    fireEvent.click(screen.getByText('workspace.areas.translations.title'));
+    fireEvent.click(screen.getByText('areas.translations.title'));
     fireEvent.click(screen.getByText('dashboard.title'));
-    expect(useUiStore.getState().activeWorkspaceView).toBe('dashboard');
+    expect(useUiStore.getState().location).toEqual({ area: 'dashboard' });
   });
 });

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -98,15 +98,15 @@ export function SettingsModal() {
   };
 
   const activeTabConfig: Array<{ id: SettingsTab; icon: ReactNode; label: string }> = [
-    { id: 'translations', icon: <FileText size={14} />,          label: t('workspace.areas.translations.title') },
+    { id: 'translations', icon: <FileText size={14} />,          label: t('areas.translations.title') },
     { id: 'typography',   icon: <Type size={14} />,              label: t('settings.typographyTab') },
     { id: 'provider',     icon: <Server size={14} />,            label: t('settings.providerTab') },
     { id: 'storage',      icon: <HardDrive size={14} />,         label: t('settings.storageTab') },
   ];
 
   const disabledTabConfig: Array<{ icon: ReactNode; label: string }> = [
-    { icon: <LibraryBig size={14} />,  label: t('workspace.areas.library.title') },
-    { icon: <BookOpen size={14} />,    label: t('workspace.areas.transcriptions.title') },
+    { icon: <LibraryBig size={14} />,  label: t('areas.library.title') },
+    { icon: <BookOpen size={14} />,    label: t('areas.transcriptions.title') },
   ];
 
   const tabBar = (

--- a/src/components/workspace/AnalysisArea.tsx
+++ b/src/components/workspace/AnalysisArea.tsx
@@ -1,0 +1,27 @@
+import { BarChart3 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../ui';
+
+/**
+ * Area globale Analisi (#210 Passo B, epic #377): metriche, confronti e
+ * dataset, indipendente dal workspace attivo. Ancora senza contenuto —
+ * arriva con #378-381.
+ */
+export function AnalysisArea() {
+  const { t } = useTranslation();
+
+  return (
+    <main className="flex flex-1 h-full min-h-0 flex-col overflow-y-auto bg-editorial-paper custom-scrollbar">
+      <div className="px-5 py-5 md:px-6">
+        <h1 className="mb-5 font-display text-4xl italic text-editorial-ink md:text-5xl">
+          {t('areas.analysis.title')}
+        </h1>
+        <EmptyState
+          icon={<BarChart3 size={28} />}
+          message={t('areas.analysis.emptyMessage')}
+          hint={t('areas.analysis.emptyHint')}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/workspace/LibraryCatalogArea.tsx
+++ b/src/components/workspace/LibraryCatalogArea.tsx
@@ -1,0 +1,27 @@
+import { LibraryBig } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../ui';
+
+/**
+ * Area globale Biblioteca (#210 Passo B): catalogo di tutte le fonti/libri,
+ * indipendente dal workspace attivo. Ancora senza contenuto — arriva con
+ * #214-217 (registry IIIF, discovery, add-to-library).
+ */
+export function LibraryCatalogArea() {
+  const { t } = useTranslation();
+
+  return (
+    <main className="flex flex-1 h-full min-h-0 flex-col overflow-y-auto bg-editorial-paper custom-scrollbar">
+      <div className="px-5 py-5 md:px-6">
+        <h1 className="mb-5 font-display text-4xl italic text-editorial-ink md:text-5xl">
+          {t('areas.library.title')}
+        </h1>
+        <EmptyState
+          icon={<LibraryBig size={28} />}
+          message={t('areas.library.emptyMessage')}
+          hint={t('areas.library.emptyHint')}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/workspace/TranscriptionsCatalogArea.tsx
+++ b/src/components/workspace/TranscriptionsCatalogArea.tsx
@@ -1,0 +1,27 @@
+import { FilePen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../ui';
+
+/**
+ * Area globale Trascrizioni (#210 Passo B): catalogo di tutti i documenti di
+ * trascrizione, indipendente dal workspace attivo. Ancora senza contenuto —
+ * arriva con lo Studio di trascrizione (#182/#219).
+ */
+export function TranscriptionsCatalogArea() {
+  const { t } = useTranslation();
+
+  return (
+    <main className="flex flex-1 h-full min-h-0 flex-col overflow-y-auto bg-editorial-paper custom-scrollbar">
+      <div className="px-5 py-5 md:px-6">
+        <h1 className="mb-5 font-display text-4xl italic text-editorial-ink md:text-5xl">
+          {t('areas.transcriptions.title')}
+        </h1>
+        <EmptyState
+          icon={<FilePen size={28} />}
+          message={t('areas.transcriptions.emptyMessage')}
+          hint={t('areas.transcriptions.emptyHint')}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/components/workspace/TranslationsArea.tsx
+++ b/src/components/workspace/TranslationsArea.tsx
@@ -88,7 +88,7 @@ export function TranslationsArea() {
       <div className="px-5 py-5 md:px-6">
         <div className="mb-5 flex items-end justify-between gap-3">
           <h1 className="font-display text-4xl italic text-editorial-ink md:text-5xl">
-            {t('workspace.areas.translations.title')}
+            {t('areas.translations.title')}
           </h1>
           <div className="flex items-center gap-2 shrink-0">
             <div className="flex items-center gap-2">

--- a/src/components/workspace/WorkspaceOverview.tsx
+++ b/src/components/workspace/WorkspaceOverview.tsx
@@ -110,7 +110,7 @@ export function WorkspaceOverview() {
         {/* Progetti di traduzione del workspace */}
         <section className="mt-6">
           <div className="mb-2 flex items-center justify-between px-1">
-            <SectionLabel icon={BookOpenText} label={t('workspace.areas.translations.title')} />
+            <SectionLabel icon={BookOpenText} label={t('areas.translations.title')} />
             <IconButton
               size="sm"
               tone="muted"

--- a/src/hooks/useStatusBarData.test.ts
+++ b/src/hooks/useStatusBarData.test.ts
@@ -11,7 +11,7 @@ describe('useStatusBarData', () => {
   beforeEach(() => {
     useProjectStore.setState({ currentProjectId: null, projects: [], pipelines: [], activePipelineId: null, saveState: 'idle' } as any);
     useWorkspaceStore.setState({ activeWorkspace: null } as any);
-    useUiStore.setState({ activeWorkspaceView: 'dashboard' });
+    useUiStore.setState({ location: { area: 'dashboard' } });
     useChunksStore.setState({ chunks: [] } as any);
     usePipelineStore.setState((s) => ({ runStatus: 'idle', config: { ...s.config, pipelineId: '' } }));
   });

--- a/src/hooks/useStatusBarData.ts
+++ b/src/hooks/useStatusBarData.ts
@@ -34,7 +34,7 @@ export type StatusBarContext =
 
 export function useStatusBarData(): StatusBarContext {
   const activeWorkspace = useWorkspaceStore((s) => s.activeWorkspace);
-  const activeWorkspaceView = useUiStore((s) => s.activeWorkspaceView);
+  const location = useUiStore((s) => s.location);
   const currentProjectId = useProjectStore((s) => s.currentProjectId);
   const projects = useProjectStore((s) => s.projects);
   const pipelines = useProjectStore((s) => s.pipelines);
@@ -56,7 +56,7 @@ export function useStatusBarData(): StatusBarContext {
         kind: 'workspace',
         workspaceName: activeWorkspace.name,
         projectCount: projects.length,
-        areaName: activeWorkspaceView,
+        areaName: location.area,
       };
     }
 
@@ -92,7 +92,7 @@ export function useStatusBarData(): StatusBarContext {
     };
   }, [
     activeWorkspace,
-    activeWorkspaceView,
+    location,
     currentProjectId,
     projects,
     pipelines,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -714,6 +714,10 @@
       "transcriptions": {
         "title": "Transcriptions",
         "sidebarHint": "OCR and source prep"
+      },
+      "analysis": {
+        "title": "Analysis",
+        "sidebarHint": "Metrics and datasets"
       }
     },
     "newBookCard": "New book",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -667,6 +667,30 @@
     "updatedYearsAgo_other": "updated {{count}} years ago",
     "loadFailed": "Failed to load project"
   },
+  "areas": {
+    "translations": {
+      "title": "Translations",
+      "sidebarHint": "Projects and pipelines"
+    },
+    "library": {
+      "title": "Library",
+      "sidebarHint": "Texts and catalogues",
+      "emptyMessage": "The Library catalogue has no content yet.",
+      "emptyHint": "Coming with sources and books linkable to workspaces."
+    },
+    "transcriptions": {
+      "title": "Transcriptions",
+      "sidebarHint": "OCR and source prep",
+      "emptyMessage": "The Transcriptions catalogue has no content yet.",
+      "emptyHint": "Coming with the Transcription Studio."
+    },
+    "analysis": {
+      "title": "Analysis",
+      "sidebarHint": "Metrics and datasets",
+      "emptyMessage": "The Analysis area has no content yet.",
+      "emptyHint": "Coming with metrics, comparisons and datasets."
+    }
+  },
   "workspace": {
     "activeLabel": "Translation workspace",
     "noActive": "No active workspace",
@@ -702,24 +726,6 @@
     "pipelineBadge_one": "1 pipeline",
     "pipelineBadge_other": "{{count}} pipelines",
     "pipelineNamesFallback": "No pipelines",
-    "areas": {
-      "translations": {
-        "title": "Translations",
-        "sidebarHint": "Projects and pipelines"
-      },
-      "library": {
-        "title": "Library",
-        "sidebarHint": "Texts and catalogues"
-      },
-      "transcriptions": {
-        "title": "Transcriptions",
-        "sidebarHint": "OCR and source prep"
-      },
-      "analysis": {
-        "title": "Analysis",
-        "sidebarHint": "Metrics and datasets"
-      }
-    },
     "newBookCard": "New book",
     "memoryExtractorModel": "Memory Extractor Model",
     "memoryExtractorPrompt": "Memory Extractor Prompt",
@@ -1644,6 +1650,7 @@
     "areaTranslations": "Translations",
     "areaLibrary": "Library",
     "areaTranscriptions": "Transcriptions",
+    "areaAnalysis": "Analysis",
     "panel": {
       "config": "Configuration",
       "insights": "Analysis",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -667,6 +667,30 @@
     "updatedYearsAgo_other": "aggiornato {{count}} anni fa",
     "loadFailed": "Caricamento progetto fallito"
   },
+  "areas": {
+    "translations": {
+      "title": "Traduzioni",
+      "sidebarHint": "Progetti e pipeline"
+    },
+    "library": {
+      "title": "Biblioteca",
+      "sidebarHint": "Testi e catalogo",
+      "emptyMessage": "Il catalogo Biblioteca non ha ancora contenuto.",
+      "emptyHint": "Arriverà con le fonti e i libri collegabili ai workspace."
+    },
+    "transcriptions": {
+      "title": "Trascrizioni",
+      "sidebarHint": "OCR e preparazione",
+      "emptyMessage": "Il catalogo Trascrizioni non ha ancora contenuto.",
+      "emptyHint": "Arriverà con lo Studio di trascrizione."
+    },
+    "analysis": {
+      "title": "Analisi",
+      "sidebarHint": "Metriche e dataset",
+      "emptyMessage": "L'area Analisi non ha ancora contenuto.",
+      "emptyHint": "Arriverà con metriche, confronti e dataset."
+    }
+  },
   "workspace": {
     "activeLabel": "Workspace traduzioni",
     "noActive": "Nessun workspace attivo",
@@ -702,24 +726,6 @@
     "pipelineBadge_one": "1 pipeline",
     "pipelineBadge_other": "{{count}} pipeline",
     "pipelineNamesFallback": "Nessuna pipeline",
-    "areas": {
-      "translations": {
-        "title": "Traduzioni",
-        "sidebarHint": "Progetti e pipeline"
-      },
-      "library": {
-        "title": "Biblioteca",
-        "sidebarHint": "Testi e catalogo"
-      },
-      "transcriptions": {
-        "title": "Trascrizioni",
-        "sidebarHint": "OCR e preparazione"
-      },
-      "analysis": {
-        "title": "Analisi",
-        "sidebarHint": "Metriche e dataset"
-      }
-    },
     "newBookCard": "Nuovo libro",
     "memoryExtractorModel": "Modello estrattore Memory",
     "memoryExtractorPrompt": "Prompt estrattore Memory",
@@ -1644,6 +1650,7 @@
     "areaTranslations": "Traduzioni",
     "areaLibrary": "Biblioteca",
     "areaTranscriptions": "Trascrizioni",
+    "areaAnalysis": "Analisi",
     "panel": {
       "config": "Configurazione",
       "insights": "Analisi",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -714,6 +714,10 @@
       "transcriptions": {
         "title": "Trascrizioni",
         "sidebarHint": "OCR e preparazione"
+      },
+      "analysis": {
+        "title": "Analisi",
+        "sidebarHint": "Metriche e dataset"
       }
     },
     "newBookCard": "Nuovo libro",

--- a/src/navigation/appLocation.test.ts
+++ b/src/navigation/appLocation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { locationsEqual, translationsLocation, withWorkspaceFilter } from './appLocation';
+
+describe('withWorkspaceFilter', () => {
+  it('applies a workspace filter to a global area', () => {
+    const result = withWorkspaceFilter(translationsLocation(), 'ws-1');
+    expect(result).toEqual({ area: 'translations', workspaceFilter: 'ws-1' });
+  });
+
+  it('removes the filter entirely (no leftover undefined key) when passed null', () => {
+    const filtered = withWorkspaceFilter(translationsLocation(), 'ws-1');
+    const cleared = withWorkspaceFilter(filtered, null);
+    expect(cleared).toEqual({ area: 'translations' });
+    expect('workspaceFilter' in cleared).toBe(false);
+  });
+
+  it('is a no-op on a non-global-area location', () => {
+    const dashboard = { area: 'dashboard' } as const;
+    expect(withWorkspaceFilter(dashboard, 'ws-1')).toBe(dashboard);
+  });
+});
+
+describe('locationsEqual', () => {
+  it('treats two locations with the same shape and values as equal', () => {
+    expect(locationsEqual({ area: 'translations' }, { area: 'translations' })).toBe(true);
+    expect(
+      locationsEqual(
+        { area: 'translations', workspaceFilter: 'ws-1' },
+        { area: 'translations', workspaceFilter: 'ws-1' },
+      ),
+    ).toBe(true);
+  });
+
+  it('treats a filtered and an unfiltered location as different', () => {
+    expect(
+      locationsEqual({ area: 'translations' }, { area: 'translations', workspaceFilter: 'ws-1' }),
+    ).toBe(false);
+  });
+
+  it('treats different areas as different', () => {
+    expect(locationsEqual({ area: 'dashboard' }, { area: 'translations' })).toBe(false);
+  });
+});

--- a/src/navigation/appLocation.ts
+++ b/src/navigation/appLocation.ts
@@ -61,5 +61,16 @@ export function getWorkspaceFilter(location: AppLocation): string | undefined {
  */
 export function withWorkspaceFilter(location: AppLocation, workspaceFilter: string | null): AppLocation {
   if (!isGlobalArea(location)) return location;
-  return { ...location, workspaceFilter: workspaceFilter ?? undefined };
+  if (workspaceFilter !== null) return { ...location, workspaceFilter };
+  const cleared: Partial<Record<'workspaceFilter', string>> & typeof location = { ...location };
+  delete cleared.workspaceFilter;
+  return cleared;
+}
+
+/** Confronto per valore (non identità): evita di ri-rendere i consumatori di `location` a fronte di una navigazione verso una posizione equivalente. */
+export function locationsEqual(a: AppLocation, b: AppLocation): boolean {
+  const aKeys = Object.keys(a) as Array<keyof AppLocation>;
+  const bKeys = Object.keys(b) as Array<keyof AppLocation>;
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
 }

--- a/src/navigation/appLocation.ts
+++ b/src/navigation/appLocation.ts
@@ -1,0 +1,65 @@
+/**
+ * Contratto di navigazione dello shell 2.0 (#210), definito in
+ * `docs-dev/PRODUCT_ARCHITECTURE_2_0.md` §6: posizione, workspace operativo
+ * e filtro workspace sono tre concetti distinti, mai dedotti l'uno
+ * dall'altro. Nessuna variante ammette un fallback implicito — il default è
+ * sempre `dashboardLocation()`, mai un'area o un oggetto "a caso".
+ */
+export type GlobalArea = 'library' | 'transcriptions' | 'translations' | 'analysis';
+
+export type AppLocation =
+  | { area: 'dashboard' }
+  | { area: 'workspace'; workspaceId: string }
+  | { area: 'library'; itemId?: string; workspaceFilter?: string }
+  | { area: 'transcriptions'; documentId?: string; workspaceFilter?: string }
+  | { area: 'translations'; projectId?: string; workspaceFilter?: string }
+  | { area: 'analysis'; workspaceFilter?: string };
+
+export const GLOBAL_AREAS: readonly GlobalArea[] = [
+  'library',
+  'transcriptions',
+  'translations',
+  'analysis',
+];
+
+export function dashboardLocation(): AppLocation {
+  return { area: 'dashboard' };
+}
+
+export function workspaceLocation(workspaceId: string): AppLocation {
+  return { area: 'workspace', workspaceId };
+}
+
+export function libraryLocation(opts?: { itemId?: string; workspaceFilter?: string }): AppLocation {
+  return { area: 'library', ...opts };
+}
+
+export function transcriptionsLocation(opts?: { documentId?: string; workspaceFilter?: string }): AppLocation {
+  return { area: 'transcriptions', ...opts };
+}
+
+export function translationsLocation(opts?: { projectId?: string; workspaceFilter?: string }): AppLocation {
+  return { area: 'translations', ...opts };
+}
+
+export function analysisLocation(opts?: { workspaceFilter?: string }): AppLocation {
+  return { area: 'analysis', ...opts };
+}
+
+export function isGlobalArea(location: AppLocation): location is Extract<AppLocation, { area: GlobalArea }> {
+  return (GLOBAL_AREAS as readonly string[]).includes(location.area);
+}
+
+export function getWorkspaceFilter(location: AppLocation): string | undefined {
+  return isGlobalArea(location) ? location.workspaceFilter : undefined;
+}
+
+/**
+ * Applica o rimuove (`workspaceFilter: null`) il filtro workspace su un'area
+ * globale. No-op sulle posizioni che non ne hanno concetto (dashboard,
+ * workspace) — restituisce la stessa posizione invariata.
+ */
+export function withWorkspaceFilter(location: AppLocation, workspaceFilter: string | null): AppLocation {
+  if (!isGlobalArea(location)) return location;
+  return { ...location, workspaceFilter: workspaceFilter ?? undefined };
+}

--- a/src/stores/uiStore.test.ts
+++ b/src/stores/uiStore.test.ts
@@ -197,24 +197,24 @@ describe('uiStore uiFont preference', () => {
   });
 });
 
-describe('uiStore — activeWorkspaceView', () => {
+describe('uiStore — location', () => {
   beforeEach(() => {
-    useUiStore.setState({ activeWorkspaceView: 'dashboard' });
+    useUiStore.setState({ location: { area: 'dashboard' } });
   });
 
   it('defaults to dashboard (never an empty selection)', () => {
-    expect(useUiStore.getState().activeWorkspaceView).toBe('dashboard');
+    expect(useUiStore.getState().location).toEqual({ area: 'dashboard' });
   });
 
-  it('setActiveWorkspaceView switches to an area', () => {
-    useUiStore.getState().setActiveWorkspaceView('translations');
-    expect(useUiStore.getState().activeWorkspaceView).toBe('translations');
+  it('navigate switches to an area', () => {
+    useUiStore.getState().navigate({ area: 'translations' });
+    expect(useUiStore.getState().location).toEqual({ area: 'translations' });
   });
 
-  it('setActiveWorkspaceView returns to the dashboard', () => {
-    useUiStore.getState().setActiveWorkspaceView('translations');
-    useUiStore.getState().setActiveWorkspaceView('dashboard');
-    expect(useUiStore.getState().activeWorkspaceView).toBe('dashboard');
+  it('navigate returns to the dashboard', () => {
+    useUiStore.getState().navigate({ area: 'translations' });
+    useUiStore.getState().navigate({ area: 'dashboard' });
+    expect(useUiStore.getState().location).toEqual({ area: 'dashboard' });
   });
 });
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { DocumentLayoutPreference } from '../types';
+import { dashboardLocation, type AppLocation } from '../navigation/appLocation';
 
 export type InsightsDrawerTab = 'index' | 'search' | 'stats' | 'coherence' | 'glossary';
 export type ChunkDrawerTab = 'summary' | 'audit' | 'notes' | 'operations' | 'memory';
@@ -19,14 +20,6 @@ export const DOC_FONT_SIZE_CSS: Record<DocumentFontSize, string> = {
 };
 export type DocumentLineHeight = 'tight' | 'normal' | 'relaxed';
 export type SettingsTab = 'translations' | 'provider' | 'typography' | 'storage';
-export type WorkspaceArea = 'translations' | 'library' | 'transcriptions' | 'analysis';
-/**
- * Vista corrente della shell: Dashboard (home app-level), pagina del workspace
- * attivo ('workspace'), o un'area del workspace attivo. Sempre esattamente una
- * attiva (semantica radio, mai deselezione) — ogni voce del rail naviga al
- * proprio contenuto.
- */
-export type WorkspaceView = 'dashboard' | 'workspace' | WorkspaceArea;
 
 export interface HLColorSet {
   sourceTerm: string;
@@ -109,9 +102,9 @@ interface UiState {
   projectSidebarWidth: number;
   projectFlyoutWidth: number;
   pendingAnnotationAnchor: { chunkId: string; text: string; content?: string } | null;
-  activeWorkspaceView: WorkspaceView;
+  location: AppLocation;
   setTraceStageId: (id: string | null) => void;
-  setActiveWorkspaceView: (view: WorkspaceView) => void;
+  navigate: (location: AppLocation) => void;
   setPendingAnnotationAnchor: (anchor: { chunkId: string; text: string; content?: string } | null) => void;
   setDocumentLayout: (layout: DocumentLayoutPreference) => void;
   setDocumentPaneFocus: (focus: DocumentPaneFocus) => void;
@@ -296,7 +289,7 @@ export const useUiStore = create<UiState>()(
       projectSidebarWidth: 300,
       projectFlyoutWidth: 430,
       pendingAnnotationAnchor: null,
-      activeWorkspaceView: 'dashboard',
+      location: dashboardLocation(),
       setDocumentLayout: (layout) => set({ documentLayout: layout }),
       setDocumentPaneFocus: (focus) => set({ documentPaneFocus: focus }),
       setSyncScrollEnabled: (enabled) => set({ syncScrollEnabled: enabled }),
@@ -427,7 +420,7 @@ export const useUiStore = create<UiState>()(
       clearAnnotationFocus: () => set({ focusedIssueQuery: null, focusIsAnnotation: false }),
       setTraceStageId: (id) => set({ traceStageId: id }),
       setPendingAnnotationAnchor: (anchor) => set({ pendingAnnotationAnchor: anchor }),
-      setActiveWorkspaceView: (view) => set({ activeWorkspaceView: view }),
+      navigate: (location) => set({ location }),
       setActiveProjectPanel: (panel) =>
         set((state) => {
           if (panel === 'insight') {

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -19,7 +19,7 @@ export const DOC_FONT_SIZE_CSS: Record<DocumentFontSize, string> = {
 };
 export type DocumentLineHeight = 'tight' | 'normal' | 'relaxed';
 export type SettingsTab = 'translations' | 'provider' | 'typography' | 'storage';
-export type WorkspaceArea = 'translations' | 'library' | 'transcriptions';
+export type WorkspaceArea = 'translations' | 'library' | 'transcriptions' | 'analysis';
 /**
  * Vista corrente della shell: Dashboard (home app-level), pagina del workspace
  * attivo ('workspace'), o un'area del workspace attivo. Sempre esattamente una

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { DocumentLayoutPreference } from '../types';
-import { dashboardLocation, type AppLocation } from '../navigation/appLocation';
+import { dashboardLocation, locationsEqual, type AppLocation } from '../navigation/appLocation';
 
 export type InsightsDrawerTab = 'index' | 'search' | 'stats' | 'coherence' | 'glossary';
 export type ChunkDrawerTab = 'summary' | 'audit' | 'notes' | 'operations' | 'memory';
@@ -420,7 +420,8 @@ export const useUiStore = create<UiState>()(
       clearAnnotationFocus: () => set({ focusedIssueQuery: null, focusIsAnnotation: false }),
       setTraceStageId: (id) => set({ traceStageId: id }),
       setPendingAnnotationAnchor: (anchor) => set({ pendingAnnotationAnchor: anchor }),
-      navigate: (location) => set({ location }),
+      navigate: (location) =>
+        set((state) => (locationsEqual(state.location, location) ? state : { location })),
       setActiveProjectPanel: (panel) =>
         set((state) => {
           if (panel === 'insight') {


### PR DESCRIPTION
## Riassunto

Parte del lavoro di #210 (shell 2.0), su base #211/#212 già chiusi.

- Sostituita l'unica stringa che teneva traccia di "dove sei nell'app" con una posizione tipizzata (`src/navigation/appLocation.ts`) che separa area, oggetto aperto e filtro workspace, come da `docs-dev/PRODUCT_ARCHITECTURE_2_0.md` §6. Nessun fallback implicito.
- Corrette le scritte che presentavano le aree globali (Traduzioni, Biblioteca, ecc.) come se fossero interne allo spazio di lavoro attivo.
- Accese le tre aree finora spente nella barra (Biblioteca, Trascrizioni, Analisi): ora si aprono e mostrano onestamente "non c'è ancora nulla qui" invece di restare disattivate.
- #212 verificata sul database reale (un solo progetto di test): integro, nessun collegamento rotto, nessuna migrazione dati necessaria. Chiusa senza altro codice.

## Non incluso (issue #210 resta aperta)

- Filtro per spazio di lavoro dentro le aree globali: il campo è predisposto nel tipo ma il controllo UI non è costruito — con un solo workspace popolato oggi non sarebbe verificabile, si aggiunge quando servirà davvero.
- Modalità di lavoro concentrata per lo Studio di trascrizione: non esiste ancora nulla da mostrarci, dipende da issue non ancora implementate (#182/#219).

## Test plan

- [x] `tsc --noEmit` pulito
- [x] Suite Vitest: 78 file / 659 test verdi
- [x] Lint: solo i 10 avvisi preesistenti (non toccati da questo lavoro), zero errori
- [x] Verificato il database reale: integrità ok, nessuna chiave esterna rotta
- [ ] Provato dal vivo in `tauri dev` — da fare prima del merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)